### PR TITLE
chore: 🍰 Automatic Deployment To `stage.ocelot.social` On Push To `master` Branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -302,10 +302,10 @@ jobs:
           kubectl -n default rollout restart deployment/ocelot-neo4j
       - name: Verify deployment and wait for the pods of each deplyment to get ready for cleaning and seeding of the database
         run: |
-          kubectl -n default rollout status deployment/ocelot-backend --timeout=400s
-          kubectl -n default rollout status deployment/ocelot-neo4j --timeout=400s
-          kubectl -n default rollout status deployment/ocelot-maintenance --timeout=400s
-          kubectl -n default rollout status deployment/ocelot-webapp --timeout=400s
+          kubectl -n default rollout status deployment/ocelot-backend --timeout=600s
+          kubectl -n default rollout status deployment/ocelot-neo4j --timeout=600s
+          kubectl -n default rollout status deployment/ocelot-maintenance --timeout=600s
+          kubectl -n default rollout status deployment/ocelot-webapp --timeout=600s
       - name: Reset and seed Neo4j database via backend for staging
         # db cleaning and seeding is only possible in production if env 'PRODUCTION_DB_CLEAN_ALLOW=true' is set in deployment
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -309,8 +309,7 @@ jobs:
       - name: Reset and seed Neo4j database via backend for staging
         # db cleaning and seeding is only possible in production if env 'PRODUCTION_DB_CLEAN_ALLOW=true' is set in deployment
         run: |
-          kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/clean.js"
-          kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/seed.js"
+          kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node --experimental-repl-await dist/db/clean.js && node --experimental-repl-await dist/db/seed.js"
 
   ##############################################################################
   # JOB: GITHUB TAG LATEST VERSION #############################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -247,7 +247,7 @@ jobs:
         run: docker push --all-tags ocelotsocialnetwork/maintenance
 
   ##############################################################################
-  # JOB: KUBERNETES DEPLOY LATEST VERSION ######################################
+  # JOB: KUBERNETES DEPLOY ACTUAL/LATEST VERSION ######################################
   ##############################################################################
   kubernetes_deploy:
     # see example https://github.com/do-community/example-doctl-action
@@ -282,26 +282,35 @@ jobs:
       ##########################################################################
       # - name: Deploy 'latest' to DigitalOcean Kubernetes
       #   run: |
-      #     kubectl set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:latest
-      #     kubectl rollout restart deployment/ocelot-webapp
-      #     kubectl set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:latest
-      #     kubectl rollout restart deployment/ocelot-backend
-      #     kubectl set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:latest
-      #     kubectl rollout restart deployment/ocelot-backend
-      #     kubectl set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:latest
-      #     kubectl rollout restart deployment/ocelot-neo4j
+      #     kubectl -n default set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:latest
+      #     kubectl -n default rollout restart deployment/ocelot-webapp
+      #     kubectl -n default set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:latest
+      #     kubectl -n default rollout restart deployment/ocelot-backend
+      #     kubectl -n default set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:latest
+      #     kubectl -n default rollout restart deployment/ocelot-maintenance
+      #     kubectl -n default set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:latest
+      #     kubectl -n default rollout restart deployment/ocelot-neo4j
       - name: Deploy actual version '$BUILD_VERSION' to DigitalOcean Kubernetes
         run: |
-          kubectl set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:$BUILD_VERSION
-          kubectl set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:$BUILD_VERSION
-          kubectl set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:$BUILD_VERSION
-          kubectl set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:$BUILD_VERSION
-      # - name: Verify deployment
-      #   run: |
-      #     kubectl rollout status deployment/ocelot-webapp
-      #     kubectl rollout status deployment/ocelot-backend
-      #     kubectl rollout status deployment/ocelot-backend
-      #     kubectl rollout status deployment/ocelot-neo4j
+          kubectl -n default set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:$BUILD_VERSION
+          kubectl -n default rollout restart deployment/ocelot-webapp
+          kubectl -n default set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:$BUILD_VERSION
+          kubectl -n default rollout restart deployment/ocelot-backend
+          kubectl -n default set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:$BUILD_VERSION
+          kubectl -n default rollout restart deployment/ocelot-maintenance
+          kubectl -n default set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:$BUILD_VERSION
+          kubectl -n default rollout restart deployment/ocelot-neo4j
+      - name: Verify deployment
+        run: |
+          kubectl -n default rollout status deployment/ocelot-backend --timeout=240s
+          kubectl -n default rollout status deployment/ocelot-neo4j --timeout=240s
+          kubectl -n default rollout status deployment/ocelot-webapp --timeout=240s
+          kubectl -n default rollout status deployment/ocelot-maintenance --timeout=240s
+      - name: Reset and seed Neo4j database via backend for staging
+        # db cleaning is only possible if env 'PRODUCTION_DB_CLEAN_ALLOW=true' is set in deployment
+        run: |
+          kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/clean.js"
+          kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/seed.js"
 
   ##############################################################################
   # JOB: GITHUB TAG LATEST VERSION #############################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -247,6 +247,63 @@ jobs:
         run: docker push --all-tags ocelotsocialnetwork/maintenance
 
   ##############################################################################
