### PR TITLE
change pixel mobile menu show by under 811px

### DIFF
--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -270,7 +270,7 @@ export default {
     },
     showMobileMenu() {
       if (!this.windowWidth) return false
-      return this.windowWidth < 810
+      return this.windowWidth < 811
     },
   },
   methods: {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest

the header menu is empty when the width of the screen is exactly 810px. i have increased the maximum width to 811px, so that at 810px the mobile header is displayed normally. 
