### PR TITLE
feat: [WIP] 🍰 Implement `JoinGroup`, `GroupMember`, `SwitchGroupMemberRole` Resolvers

### DIFF
--- a/backend/src/db/graphql/groups.js
+++ b/backend/src/db/graphql/groups.js
@@ -39,6 +39,17 @@ export const createGroupMutation = gql`
   }
 `
 
+export const enterGroupMutation = gql`
+  mutation ($id: ID!, $userId: ID!) {
+    EnterGroup(id: $id, userId: $userId) {
+      id
+      name
+      slug
+      myRoleInGroup
+    }
+  }
+`
+
 // ------ queries
 
 export const groupQuery = gql`
@@ -90,6 +101,17 @@ export const groupQuery = gql`
         name
         icon
       }
+    }
+  }
+`
+
+export const groupMemberQuery = gql`
+  query ($id: ID!, $first: Int, $offset: Int, $orderBy: [_UserOrdering], $filter: _UserFilter) {
+    GroupMember(id: $id, first: $first, offset: $offset, orderBy: $orderBy, filter: $filter) {
+      id
+      name
+      slug
+      myRoleInGroup
     }
   }
 `

--- a/backend/src/db/graphql/groups.js
+++ b/backend/src/db/graphql/groups.js
@@ -50,6 +50,17 @@ export const joinGroupMutation = gql`
   }
 `
 
+export const switchGroupMemberRoleMutation = gql`
+  mutation ($id: ID!, $userId: ID!, $roleInGroup: GroupMemberRole!) {
+    SwitchGroupMemberRole(id: $id, userId: $userId, roleInGroup: $roleInGroup) {
+      id
+      name
+      slug
+      myRoleInGroup
+    }
+  }
+`
+
 // ------ queries
 
 export const groupQuery = gql`

--- a/backend/src/db/graphql/groups.js
+++ b/backend/src/db/graphql/groups.js
@@ -39,9 +39,9 @@ export const createGroupMutation = gql`
   }
 `
 
-export const enterGroupMutation = gql`
+export const joinGroupMutation = gql`
   mutation ($id: ID!, $userId: ID!) {
-    EnterGroup(id: $id, userId: $userId) {
+    JoinGroup(id: $id, userId: $userId) {
       id
       name
       slug

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -5,7 +5,7 @@ import createServer from '../server'
 import faker from '@faker-js/faker'
 import Factory from '../db/factories'
 import { getNeode, getDriver } from '../db/neo4j'
-import { createGroupMutation } from './graphql/groups'
+import { createGroupMutation, enterGroupMutation } from './graphql/groups'
 import { createPostMutation } from './graphql/posts'
 import { createCommentMutation } from './graphql/comments'
 
@@ -400,6 +400,22 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         },
       }),
     ])
+    await Promise.all([
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u2',
+        },
+      }),
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u3',
+        },
+      }),
+    ])
 
     authenticatedUser = await jennyRostock.toJson()
     await Promise.all([
@@ -416,6 +432,36 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         },
       }),
     ])
+    await Promise.all([
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g1',
+          userId: 'u1',
+        },
+      }),
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g1',
+          userId: 'u5',
+        },
+      }),
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g1',
+          userId: 'u6',
+        },
+      }),
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g1',
+          userId: 'u7',
+        },
+      }),
+    ])
 
     authenticatedUser = await bobDerBaumeister.toJson()
     await Promise.all([
@@ -429,6 +475,36 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
           groupType: 'public',
           actionRadius: 'interplanetary',
           categoryIds: ['cat3', 'cat13', 'cat16'],
+        },
+      }),
+    ])
+    await Promise.all([
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g2',
+          userId: 'u4',
+        },
+      }),
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g2',
+          userId: 'u5',
+        },
+      }),
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g2',
+          userId: 'u6',
+        },
+      }),
+      mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'g2',
+          userId: 'u7',
         },
       }),
     ])

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -5,7 +5,7 @@ import createServer from '../server'
 import faker from '@faker-js/faker'
 import Factory from '../db/factories'
 import { getNeode, getDriver } from '../db/neo4j'
-import { createGroupMutation, enterGroupMutation } from './graphql/groups'
+import { createGroupMutation, joinGroupMutation } from './graphql/groups'
 import { createPostMutation } from './graphql/posts'
 import { createCommentMutation } from './graphql/comments'
 
@@ -402,14 +402,14 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
     ])
     await Promise.all([
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g0',
           userId: 'u2',
         },
       }),
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g0',
           userId: 'u3',
@@ -434,28 +434,28 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
     ])
     await Promise.all([
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g1',
           userId: 'u1',
         },
       }),
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g1',
           userId: 'u5',
         },
       }),
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g1',
           userId: 'u6',
         },
       }),
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g1',
           userId: 'u7',
@@ -480,28 +480,28 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
     ])
     await Promise.all([
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g2',
           userId: 'u4',
         },
       }),
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g2',
           userId: 'u5',
         },
       }),
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g2',
           userId: 'u6',
         },
       }),
       mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'g2',
           userId: 'u7',

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -5,7 +5,11 @@ import createServer from '../server'
 import faker from '@faker-js/faker'
 import Factory from '../db/factories'
 import { getNeode, getDriver } from '../db/neo4j'
-import { createGroupMutation, joinGroupMutation } from './graphql/groups'
+import {
+  createGroupMutation,
+  joinGroupMutation,
+  switchGroupMemberRoleMutation,
+} from './graphql/groups'
 import { createPostMutation } from './graphql/posts'
 import { createCommentMutation } from './graphql/comments'
 
@@ -415,6 +419,46 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
           userId: 'u3',
         },
       }),
+      mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u4',
+        },
+      }),
+      mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u6',
+        },
+      }),
+    ])
+    await Promise.all([
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u2',
+          roleInGroup: 'usual',
+        },
+      }),
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u4',
+          roleInGroup: 'admin',
+        },
+      }),
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u3',
+          roleInGroup: 'owner',
+        },
+      }),
     ])
 
     authenticatedUser = await jennyRostock.toJson()
@@ -444,6 +488,13 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         mutation: joinGroupMutation,
         variables: {
           id: 'g1',
+          userId: 'u2',
+        },
+      }),
+      mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'g1',
           userId: 'u5',
         },
       }),
@@ -459,6 +510,40 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         variables: {
           id: 'g1',
           userId: 'u7',
+        },
+      }),
+    ])
+    await Promise.all([
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u1',
+          roleInGroup: 'usual',
+        },
+      }),
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u2',
+          roleInGroup: 'usual',
+        },
+      }),
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u5',
+          roleInGroup: 'admin',
+        },
+      }),
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u6',
+          roleInGroup: 'owner',
         },
       }),
     ])
@@ -505,6 +590,32 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         variables: {
           id: 'g2',
           userId: 'u7',
+        },
+      }),
+    ])
+    await Promise.all([
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u4',
+          roleInGroup: 'usual',
+        },
+      }),
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u5',
+          roleInGroup: 'usual',
+        },
+      }),
+      mutate({
+        mutation: switchGroupMemberRoleMutation,
+        variables: {
+          id: 'g0',
+          userId: 'u6',
+          roleInGroup: 'usual',
         },
       }),
     ])

