### PR TITLE
fix: New Email Template For Signup With Invite Code

### DIFF
--- a/backend/src/middleware/email/emailMiddleware.js
+++ b/backend/src/middleware/email/emailMiddleware.js
@@ -43,9 +43,14 @@ if (!hasEmailConfig) {
 }
 
 const sendSignupMail = async (resolve, root, args, context, resolveInfo) => {
+  const { inviteCode } = args
   const response = await resolve(root, args, context, resolveInfo)
   const { email, nonce } = response
-  await sendMail(signupTemplate({ email, nonce }))
+  if (inviteCode) {
+    await sendMail(signupTemplate({ email, nonce, inviteCode }))
+  } else {
+    await sendMail(signupTemplate({ email, nonce }))
+  }
   delete response.nonce
   return response
 }

--- a/backend/src/middleware/email/templateBuilder.js
+++ b/backend/src/middleware/email/templateBuilder.js
@@ -13,13 +13,15 @@ const defaultParams = {
   welcomeImageUrl,
 }
 
-export const signupTemplate = ({ email, nonce }) => {
+export const signupTemplate = ({ email, nonce, inviteCode = null }) => {
   const subject = `Willkommen, Bienvenue, Welcome to ${CONFIG.APPLICATION_NAME}!`
   // dev format example: http://localhost:3000/registration?method=invite-mail&email=wolle.huss%40pjannto.com&nonce=64853
   const actionUrl = new URL('/registration', CONFIG.CLIENT_URI)
   actionUrl.searchParams.set('method', 'invite-mail')
   actionUrl.searchParams.set('email', email)
   actionUrl.searchParams.set('nonce', nonce)
+
+  const content = inviteCode ? templates.signupInviteCode : templates.signup
 
   return {
     from,
@@ -28,7 +30,7 @@ export const signupTemplate = ({ email, nonce }) => {
     html: mustache.render(
       templates.layout,
       { ...defaultParams, actionUrl, nonce, subject },
-      { content: templates.signup },
+      { content: content },
     ),
   }
 }

--- a/backend/src/middleware/email/templates/index.js
+++ b/backend/src/middleware/email/templates/index.js
@@ -4,6 +4,7 @@ import path from 'path'
 const readFile = (fileName) => fs.readFileSync(path.join(__dirname, fileName), 'utf-8')
 
 export const signup = readFile('./signup.html')
+export const signupInviteCode = readFile('./signupInviteCode.html')
 export const passwordReset = readFile('./resetPassword.html')
 export const wrongAccount = readFile('./wrongAccount.html')
 export const emailVerification = readFile('./emailVerification.html')

--- a/backend/src/middleware/email/templates/signupInviteCode.html
+++ b/backend/src/middleware/email/templates/signupInviteCode.html
@@ -1,0 +1,190 @@
+<!-- Email Body German : BEGIN -->
+<table class="email-german" align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"
+  style="margin: auto;">
+
+  <!-- Hero Image, Flush : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff;">
+      <img
+        src="{{{ welcomeImageUrl }}}"
+        width="300" height="" alt="Welcome image" border="0"
+        style="width: 100%; max-width: 300px; height: auto; background: #ffffff; font-family: Lato, sans-serif; font-size: 16px; line-height: 15px; color: #555555; margin: auto; display: block; padding: 20px;"
+        class="g-img">
+    </td>
+  </tr>
+  <!-- Hero Image, Flush : END -->
+
+  <!-- 1 Column Text + Button : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff; padding: 0 20px;">
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+        <tr>
+          <td
+            style="padding: 20px; padding-top: 0; font-family: Lato, sans-serif; font-size: 16px; line-height: 22px; color: #555555;">
+            <h1
+              style="margin: 0 0 10px 0; font-family: Lato, sans-serif; font-size: 25px; line-height: 30px; color: #333333; font-weight: normal;">
+              Willkommen bei {{APPLICATION_NAME}}!</h1>
+            <p style="margin: 0;">Danke, dass Du dich angemeldet hast – wir freuen uns, Dich dabei zu haben. Jetzt
+              fehlt nur noch eine Kleinigkeit, bevor wir gemeinsam die Welt verbessern können ... Bitte bestätige
+              Deine E-Mail Adresse in dem Du diesen Code in dem Anmeldeformular eingibst:</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding: 0 20px;">
+            <p style="text-align: center;"><span style="color: #17b53e; font-wight: bold; font-size: 18px">{{{ nonce }}}</span></p>
+          </td>
+        </tr>
+        <tr>
+          <td style="text-align: center; color :#17b53e">
+            <p>–––––––––––––––––––––––––––––––––––––––––––––––</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <!-- 1 Column Text + Button : END -->
+
+  <!-- 1 Column Text : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff; padding: 0 20px;">
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+        <tr>
+          <td style="padding: 20px; font-family: Lato, sans-serif; font-size: 16px; line-height: 22px; color: #555555;">
+            <p style="margin: 0; margin-top: 10px;">Falls Du Dich nicht selbst bei <a href="{{{ ORGANIZATION_URL }}}"
+                                                                                      style="color: #17b53e;">{{APPLICATION_NAME}}</a> angemeldet hast, schau doch mal vorbei!
+              Wir sind ein gemeinnütziges Aktionsnetzwerk – von Menschen für Menschen.</p>
+            <p style="margin: 0; margin-top: 10px;">PS: Wenn Du keinen Account bei uns möchtest, kannst Du diese
+              E-Mail einfach ignorieren. ;)</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="text-align: center; color :#17b53e">
+            <p>–––––––––––––––––––––––––––––––––––––––––––––––</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <!-- 1 Column Text : END -->
+
+  <!-- 1 Column Text : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff; padding: 0 20px;">
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+        <tr>
+          <td style="padding: 20px; font-family: Lato, sans-serif; font-size: 16px; line-height: 22px; color: #555555;">
+            <p style="margin: 0;">Melde Dich gerne <a href="{{{ supportUrl }}}" style="color: #17b53e;">bei
+                unserem Support Team</a>, wenn Du Fragen hast.</p>
+            <p style="margin: 0; margin-top: 10px;">Bis bald bei <a href="{{{ ORGANIZATION_URL }}}"
+                                                                    style="color: #17b53e;">{{APPLICATION_NAME}}</a>!</p>
+            <p style="margin: 0; margin-bottom: 10px;">– Dein {{APPLICATION_NAME}} Team</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="display: none;">
+            <p>–––––––––––––––––––––––––––––––––––––––––––––––</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <!-- 1 Column Text : END -->
+
+</table>
+<!-- Email Body German : END -->
+
+<!-- Email Body English : BEGIN -->
+<table class="email-english" align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%"
+  style="margin: auto;">
+  <tr>
+    <td style="padding: 20px 0; text-align: center">
+    </td>
+  </tr>
+
+  <!-- Hero Image, Flush : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff;">
+      <img
+        src="{{{ welcomeImageUrl }}}"
+        width="300" height="" alt="Welcome image" border="0"
+        style="width: 100%; max-width: 300px; height: auto; background: #ffffff; font-family: Lato, sans-serif; font-size: 16px; line-height: 15px; color: #555555; margin: auto; display: block; padding: 20px;"
+        class="g-img">
+    </td>
+  </tr>
+  <!-- Hero Image, Flush : END -->
+
+  <!-- 1 Column Text + Button : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff; padding: 0 20px;">
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+        <tr>
+          <td
+            style="padding: 20px; padding-top: 0; font-family: Lato, sans-serif; font-size: 16px; line-height: 22px; color: #555555;">
+            <h1
+              style="margin: 0 0 10px 0; font-family: Lato, sans-serif; font-size: 25px; line-height: 30px; color: #333333; font-weight: normal;">
+              Welcome to {{APPLICATION_NAME}}!</h1>
+            <p style="margin: 0;">Thank you for joining our cause – it's awesome to have you on board. There's
+              just one tiny step missing before we can start shaping the world together ... Please confirm your
+              e-mail address by entering this code in the registration form:</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding: 0 20px;">
+            <p style="text-align: center;"><span style="color: #17b53e; font-wight: bold; font-size: 18px">{{{ nonce }}}</span></p>
+          </td>
+        </tr>
+        <tr>
+          <td style="text-align: center; color :#17b53e">
+            <p>–––––––––––––––––––––––––––––––––––––––––––––––</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <!-- 1 Column Text + Button : END -->
+
+  <!-- 1 Column Text : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff; padding: 0 20px;">
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+        <tr>
+          <td style="padding: 20px; font-family: Lato, sans-serif; font-size: 16px; line-height: 22px; color: #555555;">
+            <p style="margin: 0; margin-top: 10px;">If you didn't sign up for <a href="{{{ ORGANIZATION_URL }}}"
+                                                                                 style="color: #17b53e;">{{APPLICATION_NAME}}</a> we recommend you to check it out!
+              It's a social network from people for people who want to connect and change the world together.</p>
+            <p style="margin: 0; margin-top: 10px;">PS: If you ignore this e-mail we will not create an account
+              for
+              you. ;)</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="text-align: center; color :#17b53e">
+            <p>–––––––––––––––––––––––––––––––––––––––––––––––</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <!-- 1 Column Text : END -->
+
+  <!-- 1 Column Text : BEGIN -->
+  <tr>
+    <td style="background-color: #ffffff; padding: 0 20px;">
+      <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+        <tr>
+          <td style="padding: 20px; font-family: Lato, sans-serif; font-size: 16px; line-height: 22px; color: #555555;">
+            <p style="margin: 0;">Feel free to <a href="{{{ supportUrl }}}" style="color: #17b53e;">contact our
+                support team</a> with any
+              questions you have.</p>
+            <p style="margin: 0; margin-top: 10px;">See you soon on <a href="{{{ ORGANIZATION_URL }}}"
+                                                                       style="color: #17b53e;">{{APPLICATION_NAME}}</a>!</p>
+            <p style="margin: 0; margin-bottom: 10px;">– The {{APPLICATION_NAME}} Team</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <!-- 1 Column Text : END -->
+
+</table>
+<!-- Email Body English : END -->


### PR DESCRIPTION
## 🍰 Pullrequest

A new template for the signup verification email when using an invite code. The Email looks like this:

![email_german](https://user-images.githubusercontent.com/15882241/113510369-e1a1ba80-955a-11eb-8890-a4e9748444ca.jpg)

This is the English version:

![email_english](https://user-images.githubusercontent.com/15882241/113510445-2594bf80-955b-11eb-8faa-600aa7cf4496.jpg)


### Issues
- fixes #4339
- fixes #4325
- relates #4332
