### PR TITLE
feat: 🍰 Password Field Capslock Alert

### DIFF
--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -63,14 +63,13 @@ describe('LoginForm', () => {
       const wrapper = Wrapper()
 
       it('Caps-lock warning message is hidden on page load', () => {
-        expect(wrapper.find('text.caps-warning').attributes('style')).toEqual('display: none;')
+        expect(wrapper.find('.caps-warning').isVisible()).toBe(false)
       })
 
-      it('shows warning when caps-lock is press', async () => {
-        const formWrapper = wrapper.find({ ref: 'form' })
-        formWrapper.trigger('keydown', {key: 'CapsLock'})
-        // await Vue.nextTick()
-        expect(wrapper.vm.caps).toBe(true)
+      it('shows warning when caps-lock is pressed', async () => {
+        wrapper.setData({ caps: true })
+        await Vue.nextTick()
+        expect(wrapper.find('.caps-warning').isVisible()).toBe(true)
       })
     })
   })

--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import LoginForm from './LoginForm.vue'
 import Styleguide from '@human-connection/styleguide'
 import Vuex from 'vuex'
@@ -55,6 +56,21 @@ describe('LoginForm', () => {
           email: 'email@example.org',
           password: '1234',
         })
+      })
+    })
+
+    describe('Warning message is visible when caps lock is on', () => {
+      const wrapper = Wrapper()
+
+      it('Caps-lock warning message is hidden on page load', () => {
+        expect(wrapper.find('text.caps-warning').attributes('style')).toEqual('display: none;')
+      })
+
+      it('shows warning when caps-lock is press', async () => {
+        const formWrapper = wrapper.find({ ref: 'form' })
+        formWrapper.trigger('keydown', {key: 'CapsLock'})
+        // await Vue.nextTick()
+        expect(wrapper.vm.caps).toBe(true)
       })
     })
   })

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -31,6 +31,7 @@
             name="password"
             type="password"
             ref="passwordInput"
+            @focus="capsLock"
           />
         <nuxt-link to="/password-reset/request">
           {{ $t('login.forgotPassword') }}
@@ -84,10 +85,12 @@ export default {
         this.$toast.error(this.$t('login.failure'))
       }
     },
-    capsLock(){
-      if(document.activeElement.name === 'password') {
-        this.caps = !this.caps
-      }
+    capsLock(e){
+      this.caps = e.getModifierState('CapsLock')
+      console.log(this.caps)
+      // if(document.activeElement.name === 'password') {
+      //   this.caps = !this.caps
+      // }
     }
   },
 }

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -11,11 +11,13 @@
         </a>
       </template>
       <h2 class="title">{{ $t('login.login') }}</h2>
-      <form 
-          ref="form"
-          :disabled="pending" @submit.prevent="onSubmit" 
-          @keydown.caps-lock="capsLock"
-          @keyup.caps-lock="capsLock">
+      <form
+        ref="form"
+        :disabled="pending"
+        @submit.prevent="onSubmit"
+        @keydown="capsLock"
+        @keyup="capsLock"
+      >
         <ds-input
           v-model="form.email"
           :disabled="pending"
@@ -24,20 +26,20 @@
           name="email"
           icon="envelope"
         />
-          <ds-input
-            v-model="form.password"
-            :disabled="pending"
-            :placeholder="$t('login.password')"
-            icon="lock"
-            icon-right="question-circle"
-            name="password"
-            type="password"
-            ref="passwordInput"
-          />
+        <ds-input
+          v-model="form.password"
+          :disabled="pending"
+          :placeholder="$t('login.password')"
+          icon="lock"
+          icon-right="question-circle"
+          name="password"
+          type="password"
+          ref="passwordInput"
+        />
         <nuxt-link to="/password-reset/request">
           {{ $t('login.forgotPassword') }}
         </nuxt-link>
-        <text class="caps-warning" v-show="caps" >CAPS LOCK ENABLED!</text>
+        <text class="caps-warning" v-show="caps">{{ $t('login.capsLock') }}</text>
         <base-button :loading="pending" filled name="submit" type="submit" icon="sign-in">
           {{ $t('login.login') }}
         </base-button>
@@ -85,11 +87,11 @@ export default {
         this.$toast.error(this.$t('login.failure'))
       }
     },
-    capsLock(e){
-      if(document.activeElement.name === 'password') {
+    capsLock(e) {
+      if (document.activeElement.name === 'password') {
         this.caps = e.getModifierState('CapsLock')
       }
-    }
+    },
   },
 }
 </script>
@@ -106,18 +108,16 @@ export default {
     margin-top: $space-large;
     margin-bottom: $space-small;
   }
-  
+
   .caps-warning {
     font-size: 12px;
     color: $text-color-danger;
     background-color: $background-color-danger-inverse;
-    border: 2px solid $border-color-softer ;
+    border: 2px solid $border-color-softer;
     border-radius: 5px;
     padding: 4px 8px;
     margin-left: 8px;
-    
-
+    width: fit-content;
   }
 }
