### PR TITLE
refactor(backend): chat messages - order by indexId instead of createdAt

### DIFF
--- a/backend/src/graphql/messages.ts
+++ b/backend/src/graphql/messages.ts
@@ -17,7 +17,7 @@ export const createMessageMutation = () => {
 export const messageQuery = () => {
   return gql`
     query ($roomId: ID!, $first: Int, $offset: Int) {
-      Message(roomId: $roomId, first: $first, offset: $offset, orderBy: createdAt_desc) {
+      Message(roomId: $roomId, first: $first, offset: $offset, orderBy: indexId_desc) {
         _id
         id
         indexId

--- a/backend/src/schema/types/type/Message.gql
+++ b/backend/src/schema/types/type/Message.gql
@@ -3,8 +3,7 @@
 # }
 
 enum _MessageOrdering {
-  createdAt_asc
-  createdAt_desc
+  indexId_desc
 }
 
 type Message {

--- a/webapp/graphql/Messages.js
+++ b/webapp/graphql/Messages.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag'
 export const messageQuery = () => {
   return gql`
     query ($roomId: ID!, $first: Int, $offset: Int) {
-      Message(roomId: $roomId, first: $first, offset: $offset, orderBy: createdAt_desc) {
+      Message(roomId: $roomId, first: $first, offset: $offset, orderBy: indexId_desc) {
         _id
         id
         indexId


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

chat messages - order by `indexId` instead of `createdAt`

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
