### PR TITLE
fix: [WIP] 🍰 Long Words Are Being Wrapped Now

### DIFF
--- a/webapp/components/_new/generic/BaseCard/BaseCard.vue
+++ b/webapp/components/_new/generic/BaseCard/BaseCard.vue
@@ -55,6 +55,7 @@ export default {
   padding: $space-base;
   border-radius: $border-radius-x-large;
   overflow: hidden;
+  overflow-wrap: break-word;
   background-color: $color-neutral-100;
   box-shadow: $box-shadow-base;
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
**Earlier Long words were not wrapped in GroupProfile and UserProfile.**

![image](https://user-images.githubusercontent.com/75859651/197468912-2d704900-7d08-413f-9a08-50f24d81709a.png)

**Now the Long words are wrapped in GroupProfile and UserProfile.**

![image](https://user-images.githubusercontent.com/75859651/197469510-6ab80fb5-acdd-40f0-8e49-544e5de564da.png)


### Issues
<!-- Which Issues does this fix, which are related?-->
- fixes   https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/5427


### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