--- a/backend/src/helpers/jest.js
+++ b/backend/src/helpers/jest.js
@@ -10,6 +10,7 @@ export function gql(strings) {
 
 // sometime we have to wait to check a db state by having a look into the db in a certain moment
 // or we wait a bit to check if we missed to set an await somewhere
+// see: https://www.sitepoint.com/delay-sleep-pause-wait/
 export function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/backend/src/helpers/jest.js
+++ b/backend/src/helpers/jest.js
@@ -7,3 +7,11 @@
 export function gql(strings) {
   return strings.join('')
 }
+
+// sometime we have to wait to check a db state by having a look into the db in a certain moment
+// or we wait a bit to check if we missed to set an await somewhere
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+// usage – 4 seconds for example
+// await sleep(4 * 1000)

--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -55,6 +55,7 @@ const isMySocialMedia = rule({
 const isAllowedSeeingMembersOfGroup = rule({
   cache: 'no_cache',
 })(async (_parent, args, { user, driver }) => {
+  // Wolle: may have a look to 'isAuthenticated'
   if (!user) return false
   const { id: groupId } = args
   // Wolle: console.log('groupId: ', groupId)
@@ -96,6 +97,7 @@ const isAllowedSeeingMembersOfGroup = rule({
 const isAllowedToSwitchGroupMemberRole = rule({
   cache: 'no_cache',
 })(async (_parent, args, { user, driver }) => {
+  // Wolle: may have a look to 'isAuthenticated'
   if (!user) return false
   const adminId = user.id
   const { id: groupId, userId, roleInGroup } = args

--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -152,6 +152,7 @@ const isAllowedToSwitchGroupMemberRole = rule({
       !!admin &&
       !!member &&
       adminId !== userId &&
+      // Wolle: member.myRoleInGroup === roleInGroup &&
       ((['admin'].includes(admin.myRoleInGroup) &&
         !['owner'].includes(member.myRoleInGroup) &&
         ['pending', 'usual', 'admin'].includes(roleInGroup)) ||

--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -62,9 +62,9 @@ const isAllowSeeingMembersOfGroup = rule({
     const transactionResponse = await transaction.run(
       `
         MATCH (group:Group {id: $groupId})
-        OPTIONAL MATCH (admin {id:User $userId})-[membership:MEMBER_OF]->(group)
+        OPTIONAL MATCH (admin:User {id: $userId})-[membership:MEMBER_OF]->(group)
         WHERE membership.role IN ['admin', 'owner']
-        RETURN group, admin
+        RETURN group, admin {.*, myRoleInGroup: membership.role}
       `,
       { groupId, userId: user.id },
     )
@@ -174,6 +174,7 @@ export default shield(
       SignupVerification: allow,
       UpdateUser: onlyYourself,
       CreateGroup: isAuthenticated,
+      EnterGroup: isAuthenticated,
       CreatePost: isAuthenticated,
       UpdatePost: isAuthor,
       DeletePost: isAuthor,

--- a/backend/src/schema/resolvers/groups.js
+++ b/backend/src/schema/resolvers/groups.js
@@ -48,15 +48,15 @@ export default {
     },
     GroupMember: async (_object, params, context, _resolveInfo) => {
       const { id: groupId } = params
+      // Wolle: console.log('groupId: ', groupId)
       const session = context.driver.session()
       const readTxResultPromise = session.readTransaction(async (txc) => {
         const groupMemberCypher = `
-          MATCH (user:User {id: $userId})-[membership:MEMBER_OF]->(:Group {id: $groupId})
+          MATCH (user:User)-[membership:MEMBER_OF]->(:Group {id: $groupId})
           RETURN user {.*, myRoleInGroup: membership.role}
         `
         const result = await txc.run(groupMemberCypher, {
           groupId,
-          userId: context.user.id,
         })
         return result.records.map((record) => record.get('user'))
       })

--- a/backend/src/schema/resolvers/groups.js
+++ b/backend/src/schema/resolvers/groups.js
@@ -131,11 +131,11 @@ export default {
         session.close()
       }
     },
-    EnterGroup: async (_parent, params, context, _resolveInfo) => {
+    JoinGroup: async (_parent, params, context, _resolveInfo) => {
       const { id: groupId, userId } = params
       const session = context.driver.session()
       const writeTxResultPromise = session.writeTransaction(async (transaction) => {
-        const enterGroupCypher = `
+        const joinGroupCypher = `
           MATCH (member:User {id: $userId}), (group:Group {id: $groupId})
           MERGE (member)-[membership:MEMBER_OF]->(group)
           ON CREATE SET
@@ -148,7 +148,7 @@ export default {
                 END
           RETURN member {.*, myRoleInGroup: membership.role}
         `
-        const result = await transaction.run(enterGroupCypher, { groupId, userId })
+        const result = await transaction.run(joinGroupCypher, { groupId, userId })
         const [member] = await result.records.map((record) => record.get('member'))
         return member
       })

--- a/backend/src/schema/resolvers/groups.spec.js
+++ b/backend/src/schema/resolvers/groups.spec.js
@@ -343,6 +343,7 @@ describe('JoinGroup', () => {
     let ownerOfHiddenGroupUser
 
     beforeEach(async () => {
+      // create users
       ownerOfClosedGroupUser = await Factory.build(
         'user',
         {
@@ -365,6 +366,8 @@ describe('JoinGroup', () => {
           password: '1234',
         },
       )
+      // create groups
+      // public-group
       authenticatedUser = await ownerOfClosedGroupUser.toJson()
       await mutate({
         mutation: createGroupMutation,
@@ -634,6 +637,7 @@ describe('SwitchGroupMemberRole', () => {
             },
           )
           // create groups
+          // public-group
           authenticatedUser = await usualMemberUser.toJson()
           await mutate({
             mutation: createGroupMutation,
@@ -647,35 +651,6 @@ describe('SwitchGroupMemberRole', () => {
               categoryIds,
             },
           })
-          authenticatedUser = await ownerMemberUser.toJson()
-          await mutate({
-            mutation: createGroupMutation,
-            variables: {
-              id: 'closed-group',
-              name: 'Uninteresting Group',
-              about: 'We will change nothing!',
-              description: 'We love it like it is!?' + descriptionAdditional100,
-              groupType: 'closed',
-              actionRadius: 'national',
-              categoryIds,
-            },
-          })
-          authenticatedUser = await adminMemberUser.toJson()
-          await mutate({
-            mutation: createGroupMutation,
-            variables: {
-              id: 'hidden-group',
-              name: 'Investigative Journalism Group',
-              about: 'We will change all.',
-              description: 'We research …' + descriptionAdditional100,
-              groupType: 'hidden',
-              actionRadius: 'global',
-              categoryIds,
-            },
-          })
-          // create additional memberships
-          // public-group
-          authenticatedUser = await usualMemberUser.toJson()
           await mutate({
             mutation: joinGroupMutation,
             variables: {
@@ -692,6 +667,18 @@ describe('SwitchGroupMemberRole', () => {
           })
           // closed-group
           authenticatedUser = await ownerMemberUser.toJson()
+          await mutate({
+            mutation: createGroupMutation,
+            variables: {
+              id: 'closed-group',
+              name: 'Uninteresting Group',
+              about: 'We will change nothing!',
+              description: 'We love it like it is!?' + descriptionAdditional100,
+              groupType: 'closed',
+              actionRadius: 'national',
+              categoryIds,
+            },
+          })
           await mutate({
             mutation: joinGroupMutation,
             variables: {
@@ -716,6 +703,18 @@ describe('SwitchGroupMemberRole', () => {
           // hidden-group
           authenticatedUser = await adminMemberUser.toJson()
           await mutate({
+            mutation: createGroupMutation,
+            variables: {
+              id: 'hidden-group',
+              name: 'Investigative Journalism Group',
+              about: 'We will change all.',
+              description: 'We research …' + descriptionAdditional100,
+              groupType: 'hidden',
+              actionRadius: 'global',
+              categoryIds,
+            },
+          })
+          await mutate({
             mutation: joinGroupMutation,
             variables: {
               id: 'hidden-group',
@@ -729,6 +728,7 @@ describe('SwitchGroupMemberRole', () => {
               userId: 'second-owner-member-user',
             },
           })
+
           // Wolle
           // function sleep(ms) {
           //   return new Promise(resolve => setTimeout(resolve, ms));
@@ -940,6 +940,7 @@ describe('GroupMember', () => {
         },
       )
       // create groups
+      // public-group
       authenticatedUser = await user.toJson()
       await mutate({
         mutation: createGroupMutation,
@@ -953,34 +954,6 @@ describe('GroupMember', () => {
           categoryIds,
         },
       })
-      authenticatedUser = await ownerOfClosedGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'closed-group',
-          name: 'Uninteresting Group',
-          about: 'We will change nothing!',
-          description: 'We love it like it is!?' + descriptionAdditional100,
-          groupType: 'closed',
-          actionRadius: 'national',
-          categoryIds,
-        },
-      })
-      authenticatedUser = await ownerOfHiddenGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'hidden-group',
-          name: 'Investigative Journalism Group',
-          about: 'We will change all.',
-          description: 'We research …' + descriptionAdditional100,
-          groupType: 'hidden',
-          actionRadius: 'global',
-          categoryIds,
-        },
-      })
-      // create additional memberships
-      // public-group
       await mutate({
         mutation: joinGroupMutation,
         variables: {
@@ -996,6 +969,19 @@ describe('GroupMember', () => {
         },
       })
       // closed-group
+      authenticatedUser = await ownerOfClosedGroupUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'closed-group',
+          name: 'Uninteresting Group',
+          about: 'We will change nothing!',
+          description: 'We love it like it is!?' + descriptionAdditional100,
+          groupType: 'closed',
+          actionRadius: 'national',
+          categoryIds,
+        },
+      })
       await mutate({
         mutation: joinGroupMutation,
         variables: {
@@ -1011,6 +997,19 @@ describe('GroupMember', () => {
         },
       })
       // hidden-group
+      authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          name: 'Investigative Journalism Group',
+          about: 'We will change all.',
+          description: 'We research …' + descriptionAdditional100,
+          groupType: 'hidden',
+          actionRadius: 'global',
+          categoryIds,
+        },
+      })
       await mutate({
         mutation: joinGroupMutation,
         variables: {

--- a/backend/src/schema/resolvers/groups.spec.js
+++ b/backend/src/schema/resolvers/groups.spec.js
@@ -940,6 +940,19 @@ describe('GroupMember', () => {
         },
       )
       // create groups
+      authenticatedUser = await user.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'public-group',
+          name: 'The Best Group',
+          about: 'We will change the world!',
+          description: 'Some description' + descriptionAdditional100,
+          groupType: 'public',
+          actionRadius: 'regional',
+          categoryIds,
+        },
+      })
       authenticatedUser = await ownerOfClosedGroupUser.toJson()
       await mutate({
         mutation: createGroupMutation,
@@ -966,20 +979,8 @@ describe('GroupMember', () => {
           categoryIds,
         },
       })
-      authenticatedUser = await user.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'public-group',
-          name: 'The Best Group',
-          about: 'We will change the world!',
-          description: 'Some description' + descriptionAdditional100,
-          groupType: 'public',
-          actionRadius: 'regional',
-          categoryIds,
-        },
-      })
       // create additional memberships
+      // public-group
       await mutate({
         mutation: joinGroupMutation,
         variables: {
@@ -994,6 +995,7 @@ describe('GroupMember', () => {
           userId: 'owner-of-hidden-group',
         },
       })
+      // closed-group
       await mutate({
         mutation: joinGroupMutation,
         variables: {
@@ -1004,10 +1006,27 @@ describe('GroupMember', () => {
       await mutate({
         mutation: joinGroupMutation,
         variables: {
+          id: 'closed-group',
+          userId: 'owner-of-hidden-group',
+        },
+      })
+      // hidden-group
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          userId: 'current-user',
+        },
+      })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
           id: 'hidden-group',
           userId: 'owner-of-closed-group',
         },
       })
+
+      authenticatedUser = await user.toJson()
     })
 
     describe('public group', () => {
@@ -1147,6 +1166,10 @@ describe('GroupMember', () => {
                     id: 'owner-of-closed-group',
                     myRoleInGroup: 'owner',
                   }),
+                  expect.objectContaining({
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'pending',
+                  }),
                 ]),
               },
               errors: undefined,
@@ -1156,13 +1179,21 @@ describe('GroupMember', () => {
               variables,
             })
             expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(2)
+            expect(result.data.GroupMember.length).toBe(3)
           })
         })
 
-        // needs 'SwitchGroupMemberRole'
-        describe.skip('by usual member "owner-of-hidden-group"', () => {
+        describe('by usual member "owner-of-hidden-group"', () => {
           beforeEach(async () => {
+            authenticatedUser = await ownerOfClosedGroupUser.toJson()
+            await mutate({
+              mutation: switchGroupMemberRoleMutation,
+              variables: {
+                id: 'closed-group',
+                userId: 'owner-of-hidden-group',
+                roleInGroup: 'usual',
+              },
+            })
             authenticatedUser = await ownerOfHiddenGroupUser.toJson()
           })
 
@@ -1237,6 +1268,10 @@ describe('GroupMember', () => {
               data: {
                 GroupMember: expect.arrayContaining([
                   expect.objectContaining({
+                    id: 'current-user',
+                    myRoleInGroup: 'pending',
+                  }),
+                  expect.objectContaining({
                     id: 'owner-of-closed-group',
                     myRoleInGroup: 'pending',
                   }),
@@ -1253,13 +1288,21 @@ describe('GroupMember', () => {
               variables,
             })
             expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(2)
+            expect(result.data.GroupMember.length).toBe(3)
           })
         })
 
-        // needs 'SwitchGroupMemberRole'
-        describe.skip('by usual member "owner-of-closed-group"', () => {
+        describe('by usual member "owner-of-closed-group"', () => {
           beforeEach(async () => {
+            authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+            await mutate({
+              mutation: switchGroupMemberRoleMutation,
+              variables: {
+                id: 'hidden-group',
+                userId: 'owner-of-closed-group',
+                roleInGroup: 'usual',
+              },
+            })
             authenticatedUser = await ownerOfClosedGroupUser.toJson()
           })
 

--- a/backend/src/schema/resolvers/groups.spec.js
+++ b/backend/src/schema/resolvers/groups.spec.js
@@ -14,8 +14,6 @@ import CONFIG from '../../config'
 const driver = getDriver()
 const neode = getNeode()
 
-let isCleanDbAfterEach = true
-let isSeedDb = true
 let authenticatedUser
 let user
 
@@ -36,6 +34,48 @@ const { server } = createServer({
 const { query } = createTestClient(server)
 const { mutate } = createTestClient(server)
 
+const seedBasicsAndClearAuthentication = async () => {
+  variables = {}
+  user = await Factory.build(
+    'user',
+    {
+      id: 'current-user',
+      name: 'TestUser',
+    },
+    {
+      email: 'test@example.org',
+      password: '1234',
+    },
+  )
+  await Promise.all([
+    neode.create('Category', {
+      id: 'cat9',
+      name: 'Democracy & Politics',
+      slug: 'democracy-politics',
+      icon: 'university',
+    }),
+    neode.create('Category', {
+      id: 'cat4',
+      name: 'Environment & Nature',
+      slug: 'environment-nature',
+      icon: 'tree',
+    }),
+    neode.create('Category', {
+      id: 'cat15',
+      name: 'Consumption & Sustainability',
+      slug: 'consumption-sustainability',
+      icon: 'shopping-cart',
+    }),
+    neode.create('Category', {
+      id: 'cat27',
+      name: 'Animal Protection',
+      slug: 'animal-protection',
+      icon: 'paw',
+    }),
+  ])
+  authenticatedUser = null
+}
+
 beforeAll(async () => {
   await cleanDatabase()
 })
@@ -44,357 +84,1038 @@ afterAll(async () => {
   await cleanDatabase()
 })
 
-beforeEach(async () => {
-  // Wolle: find a better solution
-  if (isSeedDb) {
-    variables = {}
-    user = await Factory.build(
-      'user',
-      {
-        id: 'current-user',
-        name: 'TestUser',
-      },
-      {
-        email: 'test@example.org',
-        password: '1234',
-      },
-    )
-    await Promise.all([
-      neode.create('Category', {
-        id: 'cat9',
-        name: 'Democracy & Politics',
-        slug: 'democracy-politics',
-        icon: 'university',
-      }),
-      neode.create('Category', {
-        id: 'cat4',
-        name: 'Environment & Nature',
-        slug: 'environment-nature',
-        icon: 'tree',
-      }),
-      neode.create('Category', {
-        id: 'cat15',
-        name: 'Consumption & Sustainability',
-        slug: 'consumption-sustainability',
-        icon: 'shopping-cart',
-      }),
-      neode.create('Category', {
-        id: 'cat27',
-        name: 'Animal Protection',
-        slug: 'animal-protection',
-        icon: 'paw',
-      }),
-    ])
-    authenticatedUser = null
-  }
-})
+describe('in mode: always clean db', () => {
+  beforeEach(async () => {
+    await seedBasicsAndClearAuthentication()
+  })
 
-// TODO: avoid database clean after each test in the future if possible for performance and flakyness reasons by filling the database step by step, see issue https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/4543
-afterEach(async () => {
-  if (isCleanDbAfterEach) {
+  // TODO: avoid database clean after each test in the future if possible for performance and flakyness reasons by filling the database step by step, see issue https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/4543
+  afterEach(async () => {
     await cleanDatabase()
-  }
-})
-
-describe('CreateGroup', () => {
-  beforeEach(() => {
-    variables = {
-      ...variables,
-      id: 'g589',
-      name: 'The Best Group',
-      slug: 'the-group',
-      about: 'We will change the world!',
-      description: 'Some description' + descriptionAdditional100,
-      groupType: 'public',
-      actionRadius: 'regional',
-      categoryIds,
-    }
   })
 
-  describe('unauthenticated', () => {
-    it('throws authorization error', async () => {
-      const { errors } = await mutate({ mutation: createGroupMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('authenticated', () => {
-    beforeEach(async () => {
-      authenticatedUser = await user.toJson()
-    })
-
-    it('creates a group', async () => {
-      const expected = {
-        data: {
-          CreateGroup: {
-            name: 'The Best Group',
-            slug: 'the-group',
-            about: 'We will change the world!',
-          },
-        },
-        errors: undefined,
+  describe('CreateGroup', () => {
+    beforeEach(() => {
+      variables = {
+        ...variables,
+        id: 'g589',
+        name: 'The Best Group',
+        slug: 'the-group',
+        about: 'We will change the world!',
+        description: 'Some description' + descriptionAdditional100,
+        groupType: 'public',
+        actionRadius: 'regional',
+        categoryIds,
       }
-      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
     })
 
-    it('assigns the authenticated user as owner', async () => {
-      const expected = {
-        data: {
-          CreateGroup: {
-            name: 'The Best Group',
-            myRole: 'owner',
+    describe('unauthenticated', () => {
+      it('throws authorization error', async () => {
+        const { errors } = await mutate({ mutation: createGroupMutation, variables })
+        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      })
+    })
+
+    describe('authenticated', () => {
+      beforeEach(async () => {
+        authenticatedUser = await user.toJson()
+      })
+
+      it('creates a group', async () => {
+        const expected = {
+          data: {
+            CreateGroup: {
+              name: 'The Best Group',
+              slug: 'the-group',
+              about: 'We will change the world!',
+            },
           },
-        },
-        errors: undefined,
-      }
-      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
-    })
+          errors: undefined,
+        }
+        await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
+          expected,
+        )
+      })
 
-    it('has "disabled" and "deleted" default to "false"', async () => {
-      const expected = { data: { CreateGroup: { disabled: false, deleted: false } } }
-      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
-    })
+      it('assigns the authenticated user as owner', async () => {
+        const expected = {
+          data: {
+            CreateGroup: {
+              name: 'The Best Group',
+              myRole: 'owner',
+            },
+          },
+          errors: undefined,
+        }
+        await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
+          expected,
+        )
+      })
 
-    describe('description', () => {
-      describe('length without HTML', () => {
-        describe('less then 100 chars', () => {
+      it('has "disabled" and "deleted" default to "false"', async () => {
+        const expected = { data: { CreateGroup: { disabled: false, deleted: false } } }
+        await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
+          expected,
+        )
+      })
+
+      describe('description', () => {
+        describe('length without HTML', () => {
+          describe('less then 100 chars', () => {
+            it('throws error: "Too view categories!"', async () => {
+              const { errors } = await mutate({
+                mutation: createGroupMutation,
+                variables: {
+                  ...variables,
+                  description:
+                    '0123456789' +
+                    '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0123456789</a>',
+                },
+              })
+              expect(errors[0]).toHaveProperty('message', 'Description too short!')
+            })
+          })
+        })
+      })
+
+      describe('categories', () => {
+        beforeEach(() => {
+          CONFIG.CATEGORIES_ACTIVE = true
+        })
+
+        describe('not even one', () => {
           it('throws error: "Too view categories!"', async () => {
             const { errors } = await mutate({
               mutation: createGroupMutation,
-              variables: {
-                ...variables,
-                description:
-                  '0123456789' +
-                  '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0123456789</a>',
-              },
+              variables: { ...variables, categoryIds: null },
             })
-            expect(errors[0]).toHaveProperty('message', 'Description too short!')
+            expect(errors[0]).toHaveProperty('message', 'Too view categories!')
           })
         })
-      })
-    })
 
-    describe('categories', () => {
-      beforeEach(() => {
-        CONFIG.CATEGORIES_ACTIVE = true
-      })
-
-      describe('not even one', () => {
-        it('throws error: "Too view categories!"', async () => {
-          const { errors } = await mutate({
-            mutation: createGroupMutation,
-            variables: { ...variables, categoryIds: null },
+        describe('four', () => {
+          it('throws error: "Too many categories!"', async () => {
+            const { errors } = await mutate({
+              mutation: createGroupMutation,
+              variables: { ...variables, categoryIds: ['cat9', 'cat4', 'cat15', 'cat27'] },
+            })
+            expect(errors[0]).toHaveProperty('message', 'Too many categories!')
           })
-          expect(errors[0]).toHaveProperty('message', 'Too view categories!')
-        })
-      })
-
-      describe('four', () => {
-        it('throws error: "Too many categories!"', async () => {
-          const { errors } = await mutate({
-            mutation: createGroupMutation,
-            variables: { ...variables, categoryIds: ['cat9', 'cat4', 'cat15', 'cat27'] },
-          })
-          expect(errors[0]).toHaveProperty('message', 'Too many categories!')
         })
       })
     })
   })
-})
 
-describe('Group', () => {
-  describe('unauthenticated', () => {
-    it('throws authorization error', async () => {
-      const { errors } = await query({ query: groupQuery, variables: {} })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('authenticated', () => {
-    let otherUser
-
-    beforeEach(async () => {
-      otherUser = await Factory.build(
-        'user',
-        {
-          id: 'other-user',
-          name: 'Other TestUser',
-        },
-        {
-          email: 'test2@example.org',
-          password: '1234',
-        },
-      )
-      authenticatedUser = await otherUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'others-group',
-          name: 'Uninteresting Group',
-          about: 'We will change nothing!',
-          description: 'We love it like it is!?' + descriptionAdditional100,
-          groupType: 'closed',
-          actionRadius: 'global',
-          categoryIds,
-        },
-      })
-      authenticatedUser = await user.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'my-group',
-          name: 'The Best Group',
-          about: 'We will change the world!',
-          description: 'Some description' + descriptionAdditional100,
-          groupType: 'public',
-          actionRadius: 'regional',
-          categoryIds,
-        },
+  describe('Group', () => {
+    describe('unauthenticated', () => {
+      it('throws authorization error', async () => {
+        const { errors } = await query({ query: groupQuery, variables: {} })
+        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
       })
     })
 
-    describe('query groups', () => {
-      describe('without any filters', () => {
-        it('finds all groups', async () => {
-          const expected = {
-            data: {
-              Group: expect.arrayContaining([
-                expect.objectContaining({
-                  id: 'my-group',
-                  slug: 'the-best-group',
-                  myRole: 'owner',
-                }),
-                expect.objectContaining({
-                  id: 'others-group',
-                  slug: 'uninteresting-group',
-                  myRole: null,
-                }),
-              ]),
-            },
-            errors: undefined,
-          }
-          await expect(query({ query: groupQuery, variables: {} })).resolves.toMatchObject(expected)
+    describe('authenticated', () => {
+      let otherUser
+
+      beforeEach(async () => {
+        otherUser = await Factory.build(
+          'user',
+          {
+            id: 'other-user',
+            name: 'Other TestUser',
+          },
+          {
+            email: 'test2@example.org',
+            password: '1234',
+          },
+        )
+        authenticatedUser = await otherUser.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'others-group',
+            name: 'Uninteresting Group',
+            about: 'We will change nothing!',
+            description: 'We love it like it is!?' + descriptionAdditional100,
+            groupType: 'closed',
+            actionRadius: 'global',
+            categoryIds,
+          },
+        })
+        authenticatedUser = await user.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'my-group',
+            name: 'The Best Group',
+            about: 'We will change the world!',
+            description: 'Some description' + descriptionAdditional100,
+            groupType: 'public',
+            actionRadius: 'regional',
+            categoryIds,
+          },
         })
       })
 
-      describe('isMember = true', () => {
-        it('finds only groups where user is member', async () => {
-          const expected = {
-            data: {
-              Group: [
-                {
-                  id: 'my-group',
-                  slug: 'the-best-group',
-                  myRole: 'owner',
+      describe('query groups', () => {
+        describe('without any filters', () => {
+          it('finds all groups', async () => {
+            const expected = {
+              data: {
+                Group: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'my-group',
+                    slug: 'the-best-group',
+                    myRole: 'owner',
+                  }),
+                  expect.objectContaining({
+                    id: 'others-group',
+                    slug: 'uninteresting-group',
+                    myRole: null,
+                  }),
+                ]),
+              },
+              errors: undefined,
+            }
+            await expect(query({ query: groupQuery, variables: {} })).resolves.toMatchObject(
+              expected,
+            )
+          })
+        })
+
+        describe('isMember = true', () => {
+          it('finds only groups where user is member', async () => {
+            const expected = {
+              data: {
+                Group: [
+                  {
+                    id: 'my-group',
+                    slug: 'the-best-group',
+                    myRole: 'owner',
+                  },
+                ],
+              },
+              errors: undefined,
+            }
+            await expect(
+              query({ query: groupQuery, variables: { isMember: true } }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+
+        describe('isMember = false', () => {
+          it('finds only groups where user is not(!) member', async () => {
+            const expected = {
+              data: {
+                Group: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'others-group',
+                    slug: 'uninteresting-group',
+                    myRole: null,
+                  }),
+                ]),
+              },
+              errors: undefined,
+            }
+            await expect(
+              query({ query: groupQuery, variables: { isMember: false } }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+      })
+    })
+  })
+
+  describe('JoinGroup', () => {
+    describe('unauthenticated', () => {
+      it('throws authorization error', async () => {
+        variables = {
+          id: 'not-existing-group',
+          userId: 'current-user',
+        }
+        const { errors } = await mutate({ mutation: joinGroupMutation, variables })
+        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      })
+    })
+
+    describe('authenticated', () => {
+      let ownerOfClosedGroupUser
+      let ownerOfHiddenGroupUser
+
+      beforeEach(async () => {
+        // create users
+        ownerOfClosedGroupUser = await Factory.build(
+          'user',
+          {
+            id: 'owner-of-closed-group',
+            name: 'Owner Of Closed Group',
+          },
+          {
+            email: 'owner-of-closed-group@example.org',
+            password: '1234',
+          },
+        )
+        ownerOfHiddenGroupUser = await Factory.build(
+          'user',
+          {
+            id: 'owner-of-hidden-group',
+            name: 'Owner Of Hidden Group',
+          },
+          {
+            email: 'owner-of-hidden-group@example.org',
+            password: '1234',
+          },
+        )
+        // create groups
+        // public-group
+        authenticatedUser = await ownerOfClosedGroupUser.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'closed-group',
+            name: 'Uninteresting Group',
+            about: 'We will change nothing!',
+            description: 'We love it like it is!?' + descriptionAdditional100,
+            groupType: 'closed',
+            actionRadius: 'national',
+            categoryIds,
+          },
+        })
+        authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'hidden-group',
+            name: 'Investigative Journalism Group',
+            about: 'We will change all.',
+            description: 'We research …' + descriptionAdditional100,
+            groupType: 'hidden',
+            actionRadius: 'global',
+            categoryIds,
+          },
+        })
+        authenticatedUser = await user.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'public-group',
+            name: 'The Best Group',
+            about: 'We will change the world!',
+            description: 'Some description' + descriptionAdditional100,
+            groupType: 'public',
+            actionRadius: 'regional',
+            categoryIds,
+          },
+        })
+      })
+
+      describe('public group', () => {
+        describe('entered by "owner-of-closed-group"', () => {
+          it('has "usual" as membership role', async () => {
+            variables = {
+              id: 'public-group',
+              userId: 'owner-of-closed-group',
+            }
+            const expected = {
+              data: {
+                JoinGroup: {
+                  id: 'owner-of-closed-group',
+                  myRoleInGroup: 'usual',
                 },
-              ],
-            },
-            errors: undefined,
-          }
-          await expect(
-            query({ query: groupQuery, variables: { isMember: true } }),
-          ).resolves.toMatchObject(expected)
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: joinGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+
+        describe('entered by its owner', () => {
+          describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+            it('has still "owner" as membership role', async () => {
+              variables = {
+                id: 'public-group',
+                userId: 'current-user',
+              }
+              const expected = {
+                data: {
+                  JoinGroup: {
+                    id: 'current-user',
+                    myRoleInGroup: 'owner',
+                  },
+                },
+                errors: undefined,
+              }
+              await expect(
+                mutate({
+                  mutation: joinGroupMutation,
+                  variables,
+                }),
+              ).resolves.toMatchObject(expected)
+            })
+          })
         })
       })
 
-      describe('isMember = false', () => {
-        it('finds only groups where user is not(!) member', async () => {
-          const expected = {
-            data: {
-              Group: expect.arrayContaining([
-                expect.objectContaining({
-                  id: 'others-group',
-                  slug: 'uninteresting-group',
-                  myRole: null,
+      describe('closed group', () => {
+        describe('entered by "current-user"', () => {
+          it('has "pending" as membership role', async () => {
+            variables = {
+              id: 'closed-group',
+              userId: 'current-user',
+            }
+            const expected = {
+              data: {
+                JoinGroup: {
+                  id: 'current-user',
+                  myRoleInGroup: 'pending',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: joinGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+
+        describe('entered by its owner', () => {
+          describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+            it('has still "owner" as membership role', async () => {
+              variables = {
+                id: 'closed-group',
+                userId: 'owner-of-closed-group',
+              }
+              const expected = {
+                data: {
+                  JoinGroup: {
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'owner',
+                  },
+                },
+                errors: undefined,
+              }
+              await expect(
+                mutate({
+                  mutation: joinGroupMutation,
+                  variables,
                 }),
-              ]),
-            },
-            errors: undefined,
+              ).resolves.toMatchObject(expected)
+            })
+          })
+        })
+      })
+
+      describe('hidden group', () => {
+        describe('entered by "owner-of-closed-group"', () => {
+          it('has "pending" as membership role', async () => {
+            variables = {
+              id: 'hidden-group',
+              userId: 'owner-of-closed-group',
+            }
+            const expected = {
+              data: {
+                JoinGroup: {
+                  id: 'owner-of-closed-group',
+                  myRoleInGroup: 'pending',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: joinGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+
+        describe('entered by its owner', () => {
+          describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+            it('has still "owner" as membership role', async () => {
+              variables = {
+                id: 'hidden-group',
+                userId: 'owner-of-hidden-group',
+              }
+              const expected = {
+                data: {
+                  JoinGroup: {
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'owner',
+                  },
+                },
+                errors: undefined,
+              }
+              await expect(
+                mutate({
+                  mutation: joinGroupMutation,
+                  variables,
+                }),
+              ).resolves.toMatchObject(expected)
+            })
+          })
+        })
+      })
+    })
+  })
+
+  describe('GroupMember', () => {
+    describe('unauthenticated', () => {
+      it('throws authorization error', async () => {
+        variables = {
+          id: 'not-existing-group',
+        }
+        const { errors } = await query({ query: groupMemberQuery, variables })
+        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      })
+    })
+
+    describe('authenticated', () => {
+      let otherUser
+      let ownerOfClosedGroupUser
+      let ownerOfHiddenGroupUser
+
+      beforeEach(async () => {
+        // create users
+        otherUser = await Factory.build(
+          'user',
+          {
+            id: 'other-user',
+            name: 'Other TestUser',
+          },
+          {
+            email: 'test2@example.org',
+            password: '1234',
+          },
+        )
+        ownerOfClosedGroupUser = await Factory.build(
+          'user',
+          {
+            id: 'owner-of-closed-group',
+            name: 'Owner Of Closed Group',
+          },
+          {
+            email: 'owner-of-closed-group@example.org',
+            password: '1234',
+          },
+        )
+        ownerOfHiddenGroupUser = await Factory.build(
+          'user',
+          {
+            id: 'owner-of-hidden-group',
+            name: 'Owner Of Hidden Group',
+          },
+          {
+            email: 'owner-of-hidden-group@example.org',
+            password: '1234',
+          },
+        )
+        // create groups
+        // public-group
+        authenticatedUser = await user.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'public-group',
+            name: 'The Best Group',
+            about: 'We will change the world!',
+            description: 'Some description' + descriptionAdditional100,
+            groupType: 'public',
+            actionRadius: 'regional',
+            categoryIds,
+          },
+        })
+        await mutate({
+          mutation: joinGroupMutation,
+          variables: {
+            id: 'public-group',
+            userId: 'owner-of-closed-group',
+          },
+        })
+        await mutate({
+          mutation: joinGroupMutation,
+          variables: {
+            id: 'public-group',
+            userId: 'owner-of-hidden-group',
+          },
+        })
+        // closed-group
+        authenticatedUser = await ownerOfClosedGroupUser.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'closed-group',
+            name: 'Uninteresting Group',
+            about: 'We will change nothing!',
+            description: 'We love it like it is!?' + descriptionAdditional100,
+            groupType: 'closed',
+            actionRadius: 'national',
+            categoryIds,
+          },
+        })
+        await mutate({
+          mutation: joinGroupMutation,
+          variables: {
+            id: 'closed-group',
+            userId: 'current-user',
+          },
+        })
+        await mutate({
+          mutation: joinGroupMutation,
+          variables: {
+            id: 'closed-group',
+            userId: 'owner-of-hidden-group',
+          },
+        })
+        // hidden-group
+        authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+        await mutate({
+          mutation: createGroupMutation,
+          variables: {
+            id: 'hidden-group',
+            name: 'Investigative Journalism Group',
+            about: 'We will change all.',
+            description: 'We research …' + descriptionAdditional100,
+            groupType: 'hidden',
+            actionRadius: 'global',
+            categoryIds,
+          },
+        })
+        await mutate({
+          mutation: joinGroupMutation,
+          variables: {
+            id: 'hidden-group',
+            userId: 'current-user',
+          },
+        })
+        await mutate({
+          mutation: joinGroupMutation,
+          variables: {
+            id: 'hidden-group',
+            userId: 'owner-of-closed-group',
+          },
+        })
+
+        authenticatedUser = await user.toJson()
+      })
+
+      describe('public group', () => {
+        beforeEach(async () => {
+          variables = {
+            id: 'public-group',
           }
-          await expect(
-            query({ query: groupQuery, variables: { isMember: false } }),
-          ).resolves.toMatchObject(expected)
+        })
+
+        describe('query group members', () => {
+          describe('by owner "current-user"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await user.toJson()
+            })
+
+            it('finds all members', async () => {
+              const expected = {
+                data: {
+                  GroupMember: expect.arrayContaining([
+                    expect.objectContaining({
+                      id: 'current-user',
+                      myRoleInGroup: 'owner',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-closed-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-hidden-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                  ]),
+                },
+                errors: undefined,
+              }
+              const result = await mutate({
+                mutation: groupMemberQuery,
+                variables,
+              })
+              expect(result).toMatchObject(expected)
+              expect(result.data.GroupMember.length).toBe(3)
+            })
+          })
+
+          describe('by usual member "owner-of-closed-group"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await ownerOfClosedGroupUser.toJson()
+            })
+
+            it('finds all members', async () => {
+              const expected = {
+                data: {
+                  GroupMember: expect.arrayContaining([
+                    expect.objectContaining({
+                      id: 'current-user',
+                      myRoleInGroup: 'owner',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-closed-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-hidden-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                  ]),
+                },
+                errors: undefined,
+              }
+              const result = await mutate({
+                mutation: groupMemberQuery,
+                variables,
+              })
+              expect(result).toMatchObject(expected)
+              expect(result.data.GroupMember.length).toBe(3)
+            })
+          })
+
+          describe('by none member "other-user"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await otherUser.toJson()
+            })
+
+            it('finds all members', async () => {
+              const expected = {
+                data: {
+                  GroupMember: expect.arrayContaining([
+                    expect.objectContaining({
+                      id: 'current-user',
+                      myRoleInGroup: 'owner',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-closed-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-hidden-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                  ]),
+                },
+                errors: undefined,
+              }
+              const result = await mutate({
+                mutation: groupMemberQuery,
+                variables,
+              })
+              expect(result).toMatchObject(expected)
+              expect(result.data.GroupMember.length).toBe(3)
+            })
+          })
+        })
+      })
+
+      describe('closed group', () => {
+        beforeEach(async () => {
+          variables = {
+            id: 'closed-group',
+          }
+        })
+
+        describe('query group members', () => {
+          describe('by owner "owner-of-closed-group"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await ownerOfClosedGroupUser.toJson()
+            })
+
+            it('finds all members', async () => {
+              const expected = {
+                data: {
+                  GroupMember: expect.arrayContaining([
+                    expect.objectContaining({
+                      id: 'current-user',
+                      myRoleInGroup: 'pending',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-closed-group',
+                      myRoleInGroup: 'owner',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-hidden-group',
+                      myRoleInGroup: 'pending',
+                    }),
+                  ]),
+                },
+                errors: undefined,
+              }
+              const result = await mutate({
+                mutation: groupMemberQuery,
+                variables,
+              })
+              expect(result).toMatchObject(expected)
+              expect(result.data.GroupMember.length).toBe(3)
+            })
+          })
+
+          describe('by usual member "owner-of-hidden-group"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await ownerOfClosedGroupUser.toJson()
+              await mutate({
+                mutation: switchGroupMemberRoleMutation,
+                variables: {
+                  id: 'closed-group',
+                  userId: 'owner-of-hidden-group',
+                  roleInGroup: 'usual',
+                },
+              })
+              authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+            })
+
+            it('finds all members', async () => {
+              const expected = {
+                data: {
+                  GroupMember: expect.arrayContaining([
+                    expect.objectContaining({
+                      id: 'current-user',
+                      myRoleInGroup: 'pending',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-closed-group',
+                      myRoleInGroup: 'owner',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-hidden-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                  ]),
+                },
+                errors: undefined,
+              }
+              const result = await mutate({
+                mutation: groupMemberQuery,
+                variables,
+              })
+              expect(result).toMatchObject(expected)
+              expect(result.data.GroupMember.length).toBe(3)
+            })
+          })
+
+          describe('by pending member "current-user"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await user.toJson()
+            })
+
+            it('throws authorization error', async () => {
+              const { errors } = await query({ query: groupMemberQuery, variables })
+              expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+            })
+          })
+
+          describe('by none member "other-user"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await otherUser.toJson()
+            })
+
+            it('throws authorization error', async () => {
+              const { errors } = await query({ query: groupMemberQuery, variables })
+              expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+            })
+          })
+        })
+      })
+
+      describe('hidden group', () => {
+        beforeEach(async () => {
+          variables = {
+            id: 'hidden-group',
+          }
+        })
+
+        describe('query group members', () => {
+          describe('by owner "owner-of-hidden-group"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+            })
+
+            it('finds all members', async () => {
+              const expected = {
+                data: {
+                  GroupMember: expect.arrayContaining([
+                    expect.objectContaining({
+                      id: 'current-user',
+                      myRoleInGroup: 'pending',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-closed-group',
+                      myRoleInGroup: 'pending',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-hidden-group',
+                      myRoleInGroup: 'owner',
+                    }),
+                  ]),
+                },
+                errors: undefined,
+              }
+              const result = await mutate({
+                mutation: groupMemberQuery,
+                variables,
+              })
+              expect(result).toMatchObject(expected)
+              expect(result.data.GroupMember.length).toBe(3)
+            })
+          })
+
+          describe('by usual member "owner-of-closed-group"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+              await mutate({
+                mutation: switchGroupMemberRoleMutation,
+                variables: {
+                  id: 'hidden-group',
+                  userId: 'owner-of-closed-group',
+                  roleInGroup: 'usual',
+                },
+              })
+              authenticatedUser = await ownerOfClosedGroupUser.toJson()
+            })
+
+            it('finds all members', async () => {
+              const expected = {
+                data: {
+                  GroupMember: expect.arrayContaining([
+                    expect.objectContaining({
+                      id: 'current-user',
+                      myRoleInGroup: 'pending',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-closed-group',
+                      myRoleInGroup: 'usual',
+                    }),
+                    expect.objectContaining({
+                      id: 'owner-of-hidden-group',
+                      myRoleInGroup: 'owner',
+                    }),
+                  ]),
+                },
+                errors: undefined,
+              }
+              const result = await mutate({
+                mutation: groupMemberQuery,
+                variables,
+              })
+              expect(result).toMatchObject(expected)
+              expect(result.data.GroupMember.length).toBe(3)
+            })
+          })
+
+          describe('by pending member "current-user"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await user.toJson()
+            })
+
+            it('throws authorization error', async () => {
+              const { errors } = await query({ query: groupMemberQuery, variables })
+              expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+            })
+          })
+
+          describe('by none member "other-user"', () => {
+            beforeEach(async () => {
+              authenticatedUser = await otherUser.toJson()
+            })
+
+            it('throws authorization error', async () => {
+              const { errors } = await query({ query: groupMemberQuery, variables })
+              expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+            })
+          })
         })
       })
     })
   })
 })
 
-describe('JoinGroup', () => {
-  describe('unauthenticated', () => {
-    it('throws authorization error', async () => {
-      variables = {
-        id: 'not-existing-group',
-        userId: 'current-user',
-      }
-      const { errors } = await mutate({ mutation: joinGroupMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
+describe('in mode: building up', () => {
+  beforeAll(async () => {
+    await seedBasicsAndClearAuthentication()
   })
 
-  describe('authenticated', () => {
-    let ownerOfClosedGroupUser
-    let ownerOfHiddenGroupUser
+  afterAll(async () => {
+    await cleanDatabase()
+  })
 
-    beforeEach(async () => {
+  describe('SwitchGroupMemberRole', () => {
+    let pendingMemberUser
+    let usualMemberUser
+    let adminMemberUser
+    let ownerMemberUser
+    let secondOwnerMemberUser
+
+    beforeAll(async () => {
       // create users
-      ownerOfClosedGroupUser = await Factory.build(
+      pendingMemberUser = await Factory.build(
         'user',
         {
-          id: 'owner-of-closed-group',
-          name: 'Owner Of Closed Group',
+          id: 'pending-member-user',
+          name: 'Pending Member TestUser',
         },
         {
-          email: 'owner-of-closed-group@example.org',
+          email: 'pending-member-user@example.org',
           password: '1234',
         },
       )
-      ownerOfHiddenGroupUser = await Factory.build(
+      usualMemberUser = await Factory.build(
         'user',
         {
-          id: 'owner-of-hidden-group',
-          name: 'Owner Of Hidden Group',
+          id: 'usual-member-user',
+          name: 'Usual Member TestUser',
         },
         {
-          email: 'owner-of-hidden-group@example.org',
+          email: 'usual-member-user@example.org',
+          password: '1234',
+        },
+      )
+      adminMemberUser = await Factory.build(
+        'user',
+        {
+          id: 'admin-member-user',
+          name: 'Admin Member TestUser',
+        },
+        {
+          email: 'admin-member-user@example.org',
+          password: '1234',
+        },
+      )
+      ownerMemberUser = await Factory.build(
+        'user',
+        {
+          id: 'owner-member-user',
+          name: 'Owner Member TestUser',
+        },
+        {
+          email: 'owner-member-user@example.org',
+          password: '1234',
+        },
+      )
+      secondOwnerMemberUser = await Factory.build(
+        'user',
+        {
+          id: 'second-owner-member-user',
+          name: 'Second Owner Member TestUser',
+        },
+        {
+          email: 'second-owner-member-user@example.org',
           password: '1234',
         },
       )
       // create groups
       // public-group
-      authenticatedUser = await ownerOfClosedGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'closed-group',
-          name: 'Uninteresting Group',
-          about: 'We will change nothing!',
-          description: 'We love it like it is!?' + descriptionAdditional100,
-          groupType: 'closed',
-          actionRadius: 'national',
-          categoryIds,
-        },
-      })
-      authenticatedUser = await ownerOfHiddenGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'hidden-group',
-          name: 'Investigative Journalism Group',
-          about: 'We will change all.',
-          description: 'We research …' + descriptionAdditional100,
-          groupType: 'hidden',
-          actionRadius: 'global',
-          categoryIds,
-        },
-      })
-      authenticatedUser = await user.toJson()
+      authenticatedUser = await usualMemberUser.toJson()
       await mutate({
         mutation: createGroupMutation,
         variables: {
@@ -407,362 +1128,105 @@ describe('JoinGroup', () => {
           categoryIds,
         },
       })
-    })
-
-    describe('public group', () => {
-      describe('entered by "owner-of-closed-group"', () => {
-        it('has "usual" as membership role', async () => {
-          variables = {
-            id: 'public-group',
-            userId: 'owner-of-closed-group',
-          }
-          const expected = {
-            data: {
-              JoinGroup: {
-                id: 'owner-of-closed-group',
-                myRoleInGroup: 'usual',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: joinGroupMutation,
-              variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'public-group',
+          userId: 'owner-of-closed-group',
+        },
       })
-
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'public-group',
-              userId: 'current-user',
-            }
-            const expected = {
-              data: {
-                JoinGroup: {
-                  id: 'current-user',
-                  myRoleInGroup: 'owner',
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({
-                mutation: joinGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
-          })
-        })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'public-group',
+          userId: 'owner-of-hidden-group',
+        },
       })
-    })
-
-    describe('closed group', () => {
-      describe('entered by "current-user"', () => {
-        it('has "pending" as membership role', async () => {
-          variables = {
-            id: 'closed-group',
-            userId: 'current-user',
-          }
-          const expected = {
-            data: {
-              JoinGroup: {
-                id: 'current-user',
-                myRoleInGroup: 'pending',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: joinGroupMutation,
-              variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
+      // closed-group
+      authenticatedUser = await ownerMemberUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'closed-group',
+          name: 'Uninteresting Group',
+          about: 'We will change nothing!',
+          description: 'We love it like it is!?' + descriptionAdditional100,
+          groupType: 'closed',
+          actionRadius: 'national',
+          categoryIds,
+        },
       })
-
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'closed-group',
-              userId: 'owner-of-closed-group',
-            }
-            const expected = {
-              data: {
-                JoinGroup: {
-                  id: 'owner-of-closed-group',
-                  myRoleInGroup: 'owner',
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({
-                mutation: joinGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
-          })
-        })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'closed-group',
+          userId: 'pending-member-user',
+        },
+      })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'closed-group',
+          userId: 'usual-member-user',
+        },
+      })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'closed-group',
+          userId: 'admin-member-user',
+        },
+      })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'closed-group',
+          userId: 'second-owner-member-user',
+        },
+      })
+      // hidden-group
+      authenticatedUser = await adminMemberUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          name: 'Investigative Journalism Group',
+          about: 'We will change all.',
+          description: 'We research …' + descriptionAdditional100,
+          groupType: 'hidden',
+          actionRadius: 'global',
+          categoryIds,
+        },
+      })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          userId: 'admin-member-user',
+        },
+      })
+      await mutate({
+        mutation: joinGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          userId: 'second-owner-member-user',
+        },
       })
     })
 
-    describe('hidden group', () => {
-      describe('entered by "owner-of-closed-group"', () => {
-        it('has "pending" as membership role', async () => {
-          variables = {
-            id: 'hidden-group',
-            userId: 'owner-of-closed-group',
-          }
-          const expected = {
-            data: {
-              JoinGroup: {
-                id: 'owner-of-closed-group',
-                myRoleInGroup: 'pending',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: joinGroupMutation,
-              variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
-      })
-
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'hidden-group',
-              userId: 'owner-of-hidden-group',
-            }
-            const expected = {
-              data: {
-                JoinGroup: {
-                  id: 'owner-of-hidden-group',
-                  myRoleInGroup: 'owner',
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({
-                mutation: joinGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
-          })
-        })
-      })
-    })
-  })
-})
-
-describe('SwitchGroupMemberRole', () => {
-  describe('unauthenticated', () => {
-    it('throws authorization error', async () => {
-      variables = {
-        id: 'not-existing-group',
-        userId: 'current-user',
-        roleInGroup: 'pending',
-      }
-      const { errors } = await mutate({ mutation: switchGroupMemberRoleMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('authenticated', () => {
-    describe('in building up mode', () => {
-      let pendingMemberUser
-      let usualMemberUser
-      let adminMemberUser
-      let ownerMemberUser
-      let secondOwnerMemberUser
-
-      beforeEach(async () => {
-        // Wolle: change this to beforeAll?
-        if (isSeedDb) {
-          // create users
-          pendingMemberUser = await Factory.build(
-            'user',
-            {
-              id: 'pending-member-user',
-              name: 'Pending Member TestUser',
-            },
-            {
-              email: 'pending-member-user@example.org',
-              password: '1234',
-            },
-          )
-          usualMemberUser = await Factory.build(
-            'user',
-            {
-              id: 'usual-member-user',
-              name: 'Usual Member TestUser',
-            },
-            {
-              email: 'usual-member-user@example.org',
-              password: '1234',
-            },
-          )
-          adminMemberUser = await Factory.build(
-            'user',
-            {
-              id: 'admin-member-user',
-              name: 'Admin Member TestUser',
-            },
-            {
-              email: 'admin-member-user@example.org',
-              password: '1234',
-            },
-          )
-          ownerMemberUser = await Factory.build(
-            'user',
-            {
-              id: 'owner-member-user',
-              name: 'Owner Member TestUser',
-            },
-            {
-              email: 'owner-member-user@example.org',
-              password: '1234',
-            },
-          )
-          secondOwnerMemberUser = await Factory.build(
-            'user',
-            {
-              id: 'second-owner-member-user',
-              name: 'Second Owner Member TestUser',
-            },
-            {
-              email: 'second-owner-member-user@example.org',
-              password: '1234',
-            },
-          )
-          // create groups
-          // public-group
-          authenticatedUser = await usualMemberUser.toJson()
-          await mutate({
-            mutation: createGroupMutation,
-            variables: {
-              id: 'public-group',
-              name: 'The Best Group',
-              about: 'We will change the world!',
-              description: 'Some description' + descriptionAdditional100,
-              groupType: 'public',
-              actionRadius: 'regional',
-              categoryIds,
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'public-group',
-              userId: 'owner-of-closed-group',
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'public-group',
-              userId: 'owner-of-hidden-group',
-            },
-          })
-          // closed-group
-          authenticatedUser = await ownerMemberUser.toJson()
-          await mutate({
-            mutation: createGroupMutation,
-            variables: {
-              id: 'closed-group',
-              name: 'Uninteresting Group',
-              about: 'We will change nothing!',
-              description: 'We love it like it is!?' + descriptionAdditional100,
-              groupType: 'closed',
-              actionRadius: 'national',
-              categoryIds,
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'closed-group',
-              userId: 'pending-member-user',
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'closed-group',
-              userId: 'usual-member-user',
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'closed-group',
-              userId: 'admin-member-user',
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'closed-group',
-              userId: 'second-owner-member-user',
-            },
-          })
-          // hidden-group
-          authenticatedUser = await adminMemberUser.toJson()
-          await mutate({
-            mutation: createGroupMutation,
-            variables: {
-              id: 'hidden-group',
-              name: 'Investigative Journalism Group',
-              about: 'We will change all.',
-              description: 'We research …' + descriptionAdditional100,
-              groupType: 'hidden',
-              actionRadius: 'global',
-              categoryIds,
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'hidden-group',
-              userId: 'admin-member-user',
-            },
-          })
-          await mutate({
-            mutation: joinGroupMutation,
-            variables: {
-              id: 'hidden-group',
-              userId: 'second-owner-member-user',
-            },
-          })
-
-          // Wolle
-          // function sleep(ms) {
-          //   return new Promise(resolve => setTimeout(resolve, ms));
-          // }
-          // await sleep(4 * 1000)
-          isCleanDbAfterEach = false
-          isSeedDb = false
+    describe('unauthenticated', () => {
+      it('throws authorization error', async () => {
+        variables = {
+          id: 'not-existing-group',
+          userId: 'current-user',
+          roleInGroup: 'pending',
         }
+        const { errors } = await mutate({ mutation: switchGroupMemberRoleMutation, variables })
+        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
       })
-      afterAll(async () => {
-        // Wolle: find a better solution
-        await cleanDatabase()
-        isCleanDbAfterEach = true
-        isSeedDb = true
-      })
+    })
 
+    describe('authenticated', () => {
       describe('in all group types – here "closed-group" for example', () => {
         beforeEach(async () => {
           variables = {
@@ -890,16 +1354,6 @@ describe('SwitchGroupMemberRole', () => {
                       variables,
                     }),
                   ).resolves.toMatchObject(expected)
-                  // Wolle:
-                  // const groups = await query({ query: groupQuery, variables: {} })
-                  // console.log('groups.data.Group: ', groups.data.Group)
-                  // const groupMemberOfClosedGroup = await mutate({
-                  //   mutation: groupMemberQuery,
-                  //   variables: {
-                  //     id: 'closed-group',
-                  //   },
-                  // })
-                  // console.log('groupMemberOfClosedGroup.data.GroupMember: ', groupMemberOfClosedGroup.data.GroupMember)
                 })
               })
             })
@@ -1584,478 +2038,6 @@ describe('SwitchGroupMemberRole', () => {
                 })
               })
             })
-          })
-        })
-      })
-    })
-  })
-})
-
-describe('GroupMember', () => {
-  describe('unauthenticated', () => {
-    it('throws authorization error', async () => {
-      variables = {
-        id: 'not-existing-group',
-      }
-      const { errors } = await query({ query: groupMemberQuery, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('authenticated', () => {
-    let otherUser
-    let ownerOfClosedGroupUser
-    let ownerOfHiddenGroupUser
-
-    beforeEach(async () => {
-      // create users
-      otherUser = await Factory.build(
-        'user',
-        {
-          id: 'other-user',
-          name: 'Other TestUser',
-        },
-        {
-          email: 'test2@example.org',
-          password: '1234',
-        },
-      )
-      ownerOfClosedGroupUser = await Factory.build(
-        'user',
-        {
-          id: 'owner-of-closed-group',
-          name: 'Owner Of Closed Group',
-        },
-        {
-          email: 'owner-of-closed-group@example.org',
-          password: '1234',
-        },
-      )
-      ownerOfHiddenGroupUser = await Factory.build(
-        'user',
-        {
-          id: 'owner-of-hidden-group',
-          name: 'Owner Of Hidden Group',
-        },
-        {
-          email: 'owner-of-hidden-group@example.org',
-          password: '1234',
-        },
-      )
-      // create groups
-      // public-group
-      authenticatedUser = await user.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'public-group',
-          name: 'The Best Group',
-          about: 'We will change the world!',
-          description: 'Some description' + descriptionAdditional100,
-          groupType: 'public',
-          actionRadius: 'regional',
-          categoryIds,
-        },
-      })
-      await mutate({
-        mutation: joinGroupMutation,
-        variables: {
-          id: 'public-group',
-          userId: 'owner-of-closed-group',
-        },
-      })
-      await mutate({
-        mutation: joinGroupMutation,
-        variables: {
-          id: 'public-group',
-          userId: 'owner-of-hidden-group',
-        },
-      })
-      // closed-group
-      authenticatedUser = await ownerOfClosedGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'closed-group',
-          name: 'Uninteresting Group',
-          about: 'We will change nothing!',
-          description: 'We love it like it is!?' + descriptionAdditional100,
-          groupType: 'closed',
-          actionRadius: 'national',
-          categoryIds,
-        },
-      })
-      await mutate({
-        mutation: joinGroupMutation,
-        variables: {
-          id: 'closed-group',
-          userId: 'current-user',
-        },
-      })
-      await mutate({
-        mutation: joinGroupMutation,
-        variables: {
-          id: 'closed-group',
-          userId: 'owner-of-hidden-group',
-        },
-      })
-      // hidden-group
-      authenticatedUser = await ownerOfHiddenGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'hidden-group',
-          name: 'Investigative Journalism Group',
-          about: 'We will change all.',
-          description: 'We research …' + descriptionAdditional100,
-          groupType: 'hidden',
-          actionRadius: 'global',
-          categoryIds,
-        },
-      })
-      await mutate({
-        mutation: joinGroupMutation,
-        variables: {
-          id: 'hidden-group',
-          userId: 'current-user',
-        },
-      })
-      await mutate({
-        mutation: joinGroupMutation,
-        variables: {
-          id: 'hidden-group',
-          userId: 'owner-of-closed-group',
-        },
-      })
-
-      authenticatedUser = await user.toJson()
-    })
-
-    describe('public group', () => {
-      beforeEach(async () => {
-        variables = {
-          id: 'public-group',
-        }
-      })
-
-      describe('query group members', () => {
-        describe('by owner "current-user"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await user.toJson()
-          })
-
-          it('finds all members', async () => {
-            const expected = {
-              data: {
-                GroupMember: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: 'current-user',
-                    myRoleInGroup: 'owner',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-closed-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-hidden-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                ]),
-              },
-              errors: undefined,
-            }
-            const result = await mutate({
-              mutation: groupMemberQuery,
-              variables,
-            })
-            expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(3)
-          })
-        })
-
-        describe('by usual member "owner-of-closed-group"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await ownerOfClosedGroupUser.toJson()
-          })
-
-          it('finds all members', async () => {
-            const expected = {
-              data: {
-                GroupMember: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: 'current-user',
-                    myRoleInGroup: 'owner',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-closed-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-hidden-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                ]),
-              },
-              errors: undefined,
-            }
-            const result = await mutate({
-              mutation: groupMemberQuery,
-              variables,
-            })
-            expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(3)
-          })
-        })
-
-        describe('by none member "other-user"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await otherUser.toJson()
-          })
-
-          it('finds all members', async () => {
-            const expected = {
-              data: {
-                GroupMember: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: 'current-user',
-                    myRoleInGroup: 'owner',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-closed-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-hidden-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                ]),
-              },
-              errors: undefined,
-            }
-            const result = await mutate({
-              mutation: groupMemberQuery,
-              variables,
-            })
-            expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(3)
-          })
-        })
-      })
-    })
-
-    describe('closed group', () => {
-      beforeEach(async () => {
-        variables = {
-          id: 'closed-group',
-        }
-      })
-
-      describe('query group members', () => {
-        describe('by owner "owner-of-closed-group"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await ownerOfClosedGroupUser.toJson()
-          })
-
-          it('finds all members', async () => {
-            const expected = {
-              data: {
-                GroupMember: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: 'current-user',
-                    myRoleInGroup: 'pending',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-closed-group',
-                    myRoleInGroup: 'owner',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-hidden-group',
-                    myRoleInGroup: 'pending',
-                  }),
-                ]),
-              },
-              errors: undefined,
-            }
-            const result = await mutate({
-              mutation: groupMemberQuery,
-              variables,
-            })
-            expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(3)
-          })
-        })
-
-        describe('by usual member "owner-of-hidden-group"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await ownerOfClosedGroupUser.toJson()
-            await mutate({
-              mutation: switchGroupMemberRoleMutation,
-              variables: {
-                id: 'closed-group',
-                userId: 'owner-of-hidden-group',
-                roleInGroup: 'usual',
-              },
-            })
-            authenticatedUser = await ownerOfHiddenGroupUser.toJson()
-          })
-
-          it('finds all members', async () => {
-            const expected = {
-              data: {
-                GroupMember: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: 'current-user',
-                    myRoleInGroup: 'pending',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-closed-group',
-                    myRoleInGroup: 'owner',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-hidden-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                ]),
-              },
-              errors: undefined,
-            }
-            const result = await mutate({
-              mutation: groupMemberQuery,
-              variables,
-            })
-            expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(3)
-          })
-        })
-
-        describe('by pending member "current-user"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await user.toJson()
-          })
-
-          it('throws authorization error', async () => {
-            const { errors } = await query({ query: groupMemberQuery, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-          })
-        })
-
-        describe('by none member "other-user"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await otherUser.toJson()
-          })
-
-          it('throws authorization error', async () => {
-            const { errors } = await query({ query: groupMemberQuery, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-          })
-        })
-      })
-    })
-
-    describe('hidden group', () => {
-      beforeEach(async () => {
-        variables = {
-          id: 'hidden-group',
-        }
-      })
-
-      describe('query group members', () => {
-        describe('by owner "owner-of-hidden-group"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await ownerOfHiddenGroupUser.toJson()
-          })
-
-          it('finds all members', async () => {
-            const expected = {
-              data: {
-                GroupMember: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: 'current-user',
-                    myRoleInGroup: 'pending',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-closed-group',
-                    myRoleInGroup: 'pending',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-hidden-group',
-                    myRoleInGroup: 'owner',
-                  }),
-                ]),
-              },
-              errors: undefined,
-            }
-            const result = await mutate({
-              mutation: groupMemberQuery,
-              variables,
-            })
-            expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(3)
-          })
-        })
-
-        describe('by usual member "owner-of-closed-group"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await ownerOfHiddenGroupUser.toJson()
-            await mutate({
-              mutation: switchGroupMemberRoleMutation,
-              variables: {
-                id: 'hidden-group',
-                userId: 'owner-of-closed-group',
-                roleInGroup: 'usual',
-              },
-            })
-            authenticatedUser = await ownerOfClosedGroupUser.toJson()
-          })
-
-          it('finds all members', async () => {
-            const expected = {
-              data: {
-                GroupMember: expect.arrayContaining([
-                  expect.objectContaining({
-                    id: 'current-user',
-                    myRoleInGroup: 'pending',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-closed-group',
-                    myRoleInGroup: 'usual',
-                  }),
-                  expect.objectContaining({
-                    id: 'owner-of-hidden-group',
-                    myRoleInGroup: 'owner',
-                  }),
-                ]),
-              },
-              errors: undefined,
-            }
-            const result = await mutate({
-              mutation: groupMemberQuery,
-              variables,
-            })
-            expect(result).toMatchObject(expected)
-            expect(result.data.GroupMember.length).toBe(3)
-          })
-        })
-
-        describe('by pending member "current-user"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await user.toJson()
-          })
-
-          it('throws authorization error', async () => {
-            const { errors } = await query({ query: groupMemberQuery, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-          })
-        })
-
-        describe('by none member "other-user"', () => {
-          beforeEach(async () => {
-            authenticatedUser = await otherUser.toJson()
-          })
-
-          it('throws authorization error', async () => {
-            const { errors } = await query({ query: groupMemberQuery, variables })
-            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
           })
         })
       })

--- a/backend/src/schema/resolvers/groups.spec.js
+++ b/backend/src/schema/resolvers/groups.spec.js
@@ -1273,6 +1273,9 @@ describe('in mode: building up', () => {
                     }),
                   ).resolves.toMatchObject(expected)
                 })
+
+                // the GQL mutation needs this fields in the result for testing
+                it.todo('has "updatedAt" newer as "createdAt"')
               })
             })
 

--- a/backend/src/schema/resolvers/groups.spec.js
+++ b/backend/src/schema/resolvers/groups.spec.js
@@ -208,127 +208,309 @@ describe('Group', () => {
   })
 })
 
-// describe('GroupMember', () => {
-//   describe('unauthenticated', () => {
-//     it('throws authorization error', async () => {
-//       const { errors } = await query({ query: groupMemberQuery, variables: {} })
-//       expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-//     })
-//   })
+describe('GroupMember', () => {
+  describe('unauthenticated', () => {
+    it('throws authorization error', async () => {
+      variables = {
+        id: 'not-existing-group',
+      }
+      const { errors } = await query({ query: groupMemberQuery, variables })
+      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+  })
 
-//   describe('authenticated', () => {
-//     beforeEach(async () => {
-//       authenticatedUser = await user.toJson()
-//     })
+  describe('authenticated', () => {
+    let otherUser
+    let ownerOfClosedGroupUser
+    let ownerOfHiddenGroupUser
 
-//     let otherUser
+    beforeEach(async () => {
+      // create users
+      otherUser = await Factory.build(
+        'user',
+        {
+          id: 'other-user',
+          name: 'Other TestUser',
+        },
+        {
+          email: 'test2@example.org',
+          password: '1234',
+        },
+      )
+      ownerOfClosedGroupUser = await Factory.build(
+        'user',
+        {
+          id: 'owner-of-closed-group',
+          name: 'Owner Of Closed Group',
+        },
+        {
+          email: 'owner-of-closed-group@example.org',
+          password: '1234',
+        },
+      )
+      ownerOfHiddenGroupUser = await Factory.build(
+        'user',
+        {
+          id: 'owner-of-hidden-group',
+          name: 'Owner Of Hidden Group',
+        },
+        {
+          email: 'owner-of-hidden-group@example.org',
+          password: '1234',
+        },
+      )
+      // create groups
+      authenticatedUser = await ownerOfClosedGroupUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'closed-group',
+          name: 'Uninteresting Group',
+          about: 'We will change nothing!',
+          description: 'We love it like it is!?' + descriptionAdditional100,
+          groupType: 'closed',
+          actionRadius: 'national',
+          categoryIds,
+        },
+      })
+      authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          name: 'Investigative Journalism Group',
+          about: 'We will change all.',
+          description: 'We research …' + descriptionAdditional100,
+          groupType: 'hidden',
+          actionRadius: 'global',
+          categoryIds,
+        },
+      })
+      authenticatedUser = await user.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'public-group',
+          name: 'The Best Group',
+          about: 'We will change the world!',
+          description: 'Some description' + descriptionAdditional100,
+          groupType: 'public',
+          actionRadius: 'regional',
+          categoryIds,
+        },
+      })
+      // create additional memberships
+      await mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'public-group',
+          userId: 'owner-of-closed-group',
+        },
+      })
+      await mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'public-group',
+          userId: 'owner-of-hidden-group',
+        },
+      })
+      await mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'closed-group',
+          userId: 'current-user',
+        },
+      })
+      await mutate({
+        mutation: enterGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          userId: 'owner-of-closed-group',
+        },
+      })
+    })
 
-//     beforeEach(async () => {
-//       otherUser = await Factory.build(
-//         'user',
-//         {
-//           id: 'other-user',
-//           name: 'Other TestUser',
-//         },
-//         {
-//           email: 'test2@example.org',
-//           password: '1234',
-//         },
-//       )
-//       authenticatedUser = await otherUser.toJson()
-//       await mutate({
-//         mutation: createGroupMutation,
-//         variables: {
-//           id: 'others-group',
-//           name: 'Uninteresting Group',
-//           about: 'We will change nothing!',
-//           description: 'We love it like it is!?' + descriptionAdditional100,
-//           groupType: 'closed',
-//           actionRadius: 'global',
-//           categoryIds,
-//         },
-//       })
-//       authenticatedUser = await user.toJson()
-//       await mutate({
-//         mutation: createGroupMutation,
-//         variables: {
-//           id: 'my-group',
-//           name: 'The Best Group',
-//           about: 'We will change the world!',
-//           description: 'Some description' + descriptionAdditional100,
-//           groupType: 'public',
-//           actionRadius: 'regional',
-//           categoryIds,
-//         },
-//       })
-//     })
+    describe('public group', () => {
+      beforeEach(async () => {
+        variables = {
+          id: 'public-group',
+        }
+      })
 
-//     describe('query group members', () => {
-//       describe('by owner', () => {
-//         it.only('finds all members', async () => {
-//           const expected = {
-//             data: {
-//               GroupMember: expect.arrayContaining([
-//                 expect.objectContaining({
-//                   id: 'my-group',
-//                   slug: 'the-best-group',
-//                   myRole: 'owner',
-//                 }),
-//                 // Wolle: expect.objectContaining({
-//                 //   id: 'others-group',
-//                 //   slug: 'uninteresting-group',
-//                 //   myRole: null,
-//                 // }),
-//               ]),
-//             },
-//             errors: undefined,
-//           }
-//           await expect(query({ query: groupQuery, variables: {} })).resolves.toMatchObject(expected)
-//         })
-//       })
+      describe('query group members', () => {
+        describe('by owner', () => {
+          it('finds all members', async () => {
+            const expected = {
+              data: {
+                GroupMember: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'current-user',
+                    myRoleInGroup: 'owner',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                ]),
+              },
+              errors: undefined,
+            }
+            const result = await mutate({
+              mutation: groupMemberQuery,
+              variables,
+            })
+            expect(result).toMatchObject(expected)
+            expect(result.data.GroupMember.length).toBe(3)
+          })
+        })
 
-//       describe('isMember = true', () => {
-//         it('finds only groups where user is member', async () => {
-//           const expected = {
-//             data: {
-//               Group: [
-//                 {
-//                   id: 'my-group',
-//                   slug: 'the-best-group',
-//                   myRole: 'owner',
-//                 },
-//               ],
-//             },
-//             errors: undefined,
-//           }
-//           await expect(
-//             query({ query: groupQuery, variables: { isMember: true } }),
-//           ).resolves.toMatchObject(expected)
-//         })
-//       })
+        describe('by "other-user"', () => {
+          it.only('throws authorization error', async () => {
+            authenticatedUser = await otherUser.toJson()
+            const result = await query({ query: groupMemberQuery, variables })
+            console.log('result: ', result)
+            // Wolle: const { errors } = await query({ query: groupMemberQuery, variables })
+            // expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+          })
+        })
+      })
 
-//       describe('isMember = false', () => {
-//         it('finds only groups where user is not(!) member', async () => {
-//           const expected = {
-//             data: {
-//               Group: expect.arrayContaining([
-//                 expect.objectContaining({
-//                   id: 'others-group',
-//                   slug: 'uninteresting-group',
-//                   myRole: null,
-//                 }),
-//               ]),
-//             },
-//             errors: undefined,
-//           }
-//           await expect(
-//             query({ query: groupQuery, variables: { isMember: false } }),
-//           ).resolves.toMatchObject(expected)
-//         })
-//       })
-//     })
-//   })
-// })
+      describe('entered by its owner', () => {
+        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+          it('has still "owner" as membership role', async () => {
+            variables = {
+              id: 'public-group',
+              userId: 'current-user',
+            }
+            const expected = {
+              data: {
+                EnterGroup: {
+                  id: 'current-user',
+                  myRoleInGroup: 'owner',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: enterGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+      })
+    })
+
+    describe('closed group', () => {
+      describe('entered by "current-user"', () => {
+        it('has "pending" as membership role', async () => {
+          variables = {
+            id: 'closed-group',
+            userId: 'current-user',
+          }
+          const expected = {
+            data: {
+              EnterGroup: {
+                id: 'current-user',
+                myRoleInGroup: 'pending',
+              },
+            },
+            errors: undefined,
+          }
+          await expect(
+            mutate({
+              mutation: enterGroupMutation,
+              variables,
+            }),
+          ).resolves.toMatchObject(expected)
+        })
+      })
+
+      describe('entered by its owner', () => {
+        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+          it('has still "owner" as membership role', async () => {
+            variables = {
+              id: 'closed-group',
+              userId: 'owner-of-closed-group',
+            }
+            const expected = {
+              data: {
+                EnterGroup: {
+                  id: 'owner-of-closed-group',
+                  myRoleInGroup: 'owner',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: enterGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+      })
+    })
+
+    describe('hidden group', () => {
+      describe('entered by "owner-of-closed-group"', () => {
+        it('has "pending" as membership role', async () => {
+          variables = {
+            id: 'hidden-group',
+            userId: 'owner-of-closed-group',
+          }
+          const expected = {
+            data: {
+              EnterGroup: {
+                id: 'owner-of-closed-group',
+                myRoleInGroup: 'pending',
+              },
+            },
+            errors: undefined,
+          }
+          await expect(
+            mutate({
+              mutation: enterGroupMutation,
+              variables,
+            }),
+          ).resolves.toMatchObject(expected)
+        })
+      })
+
+      describe('entered by its owner', () => {
+        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+          it('has still "owner" as membership role', async () => {
+            variables = {
+              id: 'hidden-group',
+              userId: 'owner-of-hidden-group',
+            }
+            const expected = {
+              data: {
+                EnterGroup: {
+                  id: 'owner-of-hidden-group',
+                  myRoleInGroup: 'owner',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: enterGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+      })
+    })
+  })
+})
 
 describe('CreateGroup', () => {
   beforeEach(() => {

--- a/backend/src/schema/resolvers/groups.spec.js
+++ b/backend/src/schema/resolvers/groups.spec.js
@@ -2,7 +2,7 @@ import { createTestClient } from 'apollo-server-testing'
 import Factory, { cleanDatabase } from '../../db/factories'
 import {
   createGroupMutation,
-  enterGroupMutation,
+  joinGroupMutation,
   groupMemberQuery,
   groupQuery,
 } from '../../db/graphql/groups'
@@ -88,6 +88,118 @@ beforeEach(async () => {
 // TODO: avoid database clean after each test in the future if possible for performance and flakyness reasons by filling the database step by step, see issue https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/4543
 afterEach(async () => {
   await cleanDatabase()
+})
+
+describe('CreateGroup', () => {
+  beforeEach(() => {
+    variables = {
+      ...variables,
+      id: 'g589',
+      name: 'The Best Group',
+      slug: 'the-group',
+      about: 'We will change the world!',
+      description: 'Some description' + descriptionAdditional100,
+      groupType: 'public',
+      actionRadius: 'regional',
+      categoryIds,
+    }
+  })
+
+  describe('unauthenticated', () => {
+    it('throws authorization error', async () => {
+      const { errors } = await mutate({ mutation: createGroupMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+  })
+
+  describe('authenticated', () => {
+    beforeEach(async () => {
+      authenticatedUser = await user.toJson()
+    })
+
+    it('creates a group', async () => {
+      const expected = {
+        data: {
+          CreateGroup: {
+            name: 'The Best Group',
+            slug: 'the-group',
+            about: 'We will change the world!',
+          },
+        },
+        errors: undefined,
+      }
+      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
+        expected,
+      )
+    })
+
+    it('assigns the authenticated user as owner', async () => {
+      const expected = {
+        data: {
+          CreateGroup: {
+            name: 'The Best Group',
+            myRole: 'owner',
+          },
+        },
+        errors: undefined,
+      }
+      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
+        expected,
+      )
+    })
+
+    it('has "disabled" and "deleted" default to "false"', async () => {
+      const expected = { data: { CreateGroup: { disabled: false, deleted: false } } }
+      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
+        expected,
+      )
+    })
+
+    describe('description', () => {
+      describe('length without HTML', () => {
+        describe('less then 100 chars', () => {
+          it('throws error: "Too view categories!"', async () => {
+            const { errors } = await mutate({
+              mutation: createGroupMutation,
+              variables: {
+                ...variables,
+                description:
+                  '0123456789' +
+                  '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0123456789</a>',
+              },
+            })
+            expect(errors[0]).toHaveProperty('message', 'Description too short!')
+          })
+        })
+      })
+    })
+
+    describe('categories', () => {
+      beforeEach(() => {
+        CONFIG.CATEGORIES_ACTIVE = true
+      })
+
+      describe('not even one', () => {
+        it('throws error: "Too view categories!"', async () => {
+          const { errors } = await mutate({
+            mutation: createGroupMutation,
+            variables: { ...variables, categoryIds: null },
+          })
+          expect(errors[0]).toHaveProperty('message', 'Too view categories!')
+        })
+      })
+
+      describe('four', () => {
+        it('throws error: "Too many categories!"', async () => {
+          const { errors } = await mutate({
+            mutation: createGroupMutation,
+            variables: { ...variables, categoryIds: ['cat9', 'cat4', 'cat15', 'cat27'] },
+          })
+          expect(errors[0]).toHaveProperty('message', 'Too many categories!')
+        })
+      })
+    })
+  })
 })
 
 describe('Group', () => {
@@ -208,6 +320,244 @@ describe('Group', () => {
   })
 })
 
+describe('JoinGroup', () => {
+  describe('unauthenticated', () => {
+    it('throws authorization error', async () => {
+      variables = {
+        id: 'not-existing-group',
+        userId: 'current-user',
+      }
+      const { errors } = await mutate({ mutation: joinGroupMutation, variables })
+      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+    })
+  })
+
+  describe('authenticated', () => {
+    let ownerOfClosedGroupUser
+    let ownerOfHiddenGroupUser
+
+    beforeEach(async () => {
+      ownerOfClosedGroupUser = await Factory.build(
+        'user',
+        {
+          id: 'owner-of-closed-group',
+          name: 'Owner Of Closed Group',
+        },
+        {
+          email: 'owner-of-closed-group@example.org',
+          password: '1234',
+        },
+      )
+      ownerOfHiddenGroupUser = await Factory.build(
+        'user',
+        {
+          id: 'owner-of-hidden-group',
+          name: 'Owner Of Hidden Group',
+        },
+        {
+          email: 'owner-of-hidden-group@example.org',
+          password: '1234',
+        },
+      )
+      authenticatedUser = await ownerOfClosedGroupUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'closed-group',
+          name: 'Uninteresting Group',
+          about: 'We will change nothing!',
+          description: 'We love it like it is!?' + descriptionAdditional100,
+          groupType: 'closed',
+          actionRadius: 'national',
+          categoryIds,
+        },
+      })
+      authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'hidden-group',
+          name: 'Investigative Journalism Group',
+          about: 'We will change all.',
+          description: 'We research …' + descriptionAdditional100,
+          groupType: 'hidden',
+          actionRadius: 'global',
+          categoryIds,
+        },
+      })
+      authenticatedUser = await user.toJson()
+      await mutate({
+        mutation: createGroupMutation,
+        variables: {
+          id: 'public-group',
+          name: 'The Best Group',
+          about: 'We will change the world!',
+          description: 'Some description' + descriptionAdditional100,
+          groupType: 'public',
+          actionRadius: 'regional',
+          categoryIds,
+        },
+      })
+    })
+
+    describe('public group', () => {
+      describe('entered by "owner-of-closed-group"', () => {
+        it('has "usual" as membership role', async () => {
+          variables = {
+            id: 'public-group',
+            userId: 'owner-of-closed-group',
+          }
+          const expected = {
+            data: {
+              JoinGroup: {
+                id: 'owner-of-closed-group',
+                myRoleInGroup: 'usual',
+              },
+            },
+            errors: undefined,
+          }
+          await expect(
+            mutate({
+              mutation: joinGroupMutation,
+              variables,
+            }),
+          ).resolves.toMatchObject(expected)
+        })
+      })
+
+      describe('entered by its owner', () => {
+        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+          it('has still "owner" as membership role', async () => {
+            variables = {
+              id: 'public-group',
+              userId: 'current-user',
+            }
+            const expected = {
+              data: {
+                JoinGroup: {
+                  id: 'current-user',
+                  myRoleInGroup: 'owner',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: joinGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+      })
+    })
+
+    describe('closed group', () => {
+      describe('entered by "current-user"', () => {
+        it('has "pending" as membership role', async () => {
+          variables = {
+            id: 'closed-group',
+            userId: 'current-user',
+          }
+          const expected = {
+            data: {
+              JoinGroup: {
+                id: 'current-user',
+                myRoleInGroup: 'pending',
+              },
+            },
+            errors: undefined,
+          }
+          await expect(
+            mutate({
+              mutation: joinGroupMutation,
+              variables,
+            }),
+          ).resolves.toMatchObject(expected)
+        })
+      })
+
+      describe('entered by its owner', () => {
+        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+          it('has still "owner" as membership role', async () => {
+            variables = {
+              id: 'closed-group',
+              userId: 'owner-of-closed-group',
+            }
+            const expected = {
+              data: {
+                JoinGroup: {
+                  id: 'owner-of-closed-group',
+                  myRoleInGroup: 'owner',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: joinGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+      })
+    })
+
+    describe('hidden group', () => {
+      describe('entered by "owner-of-closed-group"', () => {
+        it('has "pending" as membership role', async () => {
+          variables = {
+            id: 'hidden-group',
+            userId: 'owner-of-closed-group',
+          }
+          const expected = {
+            data: {
+              JoinGroup: {
+                id: 'owner-of-closed-group',
+                myRoleInGroup: 'pending',
+              },
+            },
+            errors: undefined,
+          }
+          await expect(
+            mutate({
+              mutation: joinGroupMutation,
+              variables,
+            }),
+          ).resolves.toMatchObject(expected)
+        })
+      })
+
+      describe('entered by its owner', () => {
+        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
+          it('has still "owner" as membership role', async () => {
+            variables = {
+              id: 'hidden-group',
+              userId: 'owner-of-hidden-group',
+            }
+            const expected = {
+              data: {
+                JoinGroup: {
+                  id: 'owner-of-hidden-group',
+                  myRoleInGroup: 'owner',
+                },
+              },
+              errors: undefined,
+            }
+            await expect(
+              mutate({
+                mutation: joinGroupMutation,
+                variables,
+              }),
+            ).resolves.toMatchObject(expected)
+          })
+        })
+      })
+    })
+  })
+})
+
 describe('GroupMember', () => {
   describe('unauthenticated', () => {
     it('throws authorization error', async () => {
@@ -301,28 +651,28 @@ describe('GroupMember', () => {
       })
       // create additional memberships
       await mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'public-group',
           userId: 'owner-of-closed-group',
         },
       })
       await mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'public-group',
           userId: 'owner-of-hidden-group',
         },
       })
       await mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'closed-group',
           userId: 'current-user',
         },
       })
       await mutate({
-        mutation: enterGroupMutation,
+        mutation: joinGroupMutation,
         variables: {
           id: 'hidden-group',
           userId: 'owner-of-closed-group',
@@ -338,7 +688,11 @@ describe('GroupMember', () => {
       })
 
       describe('query group members', () => {
-        describe('by owner', () => {
+        describe('by owner "current-user"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await user.toJson()
+          })
+
           it('finds all members', async () => {
             const expected = {
               data: {
@@ -368,493 +722,265 @@ describe('GroupMember', () => {
           })
         })
 
-        describe('by "other-user"', () => {
-          it.only('throws authorization error', async () => {
-            authenticatedUser = await otherUser.toJson()
-            const result = await query({ query: groupMemberQuery, variables })
-            console.log('result: ', result)
-            // Wolle: const { errors } = await query({ query: groupMemberQuery, variables })
-            // expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        describe('by usual member "owner-of-closed-group"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await ownerOfClosedGroupUser.toJson()
           })
-        })
-      })
 
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'public-group',
-              userId: 'current-user',
-            }
+          it('finds all members', async () => {
             const expected = {
               data: {
-                EnterGroup: {
-                  id: 'current-user',
-                  myRoleInGroup: 'owner',
-                },
+                GroupMember: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'current-user',
+                    myRoleInGroup: 'owner',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                ]),
               },
               errors: undefined,
             }
-            await expect(
-              mutate({
-                mutation: enterGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
-          })
-        })
-      })
-    })
-
-    describe('closed group', () => {
-      describe('entered by "current-user"', () => {
-        it('has "pending" as membership role', async () => {
-          variables = {
-            id: 'closed-group',
-            userId: 'current-user',
-          }
-          const expected = {
-            data: {
-              EnterGroup: {
-                id: 'current-user',
-                myRoleInGroup: 'pending',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: enterGroupMutation,
+            const result = await mutate({
+              mutation: groupMemberQuery,
               variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
-      })
-
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'closed-group',
-              userId: 'owner-of-closed-group',
-            }
-            const expected = {
-              data: {
-                EnterGroup: {
-                  id: 'owner-of-closed-group',
-                  myRoleInGroup: 'owner',
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({
-                mutation: enterGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
-          })
-        })
-      })
-    })
-
-    describe('hidden group', () => {
-      describe('entered by "owner-of-closed-group"', () => {
-        it('has "pending" as membership role', async () => {
-          variables = {
-            id: 'hidden-group',
-            userId: 'owner-of-closed-group',
-          }
-          const expected = {
-            data: {
-              EnterGroup: {
-                id: 'owner-of-closed-group',
-                myRoleInGroup: 'pending',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: enterGroupMutation,
-              variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
-      })
-
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'hidden-group',
-              userId: 'owner-of-hidden-group',
-            }
-            const expected = {
-              data: {
-                EnterGroup: {
-                  id: 'owner-of-hidden-group',
-                  myRoleInGroup: 'owner',
-                },
-              },
-              errors: undefined,
-            }
-            await expect(
-              mutate({
-                mutation: enterGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
-          })
-        })
-      })
-    })
-  })
-})
-
-describe('CreateGroup', () => {
-  beforeEach(() => {
-    variables = {
-      ...variables,
-      id: 'g589',
-      name: 'The Best Group',
-      slug: 'the-group',
-      about: 'We will change the world!',
-      description: 'Some description' + descriptionAdditional100,
-      groupType: 'public',
-      actionRadius: 'regional',
-      categoryIds,
-    }
-  })
-
-  describe('unauthenticated', () => {
-    it('throws authorization error', async () => {
-      const { errors } = await mutate({ mutation: createGroupMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('authenticated', () => {
-    beforeEach(async () => {
-      authenticatedUser = await user.toJson()
-    })
-
-    it('creates a group', async () => {
-      const expected = {
-        data: {
-          CreateGroup: {
-            name: 'The Best Group',
-            slug: 'the-group',
-            about: 'We will change the world!',
-          },
-        },
-        errors: undefined,
-      }
-      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
-    })
-
-    it('assigns the authenticated user as owner', async () => {
-      const expected = {
-        data: {
-          CreateGroup: {
-            name: 'The Best Group',
-            myRole: 'owner',
-          },
-        },
-        errors: undefined,
-      }
-      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
-    })
-
-    it('has "disabled" and "deleted" default to "false"', async () => {
-      const expected = { data: { CreateGroup: { disabled: false, deleted: false } } }
-      await expect(mutate({ mutation: createGroupMutation, variables })).resolves.toMatchObject(
-        expected,
-      )
-    })
-
-    describe('description', () => {
-      describe('length without HTML', () => {
-        describe('less then 100 chars', () => {
-          it('throws error: "Too view categories!"', async () => {
-            const { errors } = await mutate({
-              mutation: createGroupMutation,
-              variables: {
-                ...variables,
-                description:
-                  '0123456789' +
-                  '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0123456789</a>',
-              },
             })
-            expect(errors[0]).toHaveProperty('message', 'Description too short!')
+            expect(result).toMatchObject(expected)
+            expect(result.data.GroupMember.length).toBe(3)
           })
         })
-      })
-    })
 
-    describe('categories', () => {
-      beforeEach(() => {
-        CONFIG.CATEGORIES_ACTIVE = true
-      })
-
-      describe('not even one', () => {
-        it('throws error: "Too view categories!"', async () => {
-          const { errors } = await mutate({
-            mutation: createGroupMutation,
-            variables: { ...variables, categoryIds: null },
+        describe('by none member "other-user"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await otherUser.toJson()
           })
-          expect(errors[0]).toHaveProperty('message', 'Too view categories!')
-        })
-      })
 
-      describe('four', () => {
-        it('throws error: "Too many categories!"', async () => {
-          const { errors } = await mutate({
-            mutation: createGroupMutation,
-            variables: { ...variables, categoryIds: ['cat9', 'cat4', 'cat15', 'cat27'] },
-          })
-          expect(errors[0]).toHaveProperty('message', 'Too many categories!')
-        })
-      })
-    })
-  })
-})
-
-describe('EnterGroup', () => {
-  describe('unauthenticated', () => {
-    it('throws authorization error', async () => {
-      variables = {
-        id: 'not-existing-group',
-        userId: 'current-user',
-      }
-      const { errors } = await mutate({ mutation: enterGroupMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
-    })
-  })
-
-  describe('authenticated', () => {
-    let ownerOfClosedGroupUser
-    let ownerOfHiddenGroupUser
-
-    beforeEach(async () => {
-      ownerOfClosedGroupUser = await Factory.build(
-        'user',
-        {
-          id: 'owner-of-closed-group',
-          name: 'Owner Of Closed Group',
-        },
-        {
-          email: 'owner-of-closed-group@example.org',
-          password: '1234',
-        },
-      )
-      ownerOfHiddenGroupUser = await Factory.build(
-        'user',
-        {
-          id: 'owner-of-hidden-group',
-          name: 'Owner Of Hidden Group',
-        },
-        {
-          email: 'owner-of-hidden-group@example.org',
-          password: '1234',
-        },
-      )
-      authenticatedUser = await ownerOfClosedGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'closed-group',
-          name: 'Uninteresting Group',
-          about: 'We will change nothing!',
-          description: 'We love it like it is!?' + descriptionAdditional100,
-          groupType: 'closed',
-          actionRadius: 'national',
-          categoryIds,
-        },
-      })
-      authenticatedUser = await ownerOfHiddenGroupUser.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'hidden-group',
-          name: 'Investigative Journalism Group',
-          about: 'We will change all.',
-          description: 'We research …' + descriptionAdditional100,
-          groupType: 'hidden',
-          actionRadius: 'global',
-          categoryIds,
-        },
-      })
-      authenticatedUser = await user.toJson()
-      await mutate({
-        mutation: createGroupMutation,
-        variables: {
-          id: 'public-group',
-          name: 'The Best Group',
-          about: 'We will change the world!',
-          description: 'Some description' + descriptionAdditional100,
-          groupType: 'public',
-          actionRadius: 'regional',
-          categoryIds,
-        },
-      })
-    })
-
-    describe('public group', () => {
-      describe('entered by "owner-of-closed-group"', () => {
-        it('has "usual" as membership role', async () => {
-          variables = {
-            id: 'public-group',
-            userId: 'owner-of-closed-group',
-          }
-          const expected = {
-            data: {
-              EnterGroup: {
-                id: 'owner-of-closed-group',
-                myRoleInGroup: 'usual',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: enterGroupMutation,
-              variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
-      })
-
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'public-group',
-              userId: 'current-user',
-            }
+          it('finds all members', async () => {
             const expected = {
               data: {
-                EnterGroup: {
-                  id: 'current-user',
-                  myRoleInGroup: 'owner',
-                },
+                GroupMember: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'current-user',
+                    myRoleInGroup: 'owner',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                ]),
               },
               errors: undefined,
             }
-            await expect(
-              mutate({
-                mutation: enterGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
+            const result = await mutate({
+              mutation: groupMemberQuery,
+              variables,
+            })
+            expect(result).toMatchObject(expected)
+            expect(result.data.GroupMember.length).toBe(3)
           })
         })
       })
     })
 
     describe('closed group', () => {
-      describe('entered by "current-user"', () => {
-        it('has "pending" as membership role', async () => {
-          variables = {
-            id: 'closed-group',
-            userId: 'current-user',
-          }
-          const expected = {
-            data: {
-              EnterGroup: {
-                id: 'current-user',
-                myRoleInGroup: 'pending',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: enterGroupMutation,
-              variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
+      beforeEach(async () => {
+        variables = {
+          id: 'closed-group',
+        }
       })
 
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'closed-group',
-              userId: 'owner-of-closed-group',
-            }
+      describe('query group members', () => {
+        describe('by owner "owner-of-closed-group"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await ownerOfClosedGroupUser.toJson()
+          })
+
+          it('finds all members', async () => {
             const expected = {
               data: {
-                EnterGroup: {
-                  id: 'owner-of-closed-group',
-                  myRoleInGroup: 'owner',
-                },
+                GroupMember: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'current-user',
+                    myRoleInGroup: 'pending',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'owner',
+                  }),
+                ]),
               },
               errors: undefined,
             }
-            await expect(
-              mutate({
-                mutation: enterGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
+            const result = await mutate({
+              mutation: groupMemberQuery,
+              variables,
+            })
+            expect(result).toMatchObject(expected)
+            expect(result.data.GroupMember.length).toBe(2)
+          })
+        })
+
+        // needs 'SwitchGroupMemberRole'
+        describe.skip('by usual member "owner-of-hidden-group"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+          })
+
+          it('finds all members', async () => {
+            const expected = {
+              data: {
+                GroupMember: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'current-user',
+                    myRoleInGroup: 'pending',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'owner',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                ]),
+              },
+              errors: undefined,
+            }
+            const result = await mutate({
+              mutation: groupMemberQuery,
+              variables,
+            })
+            expect(result).toMatchObject(expected)
+            expect(result.data.GroupMember.length).toBe(3)
+          })
+        })
+
+        describe('by pending member "current-user"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await user.toJson()
+          })
+
+          it('throws authorization error', async () => {
+            const { errors } = await query({ query: groupMemberQuery, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+          })
+        })
+
+        describe('by none member "other-user"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await otherUser.toJson()
+          })
+
+          it('throws authorization error', async () => {
+            const { errors } = await query({ query: groupMemberQuery, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
           })
         })
       })
     })
 
     describe('hidden group', () => {
-      describe('entered by "owner-of-closed-group"', () => {
-        it('has "pending" as membership role', async () => {
-          variables = {
-            id: 'hidden-group',
-            userId: 'owner-of-closed-group',
-          }
-          const expected = {
-            data: {
-              EnterGroup: {
-                id: 'owner-of-closed-group',
-                myRoleInGroup: 'pending',
-              },
-            },
-            errors: undefined,
-          }
-          await expect(
-            mutate({
-              mutation: enterGroupMutation,
-              variables,
-            }),
-          ).resolves.toMatchObject(expected)
-        })
+      beforeEach(async () => {
+        variables = {
+          id: 'hidden-group',
+        }
       })
 
-      describe('entered by its owner', () => {
-        describe('does not create additional "MEMBER_OF" relation and therefore', () => {
-          it('has still "owner" as membership role', async () => {
-            variables = {
-              id: 'hidden-group',
-              userId: 'owner-of-hidden-group',
-            }
+      describe('query group members', () => {
+        describe('by owner "owner-of-hidden-group"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+          })
+
+          it('finds all members', async () => {
             const expected = {
               data: {
-                EnterGroup: {
-                  id: 'owner-of-hidden-group',
-                  myRoleInGroup: 'owner',
-                },
+                GroupMember: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'pending',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'owner',
+                  }),
+                ]),
               },
               errors: undefined,
             }
-            await expect(
-              mutate({
-                mutation: enterGroupMutation,
-                variables,
-              }),
-            ).resolves.toMatchObject(expected)
+            const result = await mutate({
+              mutation: groupMemberQuery,
+              variables,
+            })
+            expect(result).toMatchObject(expected)
+            expect(result.data.GroupMember.length).toBe(2)
+          })
+        })
+
+        // needs 'SwitchGroupMemberRole'
+        describe.skip('by usual member "owner-of-closed-group"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await ownerOfClosedGroupUser.toJson()
+          })
+
+          it('finds all members', async () => {
+            const expected = {
+              data: {
+                GroupMember: expect.arrayContaining([
+                  expect.objectContaining({
+                    id: 'current-user',
+                    myRoleInGroup: 'pending',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-closed-group',
+                    myRoleInGroup: 'usual',
+                  }),
+                  expect.objectContaining({
+                    id: 'owner-of-hidden-group',
+                    myRoleInGroup: 'owner',
+                  }),
+                ]),
+              },
+              errors: undefined,
+            }
+            const result = await mutate({
+              mutation: groupMemberQuery,
+              variables,
+            })
+            expect(result).toMatchObject(expected)
+            expect(result.data.GroupMember.length).toBe(3)
+          })
+        })
+
+        describe('by pending member "current-user"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await user.toJson()
+          })
+
+          it('throws authorization error', async () => {
+            const { errors } = await query({ query: groupMemberQuery, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+          })
+        })
+
+        describe('by none member "other-user"', () => {
+          beforeEach(async () => {
+            authenticatedUser = await otherUser.toJson()
+          })
+
+          it('throws authorization error', async () => {
+            const { errors } = await query({ query: groupMemberQuery, variables })
+            expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
           })
         })
       })

--- a/backend/src/schema/types/type/Group.gql
+++ b/backend/src/schema/types/type/Group.gql
@@ -71,15 +71,14 @@ type Query {
     first: Int
     offset: Int
     orderBy: [_GroupOrdering]
-    filter: _GroupFilter
   ): [Group]
 
   GroupMember(
-    id: ID
+    id: ID!
     first: Int
     offset: Int
-    orderBy: [_GroupOrdering]
-    filter: _GroupFilter
+    orderBy: [_UserOrdering]
+    filter: _UserFilter
   ): [User]
 
   AvailableGroupTypes: [GroupType]!
@@ -114,4 +113,9 @@ type Mutation {
   ): Group
 
   DeleteGroup(id: ID!): Group
+
+  EnterGroup(
+    id: ID!
+    userId: ID!
+  ): User
 }

--- a/backend/src/schema/types/type/Group.gql
+++ b/backend/src/schema/types/type/Group.gql
@@ -74,6 +74,14 @@ type Query {
     filter: _GroupFilter
   ): [Group]
 
+  GroupMember(
+    id: ID
+    first: Int
+    offset: Int
+    orderBy: [_GroupOrdering]
+    filter: _GroupFilter
+  ): [User]
+
   AvailableGroupTypes: [GroupType]!
 
   AvailableGroupActionRadii: [GroupActionRadius]!

--- a/backend/src/schema/types/type/Group.gql
+++ b/backend/src/schema/types/type/Group.gql
@@ -114,7 +114,7 @@ type Mutation {
 
   DeleteGroup(id: ID!): Group
 
-  EnterGroup(
+  JoinGroup(
     id: ID!
     userId: ID!
   ): User

--- a/backend/src/schema/types/type/Group.gql
+++ b/backend/src/schema/types/type/Group.gql
@@ -118,4 +118,10 @@ type Mutation {
     id: ID!
     userId: ID!
   ): User
+
+  SwitchGroupMemberRole(
+    id: ID!
+    userId: ID!
+    roleInGroup: GroupMemberRole!
+  ): User
 }

--- a/backend/src/schema/types/type/User.gql
+++ b/backend/src/schema/types/type/User.gql
@@ -114,6 +114,8 @@ type User {
   badgesCount: Int! @cypher(statement: "MATCH (this)<-[:REWARDED]-(r:Badge) RETURN COUNT(r)")
 
   emotions: [EMOTED]
+
+  myRoleInGroup: GroupMemberRole
 }
 
 


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Implement `JoinGroup`, `GroupMember`, and `SwitchGroupMemberRole` resolvers.

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

- fixes #5188
- fixes #5189

### Todo
<!-- In case some parts are still missing, list them here. -->

- [x] rename `EnterGroup` to `JoinGroup`
- [ ] change name `SwitchGroupMemberRole` to `ChangeGroupMemberRole`
- [ ] implement `ChangeGroupMemberRole`
  - [ ] add functionallity to join group with `ChangeGroupMemberRole`
    - [ ] test this
- [ ] test `ChangeGroupMemberRole`
  - [x] general tests
  - [x] check for `has "updatedAt" newer as "createdAt"`?
    - the GQL mutation would need this fields in the result for testing
    - !!! we decided to do it not yet
  - [ ] shall a switch to a role which the a member already has through a permission error?
    - !!! we decided to through no error
  - [ ] can an owner be degraded?
    - shall an owner can switch the role of another owner to a lower role yet?
    - or shall only an owner who gave the second owner the owner role downgrade themself?
    - !!! we decided an owner can not be degraded yet
- [x] switch some group members role in seeding
- [ ] who can make a user joining a group
  - [ ] the user themselfs in case of groups of type `public` and `closed`
  - [ ] the admin/owner with an invite code in case of groups of type `hidden`
    - [ ] we decided that a hidden group can not be join
      - !!! we decide a hidden group can only be joined by `ChangeGroupMemberRole` by an owner (no admin)
- [ ] cleanup: search `Wolle`
