### PR TITLE
[Feature] Show/Hide Password Icon - Issue # 2434

### DIFF
--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -70,9 +70,8 @@ describe('LoginForm', () => {
         await Vue.nextTick()
         await expect(wrapper.find('input[name = "password"]').attributes('type')).toEqual('text')
       })
-
     })
-        
+
     describe('Click on show password icon, icon change', () => {
       const wrapper = Wrapper()
       it('shows eye icon by default', () => {
@@ -86,12 +85,12 @@ describe('LoginForm', () => {
       })
     })
 
-    describe('Focus returns to password input container after show password click', () =>{
+    describe('Focus returns to password input container after show password click', () => {
       const wrapper = Wrapper()
       const componentToGetFocus = wrapper.find('input[name ="password"]')
       it('Focus is on the password field container after click', async () => {
         wrapper.find('span.click-wrapper').trigger('click', {
-          relateTarget: componentToGetFocus
+          relateTarget: componentToGetFocus,
         })
         await Vue.nextTick()
         await expect(wrapper.emitted('focus')).toBeTruthy()

--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -59,7 +59,7 @@ describe('LoginForm', () => {
       })
     })
 
-    describe('Click on show password input field type change', () => {
+    describe('Visibility of password', () => {
       const wrapper = Wrapper()
       it('does not show the password by default', () => {
         expect(wrapper.find('input[name ="password"]').attributes('type')).toEqual('password')
@@ -85,10 +85,10 @@ describe('LoginForm', () => {
       })
     })
 
-    describe('Focus returns to password input container after show password click', () => {
+    describe('Focus on password input container after show-password click', () => {
       const wrapper = Wrapper()
       const componentToGetFocus = wrapper.find('input[name ="password"]')
-      it('Focus is on the password field container after click', async () => {
+      it('Focuses on the password field after click', async () => {
         wrapper.find('span.click-wrapper').trigger('click', {
           relateTarget: componentToGetFocus,
         })

--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import LoginForm from './LoginForm.vue'
 import Styleguide from '@human-connection/styleguide'
 import Vuex from 'vuex'
@@ -38,7 +39,7 @@ describe('LoginForm', () => {
           error: jest.fn(),
         },
       }
-      return mount(LoginForm, { mocks, localVue, propsData, store, data })
+      return mount(LoginForm, { mocks, localVue, propsData, store })
     }
 
     describe('fill in email and password and submit', () => {
@@ -57,13 +58,44 @@ describe('LoginForm', () => {
         })
       })
     })
-    
-    describe('Click event', () => {
-      it('clicking icon shows/hides password and changes icon', () => {   
-        wrapper.find('a.click-wrapper').trigger('click')
-        expect(wrapper.data.showPassword).toEqual(!showPassword)
+
+    describe('Click on show password input field type change', () => {
+      const wrapper = Wrapper()
+      it('does not show the password by default', () => {
+        expect(wrapper.find('input[name ="password"]').attributes('type')).toEqual('password')
+      })
+
+      it('shows the password after click on show password', async () => {
+        wrapper.find('span.click-wrapper').trigger('click')
+        await Vue.nextTick()
+        await expect(wrapper.find('input[name = "password"]').attributes('type')).toEqual('text')
+      })
+
+    })
+        
+    describe('Click on show password icon, icon change', () => {
+      const wrapper = Wrapper()
+      it('shows eye icon by default', () => {
+        expect(wrapper.find('span.icon-wrapper').attributes('data-test')).toEqual('eye')
+      })
+
+      it('shows the slash-eye icon after click', async () => {
+        wrapper.find('span.click-wrapper').trigger('click')
+        await Vue.nextTick()
+        await expect(wrapper.find('span.icon-wrapper').attributes('data-test')).toEqual('eye-slash')
+      })
+    })
+
+    describe('Focus returns to password input container after show password click', () =>{
+      const wrapper = Wrapper()
+      const componentToGetFocus = wrapper.find('input[name ="password"]')
+      it('Focus is on the password field container after click', async () => {
+        wrapper.find('span.click-wrapper').trigger('click', {
+          relateTarget: componentToGetFocus
+        })
+        await Vue.nextTick()
+        await expect(wrapper.emitted('focus')).toBeTruthy()
       })
     })
   })
-
 })

--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -38,7 +38,7 @@ describe('LoginForm', () => {
           error: jest.fn(),
         },
       }
-      return mount(LoginForm, { mocks, localVue, propsData, store })
+      return mount(LoginForm, { mocks, localVue, propsData, store, data })
     }
 
     describe('fill in email and password and submit', () => {
@@ -57,5 +57,13 @@ describe('LoginForm', () => {
         })
       })
     })
+    
+    describe('Click event', () => {
+      it('clicking icon shows/hides password and changes icon', () => {   
+        wrapper.find('a.click-wrapper').trigger('click')
+        expect(wrapper.data.showPassword).toEqual(!showPassword)
+      })
+    })
   })
+
 })

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -27,6 +27,7 @@
             :placeholder="$t('login.password')"
             icon="lock"
             name="password"
+            class="password-field"
             :type="showPassword ? 'text' : 'password'"
           />
           <a
@@ -38,7 +39,7 @@
           >
             <base-icon 
                 class="toggle-icon"
-                :name="showPassword ? 'eye-slash' :  'eye'"
+                :name="showPassword ? 'eye-slash' : 'eye'"
             />
           </a>
         </div>
@@ -113,12 +114,13 @@ export default {
 }
 
 .password-wrapper {
-  position: relative;
   display: flex;
-  appearance: none;
   width: 100%;
+  align-items: center;
   padding: $input-padding-vertical $space-x-small;
+  padding-left: 0;
   height: $input-height;
+  margin-bottom: 10px;
 
   color: $text-color-base;
   background: $background-color-disabled;
@@ -127,12 +129,32 @@ export default {
   border-radius: $border-radius-base;
   outline: none;
   transition: all $duration-short $ease-out;
+
+  .click-wrapper {
+    padding: 5px;
+    color: $text-color-disabled;
+  }
+
   &:focus-within {
     background-color: $background-color-base;
     border: $input-border-size solid $border-color-active;
+
     .toggle-icon {
       color: $text-color-base;
     }
   }
+  .password-field {
+    position: relative;
+    padding-top: 16px;
+    padding-right: 20px;
+    border: none;
+    border-style: none;
+    appearance: none;
+    margin-left: 0;
+    margin-right: -16px;
+    width: 100%;
+  }
+
 }
+
 </style>

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -30,10 +30,7 @@
             class="password-field"
             :type="showPassword ? 'text' : 'password'"
           />
-          <a
-            class="click-wrapper"
-            @click="toggleShowPassword"
-          >
+          <a class="click-wrapper" @click="toggleShowPassword">
             <base-icon class="toggle-icon" :name="showPassword ? 'eye-slash' : 'eye'" />
           </a>
         </div>
@@ -90,10 +87,9 @@ export default {
       }
     },
     toggleShowPassword(event) {
-      console.log(event);
-      event.preventDefault();
       this.showPassword = !this.showPassword
-    }
+      event.preventDefault()
+    },
   },
 }
 </script>
@@ -140,13 +136,13 @@ export default {
     cursor: pointer;
 
     &:focus-within {
-    background-color: $background-color-base;
-    border: $input-border-size solid $border-color-active;
+      background-color: $background-color-base;
+      border: $input-border-size solid $border-color-active;
 
-    .toggle-icon {
-      color: $text-color-base;
+      .toggle-icon {
+        color: $text-color-base;
+      }
     }
-  }
   }
 
   &:focus-within {

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -20,7 +20,7 @@
           name="email"
           icon="envelope"
         />
-        <div class="password-wrapper">
+        <div class="password-wrapper" >
           <ds-input
             v-model="form.password"
             :disabled="pending"
@@ -28,11 +28,14 @@
             icon="lock"
             name="password"
             class="password-field"
+            ref="password"
             :type="showPassword ? 'text' : 'password'"
           />
-          <a class="click-wrapper" @click="toggleShowPassword">
-            <base-icon class="toggle-icon" :name="showPassword ? 'eye-slash' : 'eye'" />
-          </a>
+          <span class="click-wrapper" @click="toggleShowPassword">
+            <span class="icon-wrapper" :data-test="iconName">
+              <base-icon class="toggle-icon"  :name="iconName" />
+            </span>
+          </span>
         </div>
         <nuxt-link to="/password-reset/request">
           {{ $t('login.forgotPassword') }}
@@ -74,6 +77,9 @@ export default {
     pending() {
       return this.$store.getters['auth/pending']
     },
+    iconName() {
+      return this.showPassword ? 'eye-slash' : 'eye'
+    }
   },
   methods: {
     async onSubmit() {
@@ -89,6 +95,10 @@ export default {
     toggleShowPassword(event) {
       this.showPassword = !this.showPassword
       event.preventDefault()
+      this.$nextTick(() => {
+        this.$refs.password.$el.children[1].children[1].focus()
+        this.$emit('focus')
+      })
     },
   },
 }
@@ -126,14 +136,16 @@ export default {
   outline: none;
   transition: all $duration-short $ease-out;
 
-  .click-wrapper {
+  .icon-wrapper {
     padding: 8px;
     margin: 4px;
+    padding-left: 16px;
     color: $text-color-disabled;
   }
 
   .click-wrapper:hover {
     cursor: pointer;
+
 
     &:focus-within {
       background-color: $background-color-base;
@@ -153,10 +165,11 @@ export default {
       color: $text-color-base;
     }
   }
+
   .password-field {
     position: relative;
     padding-top: 16px;
-    padding-right: 16px;
+    padding-right: 8px;
     border: none;
     border-style: none;
     appearance: none;

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -137,15 +137,17 @@ export default {
   transition: all $duration-short $ease-out;
 
   .icon-wrapper {
+    margin-right: 2px;
+  }
+
+  .click-wrapper {
     padding: 8px;
-    margin: 4px;
-    padding-left: 20px;
+    align-content: center;
     color: $text-color-disabled;
+    cursor: pointer;
   }
 
   .click-wrapper:hover {
-    cursor: pointer;
-
     &:focus-within {
       background-color: $background-color-base;
       border: $input-border-size solid $border-color-active;
@@ -155,6 +157,7 @@ export default {
       }
     }
   }
+  
 
   &:focus-within {
     background-color: $background-color-base;
@@ -168,12 +171,10 @@ export default {
   .password-field {
     position: relative;
     padding-top: 16px;
-    padding-right: 8px;
     border: none;
     border-style: none;
     appearance: none;
     margin-left: 0;
-    margin-right: -20px;
     width: 100%;
   }
 }

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -157,7 +157,6 @@ export default {
       }
     }
   }
-  
 
   &:focus-within {
     background-color: $background-color-base;

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -20,7 +20,7 @@
           name="email"
           icon="envelope"
         />
-        <div class="password-wrapper" >
+        <div class="password-wrapper">
           <ds-input
             v-model="form.password"
             :disabled="pending"
@@ -33,7 +33,7 @@
           />
           <span class="click-wrapper" @click="toggleShowPassword">
             <span class="icon-wrapper" :data-test="iconName">
-              <base-icon class="toggle-icon"  :name="iconName" />
+              <base-icon class="toggle-icon" :name="iconName" />
             </span>
           </span>
         </div>
@@ -79,7 +79,7 @@ export default {
     },
     iconName() {
       return this.showPassword ? 'eye-slash' : 'eye'
-    }
+    },
   },
   methods: {
     async onSubmit() {
@@ -145,7 +145,6 @@ export default {
 
   .click-wrapper:hover {
     cursor: pointer;
-
 
     &:focus-within {
       background-color: $background-color-base;

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -32,12 +32,7 @@
           />
           <a
             class="click-wrapper"
-            @mousedown="
-              (event) => {
-                showPassword = !showPassword
-                event.preventDefault()
-              }
-            "
+            @click="toggleShowPassword"
           >
             <base-icon class="toggle-icon" :name="showPassword ? 'eye-slash' : 'eye'" />
           </a>
@@ -94,6 +89,11 @@ export default {
         this.$toast.error(this.$t('login.failure'))
       }
     },
+    toggleShowPassword(event) {
+      console.log(event);
+      event.preventDefault();
+      this.showPassword = !this.showPassword
+    }
   },
 }
 </script>
@@ -118,6 +118,7 @@ export default {
   align-items: center;
   padding: $input-padding-vertical $space-x-small;
   padding-left: 0;
+  padding-right: 0;
   height: $input-height;
   margin-bottom: 10px;
 
@@ -130,8 +131,22 @@ export default {
   transition: all $duration-short $ease-out;
 
   .click-wrapper {
-    padding: 5px;
+    padding: 8px;
+    margin: 4px;
     color: $text-color-disabled;
+  }
+
+  .click-wrapper:hover {
+    cursor: pointer;
+
+    &:focus-within {
+    background-color: $background-color-base;
+    border: $input-border-size solid $border-color-active;
+
+    .toggle-icon {
+      color: $text-color-base;
+    }
+  }
   }
 
   &:focus-within {
@@ -145,7 +160,7 @@ export default {
   .password-field {
     position: relative;
     padding-top: 16px;
-    padding-right: 20px;
+    padding-right: 16px;
     border: none;
     border-style: none;
     appearance: none;

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -32,15 +32,14 @@
           />
           <a
             class="click-wrapper"
-            @mousedown="(event) => {
-                showPassword = !showPassword;
-                event.preventDefault();
-            }"
+            @mousedown="
+              (event) => {
+                showPassword = !showPassword
+                event.preventDefault()
+              }
+            "
           >
-            <base-icon 
-                class="toggle-icon"
-                :name="showPassword ? 'eye-slash' : 'eye'"
-            />
+            <base-icon class="toggle-icon" :name="showPassword ? 'eye-slash' : 'eye'" />
           </a>
         </div>
         <nuxt-link to="/password-reset/request">
@@ -68,7 +67,7 @@ import BaseIcon from '../_new/generic/BaseIcon/BaseIcon'
 export default {
   components: {
     LocaleSwitch,
-    BaseIcon
+    BaseIcon,
   },
   data() {
     return {
@@ -76,7 +75,7 @@ export default {
         email: '',
         password: '',
       },
-      showPassword: false
+      showPassword: false,
     }
   },
   computed: {
@@ -154,7 +153,5 @@ export default {
     margin-right: -16px;
     width: 100%;
   }
-
 }
-
 </style>

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -20,15 +20,28 @@
           name="email"
           icon="envelope"
         />
-        <ds-input
-          v-model="form.password"
-          :disabled="pending"
-          :placeholder="$t('login.password')"
-          icon="lock"
-          icon-right="question-circle"
-          name="password"
-          type="password"
-        />
+        <div class="password-wrapper">
+          <ds-input
+            v-model="form.password"
+            :disabled="pending"
+            :placeholder="$t('login.password')"
+            icon="lock"
+            name="password"
+            :type="showPassword ? 'text' : 'password'"
+          />
+          <a
+            class="click-wrapper"
+            @mousedown="(event) => {
+                showPassword = !showPassword;
+                event.preventDefault();
+            }"
+          >
+            <base-icon 
+                class="toggle-icon"
+                :name="showPassword ? 'eye-slash' :  'eye'"
+            />
+          </a>
+        </div>
         <nuxt-link to="/password-reset/request">
           {{ $t('login.forgotPassword') }}
         </nuxt-link>
@@ -49,10 +62,12 @@
 
 <script>
 import LocaleSwitch from '~/components/LocaleSwitch/LocaleSwitch'
+import BaseIcon from '../_new/generic/BaseIcon/BaseIcon'
 
 export default {
   components: {
     LocaleSwitch,
+    BaseIcon
   },
   data() {
     return {
@@ -60,6 +75,7 @@ export default {
         email: '',
         password: '',
       },
+      showPassword: false
     }
   },
   computed: {
@@ -93,6 +109,30 @@ export default {
     width: 100%;
     margin-top: $space-large;
     margin-bottom: $space-small;
+  }
+}
+
+.password-wrapper {
+  position: relative;
+  display: flex;
+  appearance: none;
+  width: 100%;
+  padding: $input-padding-vertical $space-x-small;
+  height: $input-height;
+
+  color: $text-color-base;
+  background: $background-color-disabled;
+
+  border: $input-border-size solid $border-color-softer;
+  border-radius: $border-radius-base;
+  outline: none;
+  transition: all $duration-short $ease-out;
+  &:focus-within {
+    background-color: $background-color-base;
+    border: $input-border-size solid $border-color-active;
+    .toggle-icon {
+      color: $text-color-base;
+    }
   }
 }
 </style>

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -139,7 +139,7 @@ export default {
   .icon-wrapper {
     padding: 8px;
     margin: 4px;
-    padding-left: 16px;
+    padding-left: 20px;
     color: $text-color-disabled;
   }
 
@@ -173,7 +173,7 @@ export default {
     border-style: none;
     appearance: none;
     margin-left: 0;
-    margin-right: -16px;
+    margin-right: -20px;
     width: 100%;
   }
 }


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

The pull request modifies the password input field to include an Icon that reveals or hides the password and simultaneously updates the Icon to reflect the state of password field. 




<img width="326" alt="Screen Shot 2020-11-20 at 10 43 26 AM" src="https://user-images.githubusercontent.com/60131322/99832364-a3f94380-2b1d-11eb-8606-0f56f8f032f2.png">


<img width="311" alt="Screen Shot 2020-11-20 at 10 42 50 AM" src="https://user-images.githubusercontent.com/60131322/99832350-a0fe5300-2b1d-11eb-8406-0757bd04e581.png">

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #2434

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Unit Test for Toggle