### PR TITLE
fix(webapp): remove additional markers from map

### DIFF
--- a/webapp/pages/map.vue
+++ b/webapp/pages/map.vue
@@ -209,6 +209,7 @@ export default {
         new MapboxGeocoder({
           accessToken: this.$env.MAPBOX_TOKEN,
           mapboxgl: this.mapboxgl,
+          marker: false,
         }),
       )
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
As user when I search an address in the Mapbox a blue marker appears but the blue marker is also used by groups.
After discussion with @Tirokk we agreed to remove additional markers.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #5980 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Remove additional marker posibiliter in MapboxGeocoder
