### PR TITLE
feat: 🍰 Show Supported Image Formats Implemented

### DIFF
--- a/webapp/assets/_new/styles/tokens.scss
+++ b/webapp/assets/_new/styles/tokens.scss
@@ -279,7 +279,7 @@ $size-avatar-large: 114px;
 $size-image-max-height: 2000px;
 $size-image-cropper-max-height: 600px;
 $size-image-cropper-min-height: 400px;
-$size-image-uploader-min-height: 200px;
+$size-image-uploader-min-height: 250px;
 
 /**
  * @tokens Size Icons

--- a/webapp/components/ImageUploader/ImageUploader.vue
+++ b/webapp/components/ImageUploader/ImageUploader.vue
@@ -20,6 +20,9 @@
         :title="$t('actions.delete')"
         @click.stop="deleteImage"
       />
+      <div v-if="!hasImage" class="supported-formats">
+        Insert a picture of file format JPG , PNG or GIF
+      </div>
     </vue-dropzone>
     <div v-show="showCropper" class="crop-overlay">
       <img id="cropping-image" />
@@ -194,6 +197,11 @@ export default {
       top: $space-small;
       right: $space-small;
       z-index: $z-index-surface;
+    }
+
+    > .supported-formats {
+      margin-top: 150px;
+      font-weight: bold;
     }
   }
 }

--- a/webapp/components/ImageUploader/ImageUploader.vue
+++ b/webapp/components/ImageUploader/ImageUploader.vue
@@ -21,7 +21,7 @@
         @click.stop="deleteImage"
       />
       <div v-if="!hasImage" class="supported-formats">
-        Insert a picture of file format JPG , PNG or GIF
+        {{ $t('contribution.teaserImage.supportedFormats') }}
       </div>
     </vue-dropzone>
     <div v-show="showCropper" class="crop-overlay">

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -259,7 +259,7 @@
     "success": "Gespeichert!",
     "teaserImage": {
       "cropperConfirm": "Bestätigen",
-      "supportedFormats": "Fügen Sie ein Bild im Dateiformat JPG, PNG oder GIF ein"
+      "supportedFormats": "Füge ein Bild im Dateiformat JPG, PNG oder GIF ein"
     },
     "title": "Titel"
   },

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -258,7 +258,8 @@
     "newPost": "Erstelle einen neuen Beitrag",
     "success": "Gespeichert!",
     "teaserImage": {
-      "cropperConfirm": "Bestätigen"
+      "cropperConfirm": "Bestätigen",
+      "supportedFormats": "Fügen Sie ein Bild im Dateiformat JPG, PNG oder GIF ein"
     },
     "title": "Titel"
   },

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -258,7 +258,8 @@
     "newPost": "Create a new Post",
     "success": "Saved!",
     "teaserImage": {
-      "cropperConfirm": "Confirm"
+      "cropperConfirm": "Confirm",
+      "supportedFormats": "Insert a picture of file format JPG , PNG or GIF"
     },
     "title": "Title"
   },

--- a/webapp/locales/es.json
+++ b/webapp/locales/es.json
@@ -256,7 +256,8 @@
     "newPost": "Crear una nueva contribución",
     "success": "¡Guardado!",
     "teaserImage": {
-      "cropperConfirm": "Confirmar"
+      "cropperConfirm": "Confirmar",
+      "supportedFormats": "Insertar una imagen de formato de archivo JPG, PNG o GIF"
     },
     "title": "Título"
   },

--- a/webapp/locales/fr.json
+++ b/webapp/locales/fr.json
@@ -256,7 +256,8 @@
     "newPost": "Créer un nouveau Post",
     "success": "Enregistré!",
     "teaserImage": {
-      "cropperConfirm": "Confirmer"
+      "cropperConfirm": "Confirmer",
+      "supportedFormats": "Insérer une image au format de fichier JPG, PNG ou GIF"
     },
     "title": "Titre"
   },

--- a/webapp/locales/it.json
+++ b/webapp/locales/it.json
@@ -261,7 +261,8 @@
     "newPost": "",
     "success": "",
     "teaserImage": {
-      "cropperConfirm": "Confermare"
+      "cropperConfirm": "Confermare",
+      "supportedFormats": "Inserisci un'immagine in formato file JPG, PNG o GIF"
     },
     "title": ""
   },

--- a/webapp/locales/nl.json
+++ b/webapp/locales/nl.json
@@ -68,7 +68,8 @@
     "delete": "Bijdrage verwijderen",
     "edit": "Bijdrage bewerken",
     "teaserImage": {
-      "cropperConfirm": "Bevestigen"
+      "cropperConfirm": "Bevestigen",
+      "supportedFormats": "Voeg een afbeelding in met het bestandsformaat JPG, PNG of GIF"
     }
   },
   "disable": {

--- a/webapp/locales/pl.json
+++ b/webapp/locales/pl.json
@@ -119,7 +119,8 @@
     "newPost": "Utwórz nowy wpis",
     "success": "Zapisano!",
     "teaserImage": {
-      "cropperConfirm": "Potwierdzać"
+      "cropperConfirm": "Potwierdzać",
+      "supportedFormats": "Wstaw zdjęcie w formacie pliku JPG, PNG lub GIF"
     }
   },
   "delete": {

--- a/webapp/locales/pt.json
+++ b/webapp/locales/pt.json
@@ -253,7 +253,7 @@
     "success": "Salvo!",
     "teaserImage": {
       "cropperConfirm": "Confirmar",
-      "supportedFormats": "Insira uma imagem do formato de arquivo JPG, PNG ou GIF"
+      "supportedFormats": "Insira uma imagem do formato JPG, PNG ou GIF"
     },
     "title": "Título"
   },

--- a/webapp/locales/pt.json
+++ b/webapp/locales/pt.json
@@ -252,7 +252,8 @@
     "newPost": "Criar uma nova publicação",
     "success": "Salvo!",
     "teaserImage": {
-      "cropperConfirm": "Confirmar"
+      "cropperConfirm": "Confirmar",
+      "supportedFormats": "Insira uma imagem do formato de arquivo JPG, PNG ou GIF"
     },
     "title": "Título"
   },

--- a/webapp/locales/ru.json
+++ b/webapp/locales/ru.json
@@ -256,7 +256,8 @@
     "newPost": "Создать пост",
     "success": "Сохранено!",
     "teaserImage": {
-      "cropperConfirm": "Подтвердить"
+      "cropperConfirm": "Подтвердить",
+      "supportedFormats": "Вставьте изображение файла формата JPG, PNG или GIF"
     },
     "title": "Заголовок"
   },


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

 to show the supported image formats in the ImageUploader of the editor 

![Screenshot from 2020-10-26 00-11-49](https://user-images.githubusercontent.com/64162781/97167141-5272c880-17ac-11eb-9e11-2106a08ebd45.png)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #1949 
- relates #XXX
-->
- fixes #1949 

### Todo
<!-- In case some parts are still missing, list them here. -->

- [X]  the text should be converted to other languages 
