### PR TITLE
[WIP] fix: 🍰 Issue #3504 umlaut encoding #3676

### DIFF
--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -2,7 +2,7 @@ import slugify from 'slug'
 export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
-    charmap: { Ä: 'AE', ä: 'ae', Ö: 'OE', ö: 'oe', Ü: 'UE', ü: 'ue', ñ: 'n' },
+    multicharmap: { Ä: 'AE', ä: 'ae', Ö: 'OE', ö: 'oe', Ü: 'UE', ü: 'ue', ß: 'ss' },
   })
   if (await isUnique(slug)) return slug
 

--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -2,6 +2,7 @@ import slugify from 'slug'
 export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
+    locale: 'de',
   })
   if (await isUnique(slug)) return slug
 

--- a/backend/src/middleware/slugify/uniqueSlug.js
+++ b/backend/src/middleware/slugify/uniqueSlug.js
@@ -2,7 +2,7 @@ import slugify from 'slug'
 export default async function uniqueSlug(string, isUnique) {
   const slug = slugify(string || 'anonymous', {
     lower: true,
-    locale: 'de',
+    charmap: { Ä: 'AE', ä: 'ae', Ö: 'OE', ö: 'oe', Ü: 'UE', ü: 'ue', ñ: 'n' },
   })
   if (await isUnique(slug)) return slug
 

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -18,18 +18,17 @@ describe('uniqueSlug', () => {
     const isUnique = jest.fn().mockResolvedValue(true)
     expect(uniqueSlug(string, isUnique)).resolves.toEqual('anonymous')
   })
-})
-
-describe('Slug is transliterated correctly', () => {
-  it('Converts umlaut to a two letter equivalent', () => {
+  
+  it('Converts umlaut to a two letter equivalent', async () => {
     const umlaut = 'ä'
     const isUnique = jest.fn().mockResolvedValue(true)
-    expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('ae')
+    await expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('ae')
   })
 
-  it('Removes Spanish enya ', () => {
+  it('Removes Spanish enya ', async () => {
     const enya = 'ñ'
     const isUnique = jest.fn().mockResolvedValue(true)
-    expect(uniqueSlug(enya, isUnique)).resolves.toEqual('n')
+    await expect(uniqueSlug(enya, isUnique)).resolves.toEqual('n')
   })
 })
+

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -18,7 +18,7 @@ describe('uniqueSlug', () => {
     const isUnique = jest.fn().mockResolvedValue(true)
     expect(uniqueSlug(string, isUnique)).resolves.toEqual('anonymous')
   })
-  
+
   it('Converts umlaut to a two letter equivalent', async () => {
     const umlaut = 'ä'
     const isUnique = jest.fn().mockResolvedValue(true)

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -22,14 +22,14 @@ describe('uniqueSlug', () => {
 
 describe('Slug is transliterated correctly', () => {
   it('Converts umlaut to a two letter equivalent', () => {
-    const umlaut = 'ä';
+    const umlaut = 'ä'
     const isUnique = jest.fn().mockResolvedValue(true)
-    expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('ae');
+    expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('ae')
   })
 
   it('Removes Spanish enya ', () => {
-    const enya = 'ñ';
+    const enya = 'ñ'
     const isUnique = jest.fn().mockResolvedValue(true)
-    expect(uniqueSlug(enya, isUnique)).resolves.toEqual('n');
+    expect(uniqueSlug(enya, isUnique)).resolves.toEqual('n')
   })
 })

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -31,4 +31,3 @@ describe('uniqueSlug', () => {
     await expect(uniqueSlug(enya, isUnique)).resolves.toEqual('n')
   })
 })
-

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -19,3 +19,17 @@ describe('uniqueSlug', () => {
     expect(uniqueSlug(string, isUnique)).resolves.toEqual('anonymous')
   })
 })
+
+describe('Slug is transliterated correctly', () => {
+  it('Converts umlaut to two letter equivalent', () => {
+    const umlaut = 'ä';
+    const isUnique = jest.fn().mockResolvedValue(true)
+    expect(uniqueSlug(string, isUnique)).resolves.toEqual('ae');
+  })
+
+  it('Removes Spanish enya ', () => {
+    const enya = 'ñ';
+    const isUnique = jest.fn().mockResolvedValue(true)
+    expect(uniqueSlug(string, isUnique)).resolves.toEqual('n');
+  })
+})

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -21,15 +21,15 @@ describe('uniqueSlug', () => {
 })
 
 describe('Slug is transliterated correctly', () => {
-  it('Converts umlaut to two letter equivalent', () => {
+  it('Converts umlaut to a two letter equivalent', () => {
     const umlaut = 'ä';
     const isUnique = jest.fn().mockResolvedValue(true)
-    expect(uniqueSlug(string, isUnique)).resolves.toEqual('ae');
+    expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('ae');
   })
 
   it('Removes Spanish enya ', () => {
     const enya = 'ñ';
     const isUnique = jest.fn().mockResolvedValue(true)
-    expect(uniqueSlug(string, isUnique)).resolves.toEqual('n');
+    expect(uniqueSlug(enya, isUnique)).resolves.toEqual('n');
   })
 })

--- a/backend/src/middleware/slugify/uniqueSlug.spec.js
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.js
@@ -20,14 +20,14 @@ describe('uniqueSlug', () => {
   })
 
   it('Converts umlaut to a two letter equivalent', async () => {
-    const umlaut = 'ä'
+    const umlaut = 'ÄÖÜäöüß'
     const isUnique = jest.fn().mockResolvedValue(true)
-    await expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('ae')
+    await expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('aeoeueaeoeuess')
   })
 
-  it('Removes Spanish enya ', async () => {
-    const enya = 'ñ'
+  it('Removes Spanish enya and diacritics', async () => {
+    const diacritics = 'áàéèíìóòúùñçÁÀÉÈÍÌÓÒÚÙÑÇ'
     const isUnique = jest.fn().mockResolvedValue(true)
-    await expect(uniqueSlug(enya, isUnique)).resolves.toEqual('n')
+    await expect(uniqueSlug(diacritics, isUnique)).resolves.toEqual('aaeeiioouuncaaeeiioouunc')
   })
 })


### PR DESCRIPTION
This PR is a replacement for PR #3676. The previous PR was from the old HC repository and has issues with the merge. The setting for the slug package has been set to properly resolve the umlauts to their proper two letter encoding. 


## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #3504  

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