+  # JOB: KUBERNETES DEPLOY LATEST VERSION ######################################
+  ##############################################################################
+  kubernetes_deploy:
+    # see example https://github.com/do-community/example-doctl-action
+    # see example https://github.com/do-community/example-doctl-action/blob/main/.github/workflows/workflow.yaml
+    name: Kubernetes deploy of latest version to stage.ocelot.social cluster at DigitalOcean
+    runs-on: ubuntu-latest
+    needs: [upload_to_dockerhub]
+    steps:
+      ##########################################################################
+      # CHECKOUT CODE ##########################################################
+      ##########################################################################
+      - name: Checkout code
+        uses: actions/checkout@v2
+      ##########################################################################
+      # SET ENVS ###############################################################
+      ##########################################################################
+      - name: ENV - VERSION
+        run: echo "VERSION=$(node -p -e "require('./package.json').version")" >> $GITHUB_ENV
+      - name: ENV - BUILD_VERSION
+        run: echo "BUILD_VERSION=${VERSION}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+      ##########################################################################
+      # Install DigitalOceans doctl and set kubeconfig #########################
+      ##########################################################################
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      - name: Save DigitalOcean kubeconfig with short-lived credentials
+        run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 cluster-stage-ocelot-social
+      ##########################################################################
+      # Deploy new Docker images to DigitalOcean Kubernetes cluster ############
+      ##########################################################################
+      # - name: Deploy 'latest' to DigitalOcean Kubernetes
+      #   run: |
+      #     kubectl set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:latest
+      #     kubectl rollout restart deployment/ocelot-webapp
+      #     kubectl set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:latest
+      #     kubectl rollout restart deployment/ocelot-backend
+      #     kubectl set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:latest
+      #     kubectl rollout restart deployment/ocelot-backend
+      #     kubectl set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:latest
+      #     kubectl rollout restart deployment/ocelot-neo4j
+      - name: Deploy actual version '$BUILD_VERSION' to DigitalOcean Kubernetes
+        run: |
+          kubectl set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:$BUILD_VERSION
+          kubectl set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:$BUILD_VERSION
+          kubectl set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:$BUILD_VERSION
+          kubectl set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:$BUILD_VERSION
+      # - name: Verify deployment
+      #   run: |
+      #     kubectl rollout status deployment/ocelot-webapp
+      #     kubectl rollout status deployment/ocelot-backend
+      #     kubectl rollout status deployment/ocelot-backend
+      #     kubectl rollout status deployment/ocelot-neo4j
+
+  ##############################################################################
   # JOB: GITHUB TAG LATEST VERSION #############################################
   ##############################################################################
   github_tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      # - 4451-new-deployment-with-base-and-code # for testing while developing
+      - 5065-automatic-deployment-to-stage.ocelot.social-on-push-to-master-branch # for testing while developing
 
 jobs:
   ##############################################################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -302,10 +302,10 @@ jobs:
           kubectl -n default rollout restart deployment/ocelot-neo4j
       - name: Verify deployment and wait for the pods of each deplyment to get ready for cleaning and seeding of the database
         run: |
-          kubectl -n default rollout status deployment/ocelot-webapp --timeout=240s
-          kubectl -n default rollout status deployment/ocelot-maintenance --timeout=240s
-          kubectl -n default rollout status deployment/ocelot-backend --timeout=240s
-          kubectl -n default rollout status deployment/ocelot-neo4j --timeout=240s
+          kubectl -n default rollout status deployment/ocelot-backend --timeout=400s
+          kubectl -n default rollout status deployment/ocelot-neo4j --timeout=400s
+          kubectl -n default rollout status deployment/ocelot-maintenance --timeout=400s
+          kubectl -n default rollout status deployment/ocelot-webapp --timeout=400s
       - name: Reset and seed Neo4j database via backend for staging
         # db cleaning and seeding is only possible in production if env 'PRODUCTION_DB_CLEAN_ALLOW=true' is set in deployment
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -300,14 +300,14 @@ jobs:
           kubectl -n default rollout restart deployment/ocelot-maintenance
           kubectl -n default set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:$BUILD_VERSION
           kubectl -n default rollout restart deployment/ocelot-neo4j
