### PR TITLE
feat: 🍰 Change Error Message With `Authorised` To `Authorized` All Over The Place To Have American English

### DIFF
--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -188,5 +188,6 @@ export default shield(
     debug,
     allowExternalErrors,
     fallbackRule: allow,
+    fallbackError: Error('Not Authorized!'),
   },
 )

--- a/backend/src/middleware/permissionsMiddleware.spec.js
+++ b/backend/src/middleware/permissionsMiddleware.spec.js
@@ -102,7 +102,7 @@ describe('authorization', () => {
           await expect(
             query({ query: userQuery, variables: { name: 'Owner' } }),
           ).resolves.toMatchObject({
-            errors: [{ message: 'Not Authorised!' }],
+            errors: [{ message: 'Not Authorized!' }],
             data: { User: [null] },
           })
         })
@@ -132,7 +132,7 @@ describe('authorization', () => {
             await expect(
               query({ query: userQuery, variables: { name: 'Owner' } }),
             ).resolves.toMatchObject({
-              errors: [{ message: 'Not Authorised!' }],
+              errors: [{ message: 'Not Authorized!' }],
               data: { User: [null] },
             })
           })
@@ -147,7 +147,7 @@ describe('authorization', () => {
             await expect(
               query({ query: userQuery, variables: { name: 'Owner' } }),
             ).resolves.toMatchObject({
-              errors: [{ message: 'Not Authorised!' }],
+              errors: [{ message: 'Not Authorized!' }],
               data: { User: [null] },
             })
           })
