### PR TITLE
[WIP] fix: 🍰 Issue #3504 umlaut encoding

### DIFF
--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -1,19 +1,9 @@
 import slugify from 'slug'
 
-let locale; 
-
-if(locale === 'de'){
-  locale = 'de'
-} else {
-  locale = ''
-}
-
 export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
-    charmap: slug.charmap,
-    multicharmap: slug.multicharmap,
-    locale: `${locale}`
+    locale: 'de',
   })
   if (await isUnique(slug)) return slug
 

--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -1,15 +1,19 @@
 import slugify from 'slug'
+
+let locale; 
+
+if(locale === 'de'){
+  locale = 'de'
+} else {
+  locale = ''
+}
+
 export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
-    charmap: {
-      Ä: 'ae',
-      ä: 'ae',
-      Ö: 'oe',
-      ö: 'oe',
-      Ü: 'ue',
-      ü: 'ue',
-    },
+    charmap: slug.charmap,
+    multicharmap: slug.multicharmap,
+    locale: `${locale}`
   })
   if (await isUnique(slug)) return slug
 

--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -3,13 +3,13 @@ export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
     charmap: {
-        'Ä' : 'ae',
-        'ä' : 'ae',
-        'Ö' : 'oe',
-        'ö' : 'oe',
-        'Ü' : 'ue',
-        'ü' : 'ue',
-    }
+      Ä: 'ae',
+      ä: 'ae',
+      Ö: 'oe',
+      ö: 'oe',
+      Ü: 'ue',
+      ü: 'ue',
+    },
   })
   if (await isUnique(slug)) return slug
 

--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -2,6 +2,14 @@ import slugify from 'slug'
 export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
+    charmap: {
+        'Ä' : 'ae',
+        'ä' : 'ae',
+        'Ö' : 'oe',
+        'ö' : 'oe',
+        'Ü' : 'ue',
+        'ü' : 'ue',
+    }
   })
   if (await isUnique(slug)) return slug
 

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -19,3 +19,17 @@ describe('uniqueSlug', () => {
     expect(uniqueSlug(string, isUnique)).resolves.toEqual('anonymous')
   })
 })
+
+describe('Slug is transliterated correctly', () => {
+  it('Converts umlaut to two letter equivalent', () => {
+    const umlaut = 'ä';
+    const isUnique = jest.fn().mockResolvedValue(true)
+    expect(uniqueSlug(string, isUnique)).resolves.toEqual('ae');
+  })
+
+  it('Removes Spanish enya ', () => {
+    const enya = 'ñ';
+    const isUnique = jest.fn().mockResolvedValue(true)
+    expect(uniqueSlug(string, isUnique)).resolves.toEqual('n');
+  })
+})


### PR DESCRIPTION
> [<img alt="ATOMktn" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/ATOMktn) **Authored by [ATOMktn](https://github.com/ATOMktn)**
_<time datetime="2020-06-25T22:44:01Z" title="Friday, June 26th 2020, 12:44:01 am +02:00">Jun 26, 2020</time>_

---

Updated slugify middleware to handle umlauts to specification

## 🍰 Pullrequest
Bug caused by unexpected behavior of [Trott/slug](https://github.com/Trott/slug) middleware. Function only encodes to single English characters by default. According to the [documentation](https://github.com/Trott/slug/blob/master/README.md), a character map should be specified for special cases.

### Issues
- fixes #3504 


