### PR TITLE
Name of Cookie Is Set in metadata.js

### DIFF
--- a/webapp/constants/metadata.js
+++ b/webapp/constants/metadata.js
@@ -4,4 +4,5 @@ export default {
   APPLICATION_DESCRIPTION: 'ocelot.social Community Network',
   ORGANIZATION_NAME: 'ocelot.social Community',
   ORGANIZATION_JURISDICTION: 'City of Angels',
+  COOKIE_NAME: 'ocelot-social-token',
 }

--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import dotenv from 'dotenv'
 import manifest from './constants/manifest.js'
+import metadata from './constants/metadata.js'
 
 dotenv.config() // we want to synchronize @nuxt-dotenv and nuxt-env
 
@@ -214,7 +215,7 @@ export default {
 
   // Give apollo module options
   apollo: {
-    tokenName: 'ocelot-social-token', // optional, default: apollo-token
+    tokenName: metadata.COOKIE_NAME, // optional, default: apollo-token
     cookieAttributes: {
       expires: 1, // optional, default: 7 (days)
     },

--- a/webapp/plugins/apollo-config.js
+++ b/webapp/plugins/apollo-config.js
@@ -1,5 +1,6 @@
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
 import introspectionQueryResultData from './apollo-config/fragmentTypes.json'
+import metadata from '~/constants/metadata'
 
 const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData,
@@ -16,7 +17,7 @@ export default ({ req, nuxtState }) => {
       credentials: 'same-origin',
     },
     credentials: true,
-    tokenName: 'ocelot-social-token',
+    tokenName: metadata.COOKIE_NAME,
     persisting: false,
     websocketsOnly: false,
     cache: new InMemoryCache({ fragmentMatcher }),

--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -2,6 +2,7 @@ import gql from 'graphql-tag'
 import { VERSION } from '~/constants/terms-and-conditions-version.js'
 import { currentUserQuery } from '~/graphql/User'
 import Cookie from 'universal-cookie'
+import metadata from '~/constants/metadata'
 
 const cookies = new Cookie()
 
@@ -102,7 +103,7 @@ export const actions = {
       await this.app.$apolloHelpers.onLogin(login)
       commit('SET_TOKEN', login)
       await dispatch('fetchCurrentUser')
-      if (cookies.get('ocelot-social-token') === undefined) {
+      if (cookies.get(metadata.COOKIE_NAME) === undefined) {
         throw new Error('no-cookie')
       }
     } catch (err) {


### PR DESCRIPTION
## 🍰 Pullrequest
The name of the cookie used to store the JWT is now configured in the `webapp/constants/metadata.js`

### Issues
- fixes #4090 

