### PR TITLE
chore(other): update github actions for node 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # TODO: DO STUFF ??? #####################################################
       ##########################################################################
@@ -42,7 +42,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # SET ENVS ###############################################################
       ##########################################################################
@@ -62,7 +62,7 @@ jobs:
       - name: Neo4J | Save docker image 
         run: docker save "ocelotsocialnetwork/neo4j-community" > /tmp/neo4j.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-neo4j-community
           path: /tmp/neo4j.tar
@@ -79,7 +79,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # SET ENVS ###############################################################
       ##########################################################################
@@ -102,7 +102,7 @@ jobs:
       - name: Backend | Save docker image
         run: docker save "ocelotsocialnetwork/backend" > /tmp/backend.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-backend-production
           path: /tmp/backend.tar
@@ -119,7 +119,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # SET ENVS ###############################################################
       ##########################################################################
@@ -142,7 +142,7 @@ jobs:
       - name: Webapp | Save docker image
         run: docker save "ocelotsocialnetwork/webapp" > /tmp/webapp.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-webapp-production
           path: /tmp/webapp.tar
@@ -159,7 +159,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # SET ENVS ###############################################################
       ##########################################################################
@@ -182,7 +182,7 @@ jobs:
       - name: Maintenance | Save docker image
         run: docker save "ocelotsocialnetwork/maintenance" > /tmp/maintenance.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-maintenance-production
           path: /tmp/maintenance.tar
@@ -202,7 +202,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
@@ -262,7 +262,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # SET ENVS ###############################################################
       ##########################################################################
@@ -335,7 +335,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch full History for changelog
       ##########################################################################

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,28 +207,28 @@ jobs:
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Neo4J)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-neo4j-community
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/neo4j.tar
       - name: Download Docker Image (Backend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-backend-production
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/backend.tar
       - name: Download Docker Image (WebApp)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-webapp-production
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/webapp.tar
       - name: Download Docker Image (Maintenance)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-maintenance-production
           path: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Backend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-backend-test
           path: /tmp
@@ -149,7 +149,7 @@ jobs:
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
       - name: Download Docker Image (Webapp)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-webapp-test
           path: /tmp
@@ -178,14 +178,14 @@ jobs:
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Neo4J)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-neo4j-image
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/neo4j.tar
       - name: Download Docker Image (Backend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-backend-test
           path: /tmp
@@ -235,7 +235,7 @@ jobs:
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Webapp)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-webapp-test
           path: /tmp
@@ -295,21 +295,21 @@ jobs:
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
       - name: Download Docker Image (Neo4J)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-neo4j-image
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/neo4j.tar
       - name: Download Docker Image (Backend)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-backend-test
           path: /tmp
       - name: Load Docker Image
         run: docker load < /tmp/backend.tar
       - name: Download Docker Image (Webapp)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docker-webapp-test
           path: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # TODO: DO STUFF ??? #####################################################
       ##########################################################################
@@ -37,7 +37,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # NEO4J ##################################################################
       ##########################################################################
@@ -46,7 +46,7 @@ jobs:
           docker build --target community -t "ocelotsocialnetwork/neo4j-community:test" neo4j/
           docker save "ocelotsocialnetwork/neo4j-community:test" > /tmp/neo4j.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-neo4j-image
           path: /tmp/neo4j.tar
@@ -63,7 +63,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # BUILD BACKEND DOCKER IMAGE (build) #####################################
       ##########################################################################
@@ -72,7 +72,7 @@ jobs:
           docker build --target test -t "ocelotsocialnetwork/backend:test" backend/
           docker save "ocelotsocialnetwork/backend:test" > /tmp/backend.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-backend-test
           path: /tmp/backend.tar
@@ -89,7 +89,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # BUILD WEBAPP DOCKER IMAGE (build) ######################################
       ##########################################################################
@@ -98,7 +98,7 @@ jobs:
           docker build --target test -t "ocelotsocialnetwork/webapp:test" webapp/
           docker save "ocelotsocialnetwork/webapp:test" > /tmp/webapp.tar
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker-webapp-test
           path: /tmp/webapp.tar
@@ -115,7 +115,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
@@ -144,7 +144,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGE ##################################################
       ##########################################################################
@@ -173,7 +173,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
@@ -230,7 +230,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
@@ -290,7 +290,7 @@ jobs:
       # CHECKOUT CODE ##########################################################
       ##########################################################################
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       ##########################################################################
       # DOWNLOAD DOCKER IMAGES #################################################
       ##########################################################################
@@ -332,12 +332,12 @@ jobs:
       # UPLOAD SCREENSHOTS & VIDEO #############################################
       ##########################################################################
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-screenshots
           path: cypress/screenshots/
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-videos
           path: cypress/videos/


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
There are lots of deprecated warnings that we should update our actions to run in node 16
```
Node.js 12 actions are deprecated.
Please update the following actions to use Node.js 16:
* actions/checkout@v2, 
* actions/upload-artifact@v2.

For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