@@ -198,7 +198,7 @@ describe('authorization', () => {
 
           it('denies permission', async () => {
             await expect(mutate({ mutation: signupMutation, variables })).resolves.toMatchObject({
-              errors: [{ message: 'Not Authorised!' }],
+              errors: [{ message: 'Not Authorized!' }],
               data: { Signup: null },
             })
           })
@@ -288,7 +288,7 @@ describe('authorization', () => {
 
           it('denies permission', async () => {
             await expect(mutate({ mutation: signupMutation, variables })).resolves.toMatchObject({
-              errors: [{ message: 'Not Authorised!' }],
+              errors: [{ message: 'Not Authorized!' }],
               data: { Signup: null },
             })
           })

--- a/backend/src/schema/resolvers/comments.spec.js
+++ b/backend/src/schema/resolvers/comments.spec.js
@@ -88,7 +88,7 @@ describe('CreateComment', () => {
       variables = {
         ...variables,
         postId: 'p1',
-        content: "I'm Not Authorized to comment",
+        content: "I'm not authorized to comment",
       }
       const { errors } = await mutate({ mutation: createCommentMutation, variables })
       expect(errors[0]).toHaveProperty('message', 'Not Authorized!')

--- a/backend/src/schema/resolvers/comments.spec.js
+++ b/backend/src/schema/resolvers/comments.spec.js
@@ -107,14 +107,14 @@ describe('CreateComment', () => {
         variables = {
           ...variables,
           postId: 'p1',
-          content: "I'm authorised to comment",
+          content: "I'm authorized to comment",
         }
       })
 
       it('creates a comment', async () => {
         await expect(mutate({ mutation: createCommentMutation, variables })).resolves.toMatchObject(
           {
-            data: { CreateComment: { content: "I'm authorised to comment" } },
+            data: { CreateComment: { content: "I'm authorized to comment" } },
             errors: undefined,
           },
         )

--- a/backend/src/schema/resolvers/comments.spec.js
+++ b/backend/src/schema/resolvers/comments.spec.js
@@ -88,10 +88,10 @@ describe('CreateComment', () => {
       variables = {
         ...variables,
         postId: 'p1',
-        content: "I'm not authorised to comment",
+        content: "I'm Not Authorized to comment",
       }
       const { errors } = await mutate({ mutation: createCommentMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
     })
   })
 
@@ -150,7 +150,7 @@ describe('UpdateComment', () => {
     describe('unauthenticated', () => {
       it('throws authorization error', async () => {
         const { errors } = await mutate({ mutation: updateCommentMutation, variables })
-        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -162,7 +162,7 @@ describe('UpdateComment', () => {
 
       it('throws authorization error', async () => {
         const { errors } = await mutate({ mutation: updateCommentMutation, variables })
-        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -217,7 +217,7 @@ describe('UpdateComment', () => {
         it('returns null', async () => {
           const { data, errors } = await mutate({ mutation: updateCommentMutation, variables })
           expect(data).toMatchObject({ UpdateComment: null })
-          expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+          expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
         })
       })
     })
@@ -242,7 +242,7 @@ describe('DeleteComment', () => {
     describe('unauthenticated', () => {
       it('throws authorization error', async () => {
         const result = await mutate({ mutation: deleteCommentMutation, variables })
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -254,7 +254,7 @@ describe('DeleteComment', () => {
 
       it('throws authorization error', async () => {
         const { errors } = await mutate({ mutation: deleteCommentMutation, variables })
-        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 

--- a/backend/src/schema/resolvers/donations.spec.js
+++ b/backend/src/schema/resolvers/donations.spec.js
@@ -72,7 +72,7 @@ describe('donations', () => {
       it('throws authorization error', async () => {
         authenticatedUser = undefined
         await expect(query({ query: donationsQuery, variables })).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -106,7 +106,7 @@ describe('donations', () => {
         await expect(
           mutate({ mutation: updateDonationsMutation, variables }),
         ).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -126,7 +126,7 @@ describe('donations', () => {
             mutate({ mutation: updateDonationsMutation, variables }),
           ).resolves.toMatchObject({
             data: { UpdateDonations: null },
-            errors: [{ message: 'Not Authorised!' }],
+            errors: [{ message: 'Not Authorized!' }],
           })
         })
       })
@@ -145,7 +145,7 @@ describe('donations', () => {
             mutate({ mutation: updateDonationsMutation, variables }),
           ).resolves.toMatchObject({
             data: { UpdateDonations: null },
-            errors: [{ message: 'Not Authorised!' }],
+            errors: [{ message: 'Not Authorized!' }],
           })
         })
       })

--- a/backend/src/schema/resolvers/emails.spec.js
+++ b/backend/src/schema/resolvers/emails.spec.js
@@ -63,7 +63,7 @@ describe('AddEmailAddress', () => {
     it('throws AuthorizationError', async () => {
       await expect(mutate({ mutation, variables })).resolves.toMatchObject({
         data: { AddEmailAddress: null },
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
       })
     })
   })
@@ -169,7 +169,7 @@ describe('VerifyEmailAddress', () => {
     it('throws AuthorizationError', async () => {
       await expect(mutate({ mutation, variables })).resolves.toMatchObject({
         data: { VerifyEmailAddress: null },
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
       })
     })
   })

--- a/backend/src/schema/resolvers/follow.spec.js
+++ b/backend/src/schema/resolvers/follow.spec.js
@@ -117,7 +117,7 @@ describe('follow', () => {
             variables,
           }),
         ).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
           data: { followUser: null },
         })
       })
@@ -191,7 +191,7 @@ describe('follow', () => {
         authenticatedUser = null
         await expect(mutate({ mutation: mutationUnfollowUser, variables })).resolves.toMatchObject({
           data: { unfollowUser: null },
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })

--- a/backend/src/schema/resolvers/moderation.spec.js
+++ b/backend/src/schema/resolvers/moderation.spec.js
@@ -120,7 +120,7 @@ describe('moderate resources', () => {
         await expect(
           mutate({ mutation: reviewMutation, variables: disableVariables }),
         ).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -134,7 +134,7 @@ describe('moderate resources', () => {
         await expect(
           mutate({ mutation: reviewMutation, variables: disableVariables }),
         ).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -218,7 +218,7 @@ describe('moderate resources', () => {
         await expect(
           mutate({ mutation: reviewMutation, variables: disableVariables }),
         ).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -232,7 +232,7 @@ describe('moderate resources', () => {
         await expect(
           mutate({ mutation: reviewMutation, variables: disableVariables }),
         ).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -488,7 +488,7 @@ describe('moderate resources', () => {
         await expect(
           mutate({ mutation: reviewMutation, variables: enableVariables }),
         ).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -507,7 +507,7 @@ describe('moderate resources', () => {
           await expect(
             mutate({ mutation: reviewMutation, variables: enableVariables }),
           ).resolves.toMatchObject({
-            errors: [{ message: 'Not Authorised!' }],
+            errors: [{ message: 'Not Authorized!' }],
           })
         })
       })

--- a/backend/src/schema/resolvers/notifications.spec.js
+++ b/backend/src/schema/resolvers/notifications.spec.js
@@ -165,7 +165,7 @@ describe('given some notifications', () => {
     describe('unauthenticated', () => {
       it('throws authorization error', async () => {
         const { errors } = await query({ query: notificationQuery })
-        expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -313,7 +313,7 @@ describe('given some notifications', () => {
           mutation: markAsReadMutation,
           variables: { ...variables, id: 'p1' },
         })
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 

--- a/backend/src/schema/resolvers/posts.spec.js
+++ b/backend/src/schema/resolvers/posts.spec.js
@@ -281,7 +281,7 @@ describe('CreatePost', () => {
   describe('unauthenticated', () => {
     it('throws authorization error', async () => {
       const { errors } = await mutate({ mutation: createPostMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
     })
   })
 
@@ -369,7 +369,7 @@ describe('UpdatePost', () => {
     it('throws authorization error', async () => {
       authenticatedUser = null
       expect(mutate({ mutation: updatePostMutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
         data: { UpdatePost: null },
       })
     })
@@ -382,7 +382,7 @@ describe('UpdatePost', () => {
 
     it('throws authorization error', async () => {
       const { errors } = await mutate({ mutation: updatePostMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
     })
   })
 
@@ -547,7 +547,7 @@ describe('pin posts', () => {
     it('throws authorization error', async () => {
       authenticatedUser = null
       await expect(mutate({ mutation: pinPostMutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
         data: { pinPost: null },
       })
     })
@@ -556,7 +556,7 @@ describe('pin posts', () => {
   describe('ordinary users', () => {
     it('throws authorization error', async () => {
       await expect(mutate({ mutation: pinPostMutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
         data: { pinPost: null },
       })
     })
@@ -571,7 +571,7 @@ describe('pin posts', () => {
 
     it('throws authorization error', async () => {
       await expect(mutate({ mutation: pinPostMutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
         data: { pinPost: null },
       })
     })
@@ -854,7 +854,7 @@ describe('unpin posts', () => {
     it('throws authorization error', async () => {
       authenticatedUser = null
       await expect(mutate({ mutation: unpinPostMutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
         data: { unpinPost: null },
       })
     })
@@ -863,7 +863,7 @@ describe('unpin posts', () => {
   describe('users cannot unpin posts', () => {
     it('throws authorization error', async () => {
       await expect(mutate({ mutation: unpinPostMutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
         data: { unpinPost: null },
       })
     })
@@ -878,7 +878,7 @@ describe('unpin posts', () => {
 
     it('throws authorization error', async () => {
       await expect(mutate({ mutation: unpinPostMutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
         data: { unpinPost: null },
       })
     })
@@ -975,7 +975,7 @@ describe('DeletePost', () => {
   describe('unauthenticated', () => {
     it('throws authorization error', async () => {
       const { errors } = await mutate({ mutation: deletePostMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
     })
   })
 
@@ -986,7 +986,7 @@ describe('DeletePost', () => {
 
     it('throws authorization error', async () => {
       const { errors } = await mutate({ mutation: deletePostMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
     })
   })
 
@@ -1128,7 +1128,7 @@ describe('emotions', () => {
           variables,
         })
 
-        expect(addPostEmotions.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(addPostEmotions.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -1249,7 +1249,7 @@ describe('emotions', () => {
           mutation: removePostEmotionsMutation,
           variables: removePostEmotionsVariables,
         })
-        expect(removePostEmotions.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(removePostEmotions.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 

--- a/backend/src/schema/resolvers/registration.spec.js
+++ b/backend/src/schema/resolvers/registration.spec.js
@@ -61,7 +61,7 @@ describe('Signup', () => {
       CONFIG.INVITE_REGISTRATION = false
       CONFIG.PUBLIC_REGISTRATION = false
       await expect(mutate({ mutation, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
       })
     })
 

--- a/backend/src/schema/resolvers/reports.spec.js
+++ b/backend/src/schema/resolvers/reports.spec.js
@@ -130,7 +130,7 @@ describe('file a report on a resource', () => {
         authenticatedUser = null
         await expect(mutate({ mutation: fileReportMutation, variables })).resolves.toMatchObject({
           data: { fileReport: null },
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -729,7 +729,7 @@ describe('file a report on a resource', () => {
         authenticatedUser = null
         expect(query({ query: reportsQuery })).resolves.toMatchObject({
           data: { reports: null },
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -739,7 +739,7 @@ describe('file a report on a resource', () => {
         authenticatedUser = await currentUser.toJson()
         expect(query({ query: reportsQuery })).resolves.toMatchObject({
           data: { reports: null },
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
 

--- a/backend/src/schema/resolvers/rewards.spec.js
+++ b/backend/src/schema/resolvers/rewards.spec.js
@@ -97,7 +97,7 @@ describe('rewards', () => {
         authenticatedUser = null
         await expect(mutate({ mutation: rewardMutation, variables })).resolves.toMatchObject({
           data: { reward: null },
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -255,7 +255,7 @@ describe('rewards', () => {
         it('throws authorization error', async () => {
           await expect(mutate({ mutation: rewardMutation, variables })).resolves.toMatchObject({
             data: { reward: null },
-            errors: [{ message: 'Not Authorised!' }],
+            errors: [{ message: 'Not Authorized!' }],
           })
         })
       })
@@ -308,7 +308,7 @@ describe('rewards', () => {
         authenticatedUser = null
         await expect(mutate({ mutation: unrewardMutation, variables })).resolves.toMatchObject({
           data: { unreward: null },
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -341,7 +341,7 @@ describe('rewards', () => {
         it('throws authorization error', async () => {
           await expect(mutate({ mutation: unrewardMutation, variables })).resolves.toMatchObject({
             data: { unreward: null },
-            errors: [{ message: 'Not Authorised!' }],
+            errors: [{ message: 'Not Authorized!' }],
           })
         })
       })

--- a/backend/src/schema/resolvers/shout.spec.js
+++ b/backend/src/schema/resolvers/shout.spec.js
@@ -90,7 +90,7 @@ describe('shout and unshout posts', () => {
         variables = { id: 'post-to-shout-id' }
         authenticatedUser = undefined
         await expect(mutate({ mutation: mutationShoutPost, variables })).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })
@@ -165,7 +165,7 @@ describe('shout and unshout posts', () => {
         authenticatedUser = undefined
         variables = { id: 'post-to-shout-id' }
         await expect(mutate({ mutation: mutationUnshoutPost, variables })).resolves.toMatchObject({
-          errors: [{ message: 'Not Authorised!' }],
+          errors: [{ message: 'Not Authorized!' }],
         })
       })
     })

--- a/backend/src/schema/resolvers/socialMedia.spec.js
+++ b/backend/src/schema/resolvers/socialMedia.spec.js
@@ -94,7 +94,7 @@ describe('SocialMedia', () => {
         const user = null
         const result = await socialMediaAction(user, mutation, variables)
 
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -186,7 +186,7 @@ describe('SocialMedia', () => {
         const user = null
         const result = await socialMediaAction(user, mutation, variables)
 
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -195,7 +195,7 @@ describe('SocialMedia', () => {
         const user = someUser
         const result = await socialMediaAction(user, mutation, variables)
 
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -222,7 +222,7 @@ describe('SocialMedia', () => {
         variables.id = 'some-id'
         const result = await socialMediaAction(user, mutation, variables)
 
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
   })
@@ -249,7 +249,7 @@ describe('SocialMedia', () => {
         const user = null
         const result = await socialMediaAction(user, mutation, variables)
 
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 
@@ -258,7 +258,7 @@ describe('SocialMedia', () => {
         const user = someUser
         const result = await socialMediaAction(user, mutation, variables)
 
-        expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+        expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
       })
     })
 

--- a/backend/src/schema/resolvers/user_management.spec.js
+++ b/backend/src/schema/resolvers/user_management.spec.js
@@ -310,8 +310,8 @@ describe('change password', () => {
   })
 
   describe('unauthenticated', () => {
-    it('throws "Not Authorised!"', async () => {
-      await respondsWith({ errors: [{ message: 'Not Authorised!' }] })
+    it('throws "Not Authorized!"', async () => {
+      await respondsWith({ errors: [{ message: 'Not Authorized!' }] })
     })
   })
 

--- a/backend/src/schema/resolvers/users.spec.js
+++ b/backend/src/schema/resolvers/users.spec.js
@@ -101,7 +101,7 @@ describe('User', () => {
 
     it('is forbidden', async () => {
       await expect(query({ query: userQuery, variables })).resolves.toMatchObject({
-        errors: [{ message: 'Not Authorised!' }],
+        errors: [{ message: 'Not Authorized!' }],
       })
     })
 
@@ -207,7 +207,7 @@ describe('UpdateUser', () => {
 
     it('is not allowed to change other user accounts', async () => {
       const { errors } = await mutate({ mutation: updateUserMutation, variables })
-      expect(errors[0]).toHaveProperty('message', 'Not Authorised!')
+      expect(errors[0]).toHaveProperty('message', 'Not Authorized!')
     })
   })
 
@@ -500,7 +500,7 @@ describe('switch user role', () => {
         expect.objectContaining({
           errors: [
             expect.objectContaining({
-              message: 'Not Authorised!',
+              message: 'Not Authorized!',
             }),
           ],
         }),

--- a/backend/src/schema/resolvers/users/mutedUsers.spec.js
+++ b/backend/src/schema/resolvers/users/mutedUsers.spec.js
@@ -58,7 +58,7 @@ describe('mutedUsers', () => {
   it('throws permission error', async () => {
     const { query } = createTestClient(server)
     const result = await query({ query: mutedUserQuery })
-    expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+    expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
   })
 
   describe('authenticated and given a muted user', () => {
@@ -116,7 +116,7 @@ describe('muteUser', () => {
 
   it('throws permission error', async () => {
     const result = await muteAction({ id: 'u2' })
-    expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+    expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
   })
 
   describe('authenticated', () => {
@@ -333,7 +333,7 @@ describe('unmuteUser', () => {
 
   it('throws permission error', async () => {
     const result = await unmuteAction({ id: 'u2' })
-    expect(result.errors[0]).toHaveProperty('message', 'Not Authorised!')
+    expect(result.errors[0]).toHaveProperty('message', 'Not Authorized!')
   })
 
   describe('authenticated', () => {

--- a/webapp/components/ContributionForm/ContributionForm.spec.js
+++ b/webapp/components/ContributionForm/ContributionForm.spec.js
@@ -202,7 +202,7 @@ describe('ContributionForm.vue', () => {
         beforeEach(async () => {
           jest.useFakeTimers()
           mocks.$apollo.mutate = jest.fn().mockRejectedValueOnce({
-            message: 'Not Authorised!',
+            message: 'Not Authorized!',
           })
           wrapper = Wrapper()
           postTitleInput = wrapper.find('.ds-input')
@@ -213,7 +213,7 @@ describe('ContributionForm.vue', () => {
         it('shows an error toaster when apollo mutation rejects', async () => {
           await wrapper.find('form').trigger('submit')
           await mocks.$apollo.mutate
-          await expect(mocks.$toast.error).toHaveBeenCalledWith('Not Authorised!')
+          await expect(mocks.$toast.error).toHaveBeenCalledWith('Not Authorized!')
         })
       })
     })

--- a/webapp/components/DeleteData/DeleteData.spec.js
+++ b/webapp/components/DeleteData/DeleteData.spec.js
@@ -29,7 +29,7 @@ describe('DeleteData.vue', () => {
               },
             },
           })
-          .mockRejectedValue({ message: 'Not authorised!' }),
+          .mockRejectedValue({ message: 'Not Authorized!' }),
       },
       $toast: {
         error: jest.fn(),
@@ -180,7 +180,7 @@ describe('DeleteData.vue', () => {
         // second submission causes mutation to reject
         await deleteAccountBtn.trigger('click')
         await mocks.$apollo.mutate
-        expect(mocks.$toast.error).toHaveBeenCalledWith('Not authorised!')
+        expect(mocks.$toast.error).toHaveBeenCalledWith('Not Authorized!')
       })
     })
   })

--- a/webapp/components/Modal/DisableModal.spec.js
+++ b/webapp/components/Modal/DisableModal.spec.js
@@ -25,7 +25,7 @@ describe('DisableModal.vue', () => {
       $t: jest.fn(),
       $apollo: {
         mutate: jest.fn().mockResolvedValueOnce().mockRejectedValue({
-          message: 'Not Authorised!',
+          message: 'Not Authorized!',
         }),
       },
       location: {
@@ -184,7 +184,7 @@ describe('DisableModal.vue', () => {
           })
 
           it('shows an error toaster when mutation rejects', async () => {
-            await expect(mocks.$toast.error).toHaveBeenCalledWith('Not Authorised!')
+            await expect(mocks.$toast.error).toHaveBeenCalledWith('Not Authorized!')
           })
         })
       })

--- a/webapp/components/ReleaseModal/ReleaseModal.spec.js
+++ b/webapp/components/ReleaseModal/ReleaseModal.spec.js
@@ -25,7 +25,7 @@ describe('ReleaseModal.vue', () => {
       },
       $t: jest.fn(),
       $apollo: {
-        mutate: jest.fn().mockResolvedValueOnce().mockRejectedValue({ message: 'Not Authorised!' }),
+        mutate: jest.fn().mockResolvedValueOnce().mockRejectedValue({ message: 'Not Authorized!' }),
       },
       location: {
         reload: jest.fn(),
@@ -181,7 +181,7 @@ describe('ReleaseModal.vue', () => {
           })
 
           it('shows an error toaster when mutation rejects', async () => {
-            await expect(mocks.$toast.error).toHaveBeenCalledWith('Not Authorised!')
+            await expect(mocks.$toast.error).toHaveBeenCalledWith('Not Authorized!')
           })
         })
       })


### PR DESCRIPTION
## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- Fixes https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/5203

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
