### PR TITLE
fix(backend): do not expose registered emails on registration

### DIFF
--- a/backend/src/middleware/login/loginMiddleware.js
+++ b/backend/src/middleware/login/loginMiddleware.js
@@ -10,10 +10,13 @@ const sendSignupMail = async (resolve, root, args, context, resolveInfo) => {
   const { inviteCode } = args
   const response = await resolve(root, args, context, resolveInfo)
   const { email, nonce } = response
-  if (inviteCode) {
-    await sendMail(signupTemplate({ email, variables: { nonce, inviteCode } }))
-  } else {
-    await sendMail(signupTemplate({ email, variables: { nonce } }))
+  if (nonce) {
+    // emails that already exist do not have a nonce
+    if (inviteCode) {
+      await sendMail(signupTemplate({ email, variables: { nonce, inviteCode } }))
+    } else {
+      await sendMail(signupTemplate({ email, variables: { nonce } }))
+    }
   }
   delete response.nonce
   return response

--- a/backend/src/middleware/login/loginMiddleware.js
+++ b/backend/src/middleware/login/loginMiddleware.js
@@ -33,7 +33,9 @@ const sendPasswordResetMail = async (resolve, root, args, context, resolveInfo) 
 const sendEmailVerificationMail = async (resolve, root, args, context, resolveInfo) => {
   const response = await resolve(root, args, context, resolveInfo)
   const { email, nonce, name } = response
-  await sendMail(emailVerificationTemplate({ email, variables: { nonce, name } }))
+  if (nonce) {
+    await sendMail(emailVerificationTemplate({ email, variables: { nonce, name } }))
+  }
   delete response.nonce
   return response
 }

--- a/backend/src/schema/resolvers/emails.js
+++ b/backend/src/schema/resolvers/emails.js
@@ -40,7 +40,9 @@ export default {
       }
 
       // check email does not belong to anybody
-      await existingEmailAddress({ args, context })
+      const existingEmail = await existingEmailAddress({ args, context })
+      if (existingEmail && existingEmail.alreadyExistingEmail && existingEmail.user)
+        return existingEmail.alreadyExistingEmail
 
       const nonce = generateNonce()
       const {

--- a/backend/src/schema/resolvers/emails.spec.js
+++ b/backend/src/schema/resolvers/emails.spec.js
@@ -134,11 +134,17 @@ describe('AddEmailAddress', () => {
       })
 
       describe('but if another user owns an `EmailAddress` already with that email', () => {
-        it('throws UserInputError because of unique constraints', async () => {
+        it('does not throw UserInputError', async () => {
           await Factory.build('user', {}, { email: 'new-email@example.org' })
           await expect(mutate({ mutation, variables })).resolves.toMatchObject({
-            data: { AddEmailAddress: null },
-            errors: [{ message: 'A user account with this email already exists.' }],
+            data: {
+              AddEmailAddress: {
+                createdAt: expect.any(String),
+                verifiedAt: null,
+                email: 'new-email@example.org',
+              },
+            },
+            errors: undefined,
           })
         })
       })

--- a/backend/src/schema/resolvers/helpers/existingEmailAddress.js
+++ b/backend/src/schema/resolvers/helpers/existingEmailAddress.js
@@ -1,5 +1,3 @@
-import { UserInputError } from 'apollo-server'
-
 export default async function alreadyExistingMail({ args, context }) {
   const session = context.driver.session()
   try {
@@ -20,9 +18,11 @@ export default async function alreadyExistingMail({ args, context }) {
       })
     })
     const [emailBelongsToUser] = await existingEmailAddressTxPromise
-    const { alreadyExistingEmail, user } = emailBelongsToUser || {}
-    if (user) throw new UserInputError('A user account with this email already exists.')
-    return alreadyExistingEmail
+    /*
+      const { alreadyExistingEmail, user } = 
+      if (user) throw new UserInputError('A user account with this email already exists.')
+    */
+    return emailBelongsToUser || {}
   } finally {
     session.close()
   }

--- a/backend/src/schema/resolvers/registration.js
+++ b/backend/src/schema/resolvers/registration.js
@@ -13,7 +13,12 @@ export default {
       args.nonce = generateNonce()
       args.email = normalizeEmail(args.email)
       let emailAddress = await existingEmailAddress({ args, context })
-      if (emailAddress) return emailAddress
+      /*
+      if (emailAddress.user) {
+        // what to do?
+      }
+      */
+      if (emailAddress.alreadyExistingEmail) return emailAddress.alreadyExistingEmail
       try {
         emailAddress = await neode.create('EmailAddress', args)
         return emailAddress.toJson()

--- a/backend/src/schema/resolvers/registration.spec.js
+++ b/backend/src/schema/resolvers/registration.spec.js
@@ -118,9 +118,9 @@ describe('Signup', () => {
               await emailAddress.relateTo(user, 'belongsTo')
             })
 
-            it('throws UserInputError error because of unique constraint violation', async () => {
+            it('does not throw UserInputError error', async () => {
               await expect(mutate({ mutation, variables })).resolves.toMatchObject({
-                errors: [{ message: 'A user account with this email already exists.' }],
+                data: { Signup: { email: 'someuser@example.org' } },
               })
             })
           })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Do not throw errors when emails exists on registration or add email address.

### Issues
- fixes #5878 


### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
