### PR TITLE
refactor(other): use cached docker images in github e2e flow to decrease run time of e2e test job runs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -94,12 +94,12 @@ jobs:
           cd cypress/
           node create-cucumber-html-report.js
   
-      - name: End-to-end tests | if tests failed, get pr number
+      - name: Full stack tests | if tests failed, get pr number
         id: pr
         if: ${{ failure() && steps.e2e-tests.conclusion == 'failure' }}
         uses: 8BitJonny/gh-get-current-pr@2.2.0
 
-      - name: End-to-end tests | if tests failed, upload report
+      - name: Full stack tests | if tests failed, upload report
         id: e2e-report
         if: ${{ failure() && steps.e2e-tests.conclusion == 'failure' }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -26,6 +26,15 @@ jobs:
           docker build --target test -t "ocelotsocialnetwork/webapp:test" webapp/
           docker save "ocelotsocialnetwork/webapp:test" > /tmp/images/webapp.tar
 
+      - name: Install cypress requirements
+        run: |
+          wget --no-verbose -O /opt/cucumber-json-formatter "https://github.com/cucumber/json-formatter/releases/download/v19.0.0/cucumber-json-formatter-linux-386"
+          cd backend
+          yarn install
+          yarn build
+          cd ..
+          yarn install
+
       - name: Get pr number
         id: pr
         uses: 8BitJonny/gh-get-current-pr@2.2.0
@@ -35,6 +44,9 @@ jobs:
         uses: actions/cache/save@v3.3.1
         with:
           path: |
+            /opt/cucumber-json-formatter
+            /home/runner/.cache/Cypress
+            /home/runner/work/Ocelot-Social/Ocelot-Social
             /tmp/images/
           key: e2e-preparation-cache-pr${{ steps.pr.outputs.number }}
 
@@ -50,28 +62,8 @@ jobs:
         # run copies of the current job in parallel
         job: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: webapp | copy env file
-        run: cp webapp/.env.template webapp/.env
-
-      - name: backend | copy env file
-        run: cp backend/.env.template backend/.env
-
       - name: boot up test system | docker-compose
         run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps webapp neo4j backend
-
-      - name: Full stack tests | prepare
-        run: |
-          wget --no-verbose -O /opt/cucumber-json-formatter "https://github.com/cucumber/json-formatter/releases/download/v19.0.0/cucumber-json-formatter-linux-386"
-          chmod +x /opt/cucumber-json-formatter
-          sudo ln -fs /opt/cucumber-json-formatter /usr/bin/cucumber-json-formatter
-          cd backend
-          yarn install
-          yarn build
-          cd ..
-          yarn install
 
       - name: Full stack tests | run tests
         id: e2e-tests

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -93,11 +93,6 @@ jobs:
         run: |
           cd cypress/
           node create-cucumber-html-report.js
-  
-      - name: Full stack tests | if tests failed, get pr number
-        id: pr
-        if: ${{ failure() && steps.e2e-tests.conclusion == 'failure' }}
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
 
       - name: Full stack tests | if tests failed, upload report
         id: e2e-report
@@ -107,3 +102,16 @@ jobs:
           name: ocelot-e2e-test-report-pr${{ needs.docker_preparation.outputs.pr-number }}
           path: /home/runner/work/Ocelot-Social/Ocelot-Social/cypress/reports/cucumber_html_report
 
+  cleanup:
+    name: Cleanup
+    if: always()
+    needs: [docker_preparation, fullstack_tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          KEY="e2e-preparation-cache-pr${{ needs.docker_preparation.outputs.pr-number }}"
+          gh actions-cache delete $KEY -R Ocelot-Social-Community/Ocelot-Social --confirm

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,8 +2,46 @@ name: ocelot.social end-to-end test CI
 on: push
 
 jobs:
+  docker_preparation:
+    name: Fullstack test preparation
+    runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.pr.outputs.number }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Copy env files
+        run: |
+          cp webapp/.env.template webapp/.env
+          cp backend/.env.template backend/.env
+
+      - name: Build docker images
+        run: |
+          mkdir /tmp/images
+          docker build --target community -t "ocelotsocialnetwork/neo4j-community:test" neo4j/
+          docker save "ocelotsocialnetwork/neo4j-community:test" > /tmp/images/neo4j.tar
+          docker build --target test -t "ocelotsocialnetwork/backend:test" backend/
+          docker save "ocelotsocialnetwork/backend:test" > /tmp/images/backend.tar
+          docker build --target test -t "ocelotsocialnetwork/webapp:test" webapp/
+          docker save "ocelotsocialnetwork/webapp:test" > /tmp/images/webapp.tar
+
+      - name: Get pr number
+        id: pr
+        uses: 8BitJonny/gh-get-current-pr@2.2.0
+      
+      - name: Cache docker images
+        id: cache
+        uses: actions/cache/save@v3.3.1
+        with:
+          path: |
+            /tmp/images/
+          key: e2e-preparation-cache-pr${{ steps.pr.outputs.number }}
+
   fullstack_tests:
     name: Fullstack tests
+    if: success()
+    needs: docker_preparation
     runs-on: ubuntu-latest
     env:
       jobs: 8

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -62,8 +62,27 @@ jobs:
         # run copies of the current job in parallel
         job: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
-      - name: boot up test system | docker-compose
-        run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps webapp neo4j backend
+      - name: Restore cache
+        uses: actions/cache/restore@v3.3.1
+        id: cache
+        with:
+          path: |
+            /opt/cucumber-json-formatter
+            /home/runner/.cache/Cypress
+            /home/runner/work/Ocelot-Social/Ocelot-Social
+            /tmp/images/
+          key: e2e-preparation-cache-pr${{ needs.docker_preparation.outputs.pr-number }}
+          fail-on-cache-miss: true
+
+      - name: Boot up test system | docker-compose
+        run: |
+          chmod +x /opt/cucumber-json-formatter
+          sudo ln -fs /opt/cucumber-json-formatter /usr/bin/cucumber-json-formatter
+          docker load < /tmp/images/neo4j.tar
+          docker load < /tmp/images/backend.tar
+          docker load < /tmp/images/webapp.tar
+          docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps webapp neo4j backend
+          sleep 90s
 
       - name: Full stack tests | run tests
         id: e2e-tests

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -104,6 +104,6 @@ jobs:
         if: ${{ failure() && steps.e2e-tests.conclusion == 'failure' }}
         uses: actions/upload-artifact@v3
         with:
-          name: ocelot-e2e-test-report-pr${{ steps.pr.outputs.number }}
+          name: ocelot-e2e-test-report-pr${{ needs.docker_preparation.outputs.pr-number }}
           path: /home/runner/work/Ocelot-Social/Ocelot-Social/cypress/reports/cucumber_html_report
 


### PR DESCRIPTION
## 🍰 Pullrequest
At the moment each e2e test job runs about 17 - 30 min.
Main reason is building the SUT docker images (about 15 min) in each e2e test job.

![e2e_test_flow_before](https://github.com/Ocelot-Social-Community/Ocelot-Social/assets/3883288/59ff52f2-45d0-4f43-b4cf-041de7362de7) 

### Todo
- [x] extract docker image building into a separate preparation job to build only once
- [x] use [Github Cache Action](https://github.com/actions/cache) to store and acces the docker images
  - [x] delete cache after test runs

### Result
Now one preparation job builds images once. The e2e test jobs run 15 min less now.
This way the used runners will be freed much earlier for other workflow jobs.

   ![e2e_test_flow_after](https://github.com/Ocelot-Social-Community/Ocelot-Social/assets/3883288/d5ed1831-af96-456e-8fa7-55f188e5c0ec)

