### PR TITLE
fix: 🍰 Fix Menu Legend Menu Bar Button Without Click Event

### DIFF
--- a/webapp/components/Editor/MenuBarButton.vue
+++ b/webapp/components/Editor/MenuBarButton.vue
@@ -10,7 +10,7 @@ export default {
     isActive: Boolean,
     icon: String,
     label: String,
-    onClick: Function,
+    onClick: { type: Function, default: () => {} },
   },
 }
 </script>


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Fix menu legend menu bar button without click event.

We have overseen a console warning in the browser and also by running the webapp tests:

<img width="1515" alt="Bildschirmfoto 2021-07-20 um 11 58 12" src="https://user-images.githubusercontent.com/25344101/126304987-626acd9d-ed99-4ef1-b3e5-67361ae396aa.png">


### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

- fixes #3673

### Todo
<!-- In case some parts are still missing, list them here. -->

- [X] None
