### PR TITLE
fix(webapp): remove filter by time from events

### DIFF
--- a/webapp/store/posts.js
+++ b/webapp/store/posts.js
@@ -86,13 +86,13 @@ export const mutations = {
     const filter = clone(state.filter)
     if (postType && !(filter.postType_in && filter.postType_in.includes(postType))) {
       filter.postType_in = [postType]
-      if (postType === 'Event') {
+      /* if (postType === 'Event') {
         filter.eventStart_gte = new Date()
         state.order = 'eventStart_asc'
       } else {
         delete filter.eventStart_gte
         state.order = 'createdAt_desc'
-      }
+      } */
     } else {
       delete filter.eventStart_gte
       delete filter.postType_in


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

remove filter by time from events.

This PR is a suggestion how to solve the Problem that events are missing when filtering for Events.

The solution of this PR is to remove additional time filter restrictions when filtering for Events. I believe that this is better understandable for the user.

Alternatively this can be fixed by a more complicated query, since how its currently implemented events that still happen are not displayed anymore when the start-date is in the past. The end-date is optional so that the filter must be set to the end-date if provided or start-date if not provided.

```js
TOGGLE_POST_TYPE(state, postType) {
    const filter = clone(state.filter)
    if (postType && !(filter.postType_in && filter.postType_in.includes(postType))) {
      filter.postType_in = [postType]
      /* if (postType === 'Event') {
        // check for `filter.eventEnd_gte = new Date()` if provided - else use the code below
        filter.eventStart_gte = new Date()
        state.order = 'eventStart_asc'
      } else {
        delete filter.eventStart_gte
        state.order = 'createdAt_desc'
      } */
    } else {
      delete filter.eventStart_gte
      delete filter.postType_in
      state.order = 'createdAt_desc'
    }
    state.filter = filter
  },
```

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