-      - name: Verify deployment
+      - name: Verify deployment and wait for the pods of each deplyment to get ready for cleaning and seeding of the database
         run: |
-          kubectl -n default rollout status deployment/ocelot-backend --timeout=240s
-          kubectl -n default rollout status deployment/ocelot-neo4j --timeout=240s
           kubectl -n default rollout status deployment/ocelot-webapp --timeout=240s
           kubectl -n default rollout status deployment/ocelot-maintenance --timeout=240s
+          kubectl -n default rollout status deployment/ocelot-backend --timeout=240s
+          kubectl -n default rollout status deployment/ocelot-neo4j --timeout=240s
       - name: Reset and seed Neo4j database via backend for staging
-        # db cleaning is only possible if env 'PRODUCTION_DB_CLEAN_ALLOW=true' is set in deployment
+        # db cleaning and seeding is only possible in production if env 'PRODUCTION_DB_CLEAN_ALLOW=true' is set in deployment
         run: |
           kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/clean.js"
           kubectl -n default exec -it $(kubectl -n default get pods | grep ocelot-backend | awk '{ print $1 }') -- /bin/sh -c "node dist/db/seed.js"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 5065-automatic-deployment-to-stage.ocelot.social-on-push-to-master-branch # for testing while developing
+      # - 5065-automatic-deployment-to-stage.ocelot.social-on-push-to-master-branch # for testing while developing
 
 jobs:
   ##############################################################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -304,8 +304,8 @@ jobs:
         run: |
           kubectl -n default rollout status deployment/ocelot-backend --timeout=600s
           kubectl -n default rollout status deployment/ocelot-neo4j --timeout=600s
-          kubectl -n default rollout status deployment/ocelot-maintenance --timeout=600s
-          kubectl -n default rollout status deployment/ocelot-webapp --timeout=600s
+        # kubectl -n default rollout status deployment/ocelot-maintenance --timeout=600s
+        # kubectl -n default rollout status deployment/ocelot-webapp --timeout=600s
       - name: Reset and seed Neo4j database via backend for staging
         # db cleaning and seeding is only possible in production if env 'PRODUCTION_DB_CLEAN_ALLOW=true' is set in deployment
         run: |

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -22,6 +22,8 @@ const environment = {
   DEBUG: env.NODE_ENV !== 'production' && env.DEBUG,
   TEST: env.NODE_ENV === 'test',
   PRODUCTION: env.NODE_ENV === 'production',
+  // used for staging enviroments if 'PRODUCTION=true' and 'PRODUCTION_DB_CLEAN_ALLOW=true'
+  PRODUCTION_DB_CLEAN_ALLOW: env.PRODUCTION_DB_CLEAN_ALLOW === 'true' || false, // default = false
   DISABLED_MIDDLEWARES: (env.NODE_ENV !== 'production' && env.DISABLED_MIDDLEWARES) || false,
 }
 

