### PR TITLE
refactor(other): disable cypress test retries

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -42,10 +42,7 @@ module.exports = defineConfig({
     baseUrl: "http://localhost:3000",
     specPattern: "cypress/e2e/**/*.feature",
     supportFile: "cypress/support/e2e.js",
-    retries: {
-      runMode: 2,
-      openMode: 0,
-    },
+    retries:  0,
     video: false,
     setupNodeEvents,
   },


### PR DESCRIPTION
## 🍰 Pullrequest
Since our end-to-end test setup does not yet restore the same initial state before and after each scenario run, retries of entire scenarios have no added value.
On the contrary - if a scenario fails, it is retried completely, even though the reason for failure in the first run does not change.
Retrying a scenario after failure only costs resources.

That is why at Cypress we set the `retries:runMode` to `0`.

### Todo
- [X] Set Cypress retries to `0`
