### PR TITLE
fix: [WIP] 🍰 'pages/registration.spec.js‘ Fix Internal Errors

### DIFF
--- a/webapp/pages/registration.spec.js
+++ b/webapp/pages/registration.spec.js
@@ -73,7 +73,7 @@ describe('Registration', () => {
     }
 
     it('renders', () => {
-      wrapper = Wrapper()
+      wrapper = await Wrapper()
       expect(wrapper.contains('div')).toBeTruthy()
     })
 

--- a/webapp/pages/registration.spec.js
+++ b/webapp/pages/registration.spec.js
@@ -72,7 +72,7 @@ describe('Registration', () => {
       })
     }
 
-    it('renders', () => {
+    it('renders', async () => {
       wrapper = await Wrapper()
       expect(wrapper.contains('div')).toBeTruthy()
     })

--- a/webapp/pages/registration.spec.js
+++ b/webapp/pages/registration.spec.js
@@ -72,6 +72,11 @@ describe('Registration', () => {
       })
     }
 
+    it('renders', () => {
+      wrapper = Wrapper()
+      expect(wrapper.contains('div')).toBe(true)
+    })
+
     describe('no "PUBLIC_REGISTRATION" and no "INVITE_REGISTRATION"', () => {
       beforeEach(() => {
         mocks.$env = {

--- a/webapp/pages/registration.spec.js
+++ b/webapp/pages/registration.spec.js
@@ -74,7 +74,7 @@ describe('Registration', () => {
 
     it('renders', () => {
       wrapper = Wrapper()
-      expect(wrapper.contains('div')).toBe(true)
+      expect(wrapper.contains('div')).toBeTruthy()
     })
 
     describe('no "PUBLIC_REGISTRATION" and no "INVITE_REGISTRATION"', () => {


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Just run new `renders` test and the errors are vanishing.

@Mogge says this has very likely something todo with `async` tests.
We need `await` to use in that tests.

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

- fixes #4365

### Todo
<!-- In case some parts are still missing, list them here. -->

- [X] None