-
 </style>

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -11,9 +11,11 @@
         </a>
       </template>
       <h2 class="title">{{ $t('login.login') }}</h2>
-      <form :disabled="pending" @submit.prevent="onSubmit" 
-          v-on:keydown.caps-lock="capsLock"
-          v-on:keyup.caps-lock="capsLock">
+      <form 
+          ref="form"
+          :disabled="pending" @submit.prevent="onSubmit" 
+          @keydown.caps-lock="capsLock"
+          @keyup.caps-lock="capsLock">
         <ds-input
           v-model="form.email"
           :disabled="pending"
@@ -106,7 +108,15 @@ export default {
   }
   
   .caps-warning {
+    font-size: 12px;
     color: $text-color-danger;
+    background-color: $background-color-danger-inverse;
+    border: 2px solid $border-color-softer ;
+    border-radius: 5px;
+    padding: 4px 8px;
+    margin-left: 8px;
+    
+
   }
 }
 

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -11,7 +11,9 @@
         </a>
       </template>
       <h2 class="title">{{ $t('login.login') }}</h2>
-      <form :disabled="pending" @submit.prevent="onSubmit">
+      <form :disabled="pending" @submit.prevent="onSubmit" 
+          v-on:keydown.caps-lock="capsLock"
+          v-on:keyup.caps-lock="capsLock">
         <ds-input
           v-model="form.email"
           :disabled="pending"
@@ -20,18 +22,20 @@
           name="email"
           icon="envelope"
         />
-        <ds-input
-          v-model="form.password"
-          :disabled="pending"
-          :placeholder="$t('login.password')"
-          icon="lock"
-          icon-right="question-circle"
-          name="password"
-          type="password"
-        />
+          <ds-input
+            v-model="form.password"
+            :disabled="pending"
+            :placeholder="$t('login.password')"
+            icon="lock"
+            icon-right="question-circle"
+            name="password"
+            type="password"
+            ref="passwordInput"
+          />
         <nuxt-link to="/password-reset/request">
           {{ $t('login.forgotPassword') }}
         </nuxt-link>
+        <text class="caps-warning" v-show="caps" >CAPS LOCK ENABLED!</text>
         <base-button :loading="pending" filled name="submit" type="submit" icon="sign-in">
           {{ $t('login.login') }}
         </base-button>
@@ -60,12 +64,14 @@ export default {
         email: '',
         password: '',
       },
+      caps: false,
     }
   },
   computed: {
     pending() {
       return this.$store.getters['auth/pending']
     },
+    
   },
   methods: {
     async onSubmit() {
@@ -78,6 +84,11 @@ export default {
         this.$toast.error(this.$t('login.failure'))
       }
     },
+    capsLock(){
+      if(document.activeElement.name === 'password') {
+        this.caps = !this.caps
+      }
+    }
   },
 }
 </script>
@@ -94,5 +105,10 @@ export default {
     margin-top: $space-large;
     margin-bottom: $space-small;
   }
+  
+  .caps-warning {
+    color: $text-color-danger;
+  }
 }
+
 </style>

--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -31,7 +31,6 @@
             name="password"
             type="password"
             ref="passwordInput"
-            @focus="capsLock"
           />
         <nuxt-link to="/password-reset/request">
           {{ $t('login.forgotPassword') }}
@@ -72,7 +71,6 @@ export default {
     pending() {
       return this.$store.getters['auth/pending']
     },
-    
   },
   methods: {
     async onSubmit() {
@@ -86,11 +84,9 @@ export default {
       }
     },
     capsLock(e){
-      this.caps = e.getModifierState('CapsLock')
-      console.log(this.caps)
-      // if(document.activeElement.name === 'password') {
-      //   this.caps = !this.caps
-      // }
+      if(document.activeElement.name === 'password') {
+        this.caps = e.getModifierState('CapsLock')
+      }
     }
   },
 }

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -354,6 +354,7 @@
     "no-results": "Keine Beiträge gefunden."
   },
   "login": {
+    "capsLock": "Capslock ist an",
     "copy": "Falls Du bereits ein Konto bei Human Connection hast, melde Dich bitte hier an.",
     "email": "Deine E-Mail",
     "failure": "Fehlerhafte E-Mail-Adresse oder Passwort.",

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -354,6 +354,7 @@
     "no-results": "No contributions found."
   },
   "login": {
+    "capsLock": "Caps Lock Enabled!",
     "copy": "If you already have a human-connection account, please login.",
     "email": "Your E-mail",
     "failure": "Incorrect email address or password.",


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Pull Request creates a Caps Lock enabled warning when user is typing in the password field on login. 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- #3779 

There is one small bug. If the capslock is already enabled on page refresh it will temporarily not trigger when the password field is clicked. I do not believe I can resolve this issue fully until the ds-input is migrated and there is access to the change event. 

Should this issue be put on hold until I finish migration? 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Fix Test Case for changing data visibility of warning
- [ ] Finalize styling of warning
