### PR TITLE
chore: 🍰 Update Neode From v^0.4.7 To v^0.4.8 In Backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -103,7 +103,7 @@
     "mustache": "^4.2.0",
     "neo4j-driver": "^4.0.2",
     "neo4j-graphql-js": "^2.11.5",
-    "neode": "^0.4.7",
+    "neode": "^0.4.8",
     "node-fetch": "~2.6.1",
     "nodemailer": "^6.4.4",
     "nodemailer-html-to-text": "^3.2.0",

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -7574,10 +7574,10 @@ neo4j-graphql-js@^2.11.5:
     lodash "^4.17.15"
     neo4j-driver "^4.0.1"
 
-neode@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/neode/-/neode-0.4.7.tgz#033007b57a2ee167e9ee5537493086db08d005eb"
-  integrity sha512-YXlc187JRpeKCBcUIkY6nimXXG+Tvlopfe71/FPno2THrwmYt5mm0RPHZ+mXF2O1Xg6zvjKvOpCpDz2vHBfroQ==
+neode@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/neode/-/neode-0.4.8.tgz#0889b4fc7f1bf0b470b01fa5b8870373b5d47ad6"
+  integrity sha512-pb91NfCOg4Fj5o+98H+S2XYC+ByQfbdhwcc1UVuzuUQ0Ezzj+jWz8NmKWU8ZfCH6l4plk71yDAPd2eTwpt+Xvg==
   dependencies:
     "@hapi/joi" "^15.1.1"
     dotenv "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsonwebtoken": "^8.5.1",
     "mock-socket": "^9.0.3",
     "neo4j-driver": "^4.3.4",
-    "neode": "^0.4.7",
+    "neode": "^0.4.8",
     "npm-run-all": "^4.1.5",
     "rosie": "^2.1.0",
     "slug": "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4481,10 +4481,10 @@ neo4j-driver@^4.2.2, neo4j-driver@^4.3.4:
     neo4j-driver-core "^4.3.4"
     rxjs "^6.6.3"
 
-neode@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/neode/-/neode-0.4.7.tgz#033007b57a2ee167e9ee5537493086db08d005eb"
-  integrity sha512-YXlc187JRpeKCBcUIkY6nimXXG+Tvlopfe71/FPno2THrwmYt5mm0RPHZ+mXF2O1Xg6zvjKvOpCpDz2vHBfroQ==
+neode@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/neode/-/neode-0.4.8.tgz#0889b4fc7f1bf0b470b01fa5b8870373b5d47ad6"
+  integrity sha512-pb91NfCOg4Fj5o+98H+S2XYC+ByQfbdhwcc1UVuzuUQ0Ezzj+jWz8NmKWU8ZfCH6l4plk71yDAPd2eTwpt+Xvg==
   dependencies:
     "@hapi/joi" "^15.1.1"
     dotenv "^4.0.0"


### PR DESCRIPTION
## 🍰 Pull Request
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Upgrade neode from v^0.4.7 to v^0.4.8 in backend and main folder.

So that we don't have a unnecessary difference between the branches `master` and `5059-epic-groups`.

### Issues
<!-- Which Issues does this fix, which are related? -->

- fixes #5333

### Todo
<!-- In case some parts are still missing, list them here. -->

- [x] none
