### PR TITLE
invalid(webapp): skip broken tests as basis for a discussion

### DIFF
--- a/webapp/components/ContributionForm/ContributionForm.spec.js
+++ b/webapp/components/ContributionForm/ContributionForm.spec.js
@@ -109,7 +109,7 @@ describe('ContributionForm.vue', () => {
         })
 
         it('has no event data block', () => {
-          expect(wrapper.find('div.eventDatas').exists()).toBe(false)
+          expect(wrapper.find('div.eventData').exists()).toBe(false)
         })
 
         it('title cannot be empty', async () => {
@@ -327,18 +327,18 @@ describe('ContributionForm.vue', () => {
           })
         })
 
-        describe('invalid form', () => {
+        describe.skip('invalid form', () => {
           beforeEach(() => {
             wrapper.find('input[name="title"]').setValue('Illegaler Kindergeburtstag')
             wrapper.vm.updateEditorContent('Elli hat Geburtstag!')
           })
 
-          it('has submit button disabled', () => {
+          it.skip('has submit button disabled', () => {
             expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBe('disabled')
           })
         })
 
-        describe('valid form', () => {
+        describe.skip('valid form', () => {
           const now = new Date()
 
           beforeEach(() => {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

skip broken tests as basis for a discussion

Repro on `master`:
`yarn test components/ContributionForm/ContributionForm.spec.js`

I believe the problem might be `updateEditorContent`

![image](https://github.com/Ocelot-Social-Community/Ocelot-Social/assets/1238238/89259ab7-6651-48f1-b901-999563c466a0)

The test itself runs successfully

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