--- a/backend/src/db/clean.js
+++ b/backend/src/db/clean.js
@@ -2,7 +2,7 @@ import { cleanDatabase } from '../db/factories'
 import CONFIG from '../config'
 
 if (CONFIG.PRODUCTION && !CONFIG.PRODUCTION_DB_CLEAN_ALLOW) {
-  throw new Error(`You cannot clean the database in production environment!`)
+  throw new Error(`You cannot clean the database in a non-staging and real production environment!`)
 }
 
 ;(async function () {

--- a/backend/src/db/clean.js
+++ b/backend/src/db/clean.js
@@ -1,7 +1,7 @@
 import { cleanDatabase } from '../db/factories'
 import CONFIG from '../config'
 
-if (CONFIG.PRODUCTION) {
+if (CONFIG.PRODUCTION && !CONFIG.PRODUCTION_DB_CLEAN_ALLOW) {
   throw new Error(`You cannot clean the database in production environment!`)
 }
 

--- a/backend/src/db/clean.js
+++ b/backend/src/db/clean.js
@@ -1,5 +1,5 @@
-import { cleanDatabase } from '../db/factories'
 import CONFIG from '../config'
+import { cleanDatabase } from '../db/factories'
 
 if (CONFIG.PRODUCTION && !CONFIG.PRODUCTION_DB_CLEAN_ALLOW) {
   throw new Error(`You cannot clean the database in a non-staging and real production environment!`)

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -6,6 +6,10 @@ import Factory from '../db/factories'
 import { getNeode, getDriver } from '../db/neo4j'
 import { gql } from '../helpers/jest'
 
+if (CONFIG.PRODUCTION && !CONFIG.PRODUCTION_DB_CLEAN_ALLOW) {
+  throw new Error(`You cannot seed the database in a non-staging and real production environment!`)
+}
+
 const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
 
 /* eslint-disable no-multi-spaces */

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -1,5 +1,6 @@
 import sample from 'lodash/sample'
 import { createTestClient } from 'apollo-server-testing'
+import CONFIG from '../config'
 import createServer from '../server'
 import faker from '@faker-js/faker'
 import Factory from '../db/factories'


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Automatic deployment to `stage.ocelot.social` on push to (merge into) `master` branch.

See:

- https://docs.digitalocean.com/products/kubernetes/how-to/deploy-using-github-actions/
- https://docs.digitalocean.com/tutorials/build-and-deploy-your-first-image-to-your-first-cluster/
- especially:
    - see example https://github.com/do-community/example-doctl-action
    - see example https://github.com/do-community/example-doctl-action/blob/main/.github/workflows/workflow.yaml

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

- fixes #5065
- follow up #5093

### Todo

#### First Step

- [x] use `kubectl` or `doctl` to change the docker image in the deployments

Commands for `branded`:

```bash
kubectl -n default set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp-branded:latest
kubectl -n default set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend-branded:latest
kubectl -n default set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance-branded:latest
kubectl -n default set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community-branded:latest
```

Commands for not(!) `branded`:

```bash
kubectl -n default set image deployment/ocelot-webapp container-ocelot-webapp=ocelotsocialnetwork/webapp:latest
kubectl -n default set image deployment/ocelot-backend container-ocelot-backend=ocelotsocialnetwork/backend:latest
kubectl -n default set image deployment/ocelot-maintenance container-ocelot-maintenance=ocelotsocialnetwork/maintenance:latest
kubectl -n default set image deployment/ocelot-neo4j container-ocelot-neo4j=ocelotsocialnetwork/neo4j-community:latest
```

*If we really want to use the not changing tag `latest` then we need `kubectl rollout restart deployment/*` for all deployments of us in the cluster after setting the image!*

#### Then

- [x] add the change of the Docker image in the deployments of `stage.ocelot.social` to `publish.yaml`
  - [x] it looks like we should use explicit versions and avoid `latest` for production
    - if a pod restarts it may pull a wrong docker image that is to new
      - warnings against using `latest`:
        - see https://stackoverflow.com/questions/33112789/how-do-i-force-kubernetes-to-re-pull-an-image
- [x] weigh out `kubectl set image` against `kubectl patch`
  - [x] I go for `kubectl set image`
- [ ] using `helm` would be nice either, but the Helm scripts are in our other repository: [Ocelot-Social-Deploy-Rebranding](https://github.com/Ocelot-Social-Community/Ocelot-Social-Deploy-Rebranding)
  - [x] impossible yet

#### General

- [x] change back to publish on `master` branch push
- [ ] add release version, see #5094
- [x] set DigitalOcean access token in the repo
- [x] seed db
  - [x] add `PRODUCTION_DB_CLEAN_ALLOW` and set it correct for staging to `true`
  - [ ] add chrone job to seed db every night?
- [ ] add documentation to here or on deploy/rebrand how to change the image name and trigger an image pull on a Kubernetes cluster
- [x] fix `ocelotsocialnetwork/webapp:latest` and `ocelotsocialnetwork/backend:latest` on start in cluster, see https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/5065#issuecomment-1179732798
  - [x] !!! do this before this issue in a new issue
    - [x] create new issue #5066
- [x] rename maintenance container from `maintenance` to `container-ocelot-maintenance`?
  - if not yet create an issue
    - relates https://github.com/Ocelot-Social-Community/Ocelot-Social-Deploy-Rebranding/pull/46
- [x] clean up: search for `Wolle`