### PR TITLE
Throw Error When No Cookie Can Be Set

### DIFF
--- a/webapp/components/LoginForm/LoginForm.vue
+++ b/webapp/components/LoginForm/LoginForm.vue
@@ -91,7 +91,11 @@ export default {
         this.$toast.success(this.$t('login.success'))
         this.$emit('success')
       } catch (err) {
-        this.$toast.error(this.$t('login.failure'))
+        if (err.message === 'Error: no-cookie') {
+          this.$toast.error(this.$t('login.no-cookie'))
+        } else {
+          this.$toast.error(this.$t('login.failure'))
+        }
       }
     },
     toggleShowPassword(event) {

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -315,6 +315,7 @@
     "moreInfo": "Was ist {APPLICATION_NAME}?",
     "moreInfoHint": "zur Präsentationsseite",
     "no-account": "Du hast noch kein Benutzerkonto?",
+    "no-cookie": "Es kann kein Cookie angelegt werden. Du must Cookies akzeptieren.",
     "password": "Dein Passwort",
     "register": "Benutzerkonto erstellen",
     "success": "Du bist eingeloggt!"

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -315,6 +315,7 @@
     "moreInfo": "What is {APPLICATION_NAME}?",
     "moreInfoHint": "to the presentation page",
     "no-account": "Don't have an account?",
+    "no-cookie": "No cookie can be set. You must accept cookies.",
     "password": "Your Password",
     "register": "Sign up",
     "success": "You are logged in!"

--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -1,6 +1,9 @@
 import gql from 'graphql-tag'
 import { VERSION } from '~/constants/terms-and-conditions-version.js'
 import { currentUserQuery } from '~/graphql/User'
+import Cookie from 'universal-cookie'
+
+const cookies = new Cookie()
 
 export const state = () => {
   return {
@@ -99,6 +102,9 @@ export const actions = {
       await this.app.$apolloHelpers.onLogin(login)
       commit('SET_TOKEN', login)
       await dispatch('fetchCurrentUser')
+      if (cookies.get('ocelot-social-token') === undefined) {
+        throw new Error('no-cookie')
+      }
     } catch (err) {
       throw new Error(err)
     } finally {


### PR DESCRIPTION
## 🍰 Pullrequest
Checks if a cookie with the JWT exists after login. If not, an error message is toasted, saying that no cookie could be set.

### Issues
- fixes #4080
