### PR TITLE
fix: JWT Expires In  2 Years

### DIFF
--- a/backend/src/jwt/encode.js
+++ b/backend/src/jwt/encode.js
@@ -5,7 +5,7 @@ import CONFIG from './../config'
 export default function encode(user) {
   const { id, name, slug } = user
   const token = jwt.sign({ id, name, slug }, CONFIG.JWT_SECRET, {
-    expiresIn: '1d',
+    expiresIn: '2y',
     issuer: CONFIG.GRAPHQL_URI,
     audience: CONFIG.CLIENT_URI,
     subject: user.id.toString(),


### PR DESCRIPTION
## 🍰 Pullrequest
The server keeps the JWT for 2 years instead of 1 day.

### Issues
- fixes #4258 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Test it in production
