### PR TITLE
fix: 🍰 Replace Hashtag In d.tube Url

### DIFF
--- a/webapp/components/Editor/nodes/Hashtag.js
+++ b/webapp/components/Editor/nodes/Hashtag.js
@@ -8,7 +8,7 @@ export default class Hashtag extends TipTapMention {
   get defaultOptions() {
     return {
       matcher: {
-        char: '#',
+        char: '=',
         allowSpaces: false,
         startOfLine: false,
       },

--- a/webapp/components/Editor/nodes/Hashtag.js
+++ b/webapp/components/Editor/nodes/Hashtag.js
@@ -8,7 +8,7 @@ export default class Hashtag extends TipTapMention {
   get defaultOptions() {
     return {
       matcher: {
-        char: '=',
+        char: '#',
         allowSpaces: false,
         startOfLine: false,
       },

--- a/webapp/components/Editor/plugins/eventHandler.js
+++ b/webapp/components/Editor/plugins/eventHandler.js
@@ -11,7 +11,10 @@ export default class EventHandler extends Extension {
       new Plugin({
         props: {
           transformPastedText(text) {
-            // remove hashtag from d.tube url
+            /* remove hashtag from d.tube url
+             * hashtags in url general are not a problem because the following link work like expected: 
+             * http://www.nsosp.org/de/Quanten-Fluss-Theorie/index.php#OM:FrQFT:Home:Inhalt
+            */
             if ( text.search(/d.tube/) > 0) {
               text =  text.replace(/\/#!\//gim, '/') 
             }

--- a/webapp/components/Editor/plugins/eventHandler.js
+++ b/webapp/components/Editor/plugins/eventHandler.js
@@ -12,11 +12,11 @@ export default class EventHandler extends Extension {
         props: {
           transformPastedText(text) {
             /* remove hashtag from d.tube url
-             * hashtags in url general are not a problem because the following link work like expected: 
+             * hashtags in url general are not a problem because the following link work like expected:
              * http://www.nsosp.org/de/Quanten-Fluss-Theorie/index.php#OM:FrQFT:Home:Inhalt
-            */
-            if ( text.search(/d.tube/) > 0) {
-              text =  text.replace(/\/#!\//gim, '/') 
+             */
+            if (text.search(/d.tube/) > 0) {
+              text = text.replace(/\/#!\//gim, '/')
             }
             return text.trim()
           },

--- a/webapp/components/Editor/plugins/eventHandler.js
+++ b/webapp/components/Editor/plugins/eventHandler.js
@@ -11,6 +11,10 @@ export default class EventHandler extends Extension {
       new Plugin({
         props: {
           transformPastedText(text) {
+            // remove hashtag from d.tube url
+            if ( text.search(/d.tube/) > 0) {
+              text =  text.replace(/\/#!\//gim, '/') 
+            }
             return text.trim()
           },
           transformPastedHTML(html) {


### PR DESCRIPTION
## 🍰 Pullrequest
we use the oembed library, in the provider.json ... you can see what is used. 
I cannot say at this point whether this is current. 
As far as d.tube is concerned, nothing has changed. 
but in the url you can copy from the browser is a /#!/ 
this causes the problem. 
the only solution i found now is to remove this. 

but i don't think this is a good solution. it should happen in the provider.json ... but there we have some problem in the code ... 

the hashtag function is not the problem


### Issues
- fixes #4896 

note: 
if a link from facebook shows the message 'please log in', then the user from whom this source comes has set it that way. 
