### PR TITLE
refactor(webapp): make action radius select in group form a reusable component

### DIFF
--- a/webapp/components/Group/GroupForm.vue
+++ b/webapp/components/Group/GroupForm.vue
@@ -94,21 +94,10 @@
         <ds-text class="select-label">
           {{ $t('group.actionRadius') }}
         </ds-text>
-        <!-- TODO: move 'ds-select' from styleguide to main code and implement missing translation etc. functionality -->
-        <select
-          class="select ds-input appearance--auto"
-          name="actionRadius"
-          :value="formData.actionRadius"
-          @change="changeActionRadius($event)"
-        >
-          <option
-            v-for="actionRadius in actionRadiusOptions"
-            :key="actionRadius"
-            :value="actionRadius"
-          >
-            {{ $t(`group.actionRadii.${actionRadius}`) }}
-          </option>
-        </select>
+        <action-radius-select
+          v-model="formData.actionRadius"
+          @change.native="changeActionRadius($event)"
+        />
         <ds-chip
           size="base"
           :color="
@@ -121,8 +110,9 @@
             name="warning"
           />
         </ds-chip>
-
+        
         <!-- location -->
+        <!-- TODO: move 'ds-select' from styleguide to main code and implement missing translation etc. functionality -->
         <ds-select
           id="city"
           :label="$t('settings.data.labelCity') + locationNameLabelAddOnOldName"
@@ -187,6 +177,7 @@ import {
   DESCRIPTION_WITHOUT_HTML_LENGTH_MIN,
 } from '~/constants/groups.js'
 import Editor from '~/components/Editor/Editor'
+import ActionRadiusSelect from '~/components/Select/ActionRadiusSelect'
 import { queryLocations } from '~/graphql/location'
 
 let timeout
