### PR TITLE
fix(backend): helmet + graphiql

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -82,7 +82,9 @@ const createServer = (options) => {
   const app = express()
 
   app.set('driver', driver)
-  app.use(helmet())
+  // TODO: this exception is required for the graphql playground, since the playground loads external resources
+  // See: https://github.com/graphql/graphql-playground/issues/1283
+  app.use(helmet(CONFIG.DEBUG && { contentSecurityPolicy: false, crossOriginEmbedderPolicy: false }))
   app.use('/.well-known/', webfinger())
   app.use(express.static('public'))
   app.use(bodyParser.json({ limit: '10mb' }))


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Since the update to helmet 7.x (former 3.x) helmet checks cross origin. Apparently the graphQL Playground loads its complete script from a CDN. Hence this rule must be disabled in DEBUG mode(where the Playground is available)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- related https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/6296
- related https://github.com/graphql/graphql-playground/issues/1283

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Make an issue to figure out how not to rely on a cdn for playground and remove the exception