@@ -196,6 +187,7 @@ export default {
   components: {
     CategoriesSelect,
     Editor,
+    ActionRadiusSelect,
   },
   props: {
     update: {
@@ -216,7 +208,6 @@ export default {
       categoriesActive: this.$env.CATEGORIES_ACTIVE,
       disabled: false,
       groupTypeOptions: ['public', 'closed', 'hidden'],
-      actionRadiusOptions: ['regional', 'national', 'continental', 'global'],
       loadingGeo: false,
       cities: [],
       formData: {

--- a/webapp/components/Group/GroupForm.vue
+++ b/webapp/components/Group/GroupForm.vue
@@ -110,7 +110,7 @@
             name="warning"
           />
         </ds-chip>
-        
+
         <!-- location -->
         <!-- TODO: move 'ds-select' from styleguide to main code and implement missing translation etc. functionality -->
         <ds-select

--- a/webapp/components/Group/GroupForm.vue
+++ b/webapp/components/Group/GroupForm.vue
@@ -318,10 +318,10 @@ export default {
       return false
     },
     changeGroupType(event) {
-      this.formData.groupType = event.target.value
+      this.$refs.groupForm.update('groupType', event.target.value)
     },
     changeActionRadius(event) {
-      this.formData.actionRadius = event.target.value
+      this.$refs.groupForm.update('actionRadius', event.target.value)
     },
     updateEditorDescription(value) {
       this.$refs.groupForm.update('description', value)

--- a/webapp/components/Group/GroupForm.vue
+++ b/webapp/components/Group/GroupForm.vue
@@ -37,8 +37,6 @@
         <ds-text class="select-label">
           {{ $t('group.type') }}
         </ds-text>
-        <!-- TODO: change it has to be implemented later -->
-        <!-- TODO: move 'ds-select' from style guide to main code and implement missing translation etc. functionality -->
         <select
           class="select ds-input appearance--auto"
           name="groupType"

--- a/webapp/components/Select/ActionRadiusSelect.spec.js
+++ b/webapp/components/Select/ActionRadiusSelect.spec.js
@@ -1,0 +1,37 @@
+import { shallowMount } from '@vue/test-utils'
+import ActionRadiusSelect from './ActionRadiusSelect'
+
+const localVue = global.localVue
+const propsData = { value: 'regional' }
+
+describe('ActionRadiusSelect.', () => {
+  let wrapper
+  let mocks
+
+  beforeEach(() => {
+    mocks = {
+      $t: jest.fn(),
+    }
+  })
+
+  describe('mount', () => {
+    const Wrapper = () => {
+      return shallowMount(ActionRadiusSelect, { propsData, mocks, localVue })
+    }
+
+    beforeEach(() => {
+      wrapper = Wrapper()
+    })
+    it('renders the select', () => {
+      expect(wrapper.findComponent(ActionRadiusSelect).exists()).toBe(true)
+    })
+
+    describe('when an option is selected', () => {
+      it('emits a change event with the new value', () => {
+        const select = wrapper.find('select')
+        select.trigger('change')
+        expect(wrapper.emitted().change[0]).toEqual(['regional'])
+      })
+    })
+  })
+})

--- a/webapp/components/Select/ActionRadiusSelect.vue
+++ b/webapp/components/Select/ActionRadiusSelect.vue
@@ -14,7 +14,11 @@
 <script>
 export default {
   name: 'ActionRadiusSelect',
-  props: ['value'],
+  props: {
+    value: {
+      required: true,
+    }
+  },
   data() {
     return {
       actionRadiusOptions: ['regional', 'national', 'continental', 'global'],

--- a/webapp/components/Select/ActionRadiusSelect.vue
+++ b/webapp/components/Select/ActionRadiusSelect.vue
@@ -21,7 +21,7 @@ export default {
   },
   data() {
     return {
-      actionRadiusOptions: ['regional', 'national', 'continental', 'global', 'interplanetary'],
+      actionRadiusOptions: ['regional', 'national', 'continental', 'global'],
     }
   },
   methods: {

--- a/webapp/components/Select/ActionRadiusSelect.vue
+++ b/webapp/components/Select/ActionRadiusSelect.vue
@@ -17,7 +17,7 @@ export default {
   props: {
     value: {
       required: true,
-    }
+    },
   },
   data() {
     return {

--- a/webapp/components/Select/ActionRadiusSelect.vue
+++ b/webapp/components/Select/ActionRadiusSelect.vue
@@ -1,0 +1,34 @@
+<template>
+  <select
+    class="select ds-input appearance--auto"
+    name="actionRadius"
+    :value="value"
+    @change="onActionRadiusChange"
+  >
+    <option
+      v-for="actionRadius in actionRadiusOptions"
+      :key="actionRadius"
+      :value="actionRadius"
+    >
+      {{ $t(`group.actionRadii.${actionRadius}`) }}
+    </option>
+  </select>
+</template>
+
+<script>
+export default {
+  name: 'ActionRadiusSelect',
+  props: ['value'],
+  data() {
+    const actionRadius = ''
+    return {
+      actionRadiusOptions: ['regional', 'national', 'continental', 'global'],
+    }
+  },
+  methods: {
+    onActionRadiusChange(event) {
+      this.$emit('change', event.target.value)
+    }
+  }
+}
+</script>

--- a/webapp/components/Select/ActionRadiusSelect.vue
+++ b/webapp/components/Select/ActionRadiusSelect.vue
@@ -5,11 +5,7 @@
     :value="value"
     @change="onActionRadiusChange"
   >
-    <option
-      v-for="actionRadius in actionRadiusOptions"
-      :key="actionRadius"
-      :value="actionRadius"
-    >
+    <option v-for="actionRadius in actionRadiusOptions" :key="actionRadius" :value="actionRadius">
       {{ $t(`group.actionRadii.${actionRadius}`) }}
     </option>
   </select>
@@ -20,7 +16,6 @@ export default {
   name: 'ActionRadiusSelect',
   props: ['value'],
   data() {
-    const actionRadius = ''
     return {
       actionRadiusOptions: ['regional', 'national', 'continental', 'global'],
     }
@@ -28,7 +23,7 @@ export default {
   methods: {
     onActionRadiusChange(event) {
       this.$emit('change', event.target.value)
-    }
-  }
+    },
+  },
 }
 </script>

--- a/webapp/components/Select/ActionRadiusSelect.vue
+++ b/webapp/components/Select/ActionRadiusSelect.vue
@@ -21,7 +21,7 @@ export default {
   },
   data() {
     return {
-      actionRadiusOptions: ['regional', 'national', 'continental', 'global'],
+      actionRadiusOptions: ['regional', 'national', 'continental', 'global', 'interplanetary'],
     }
   },
   methods: {


### PR DESCRIPTION
## 🍰 Pullrequest



### Todo
- [X] create separate select component for action radius
- [x]  in `GroupForm` replace previous select with `ActionRadiusSelect`

### Issues
- fixes #5441