### PR TITLE
fix(other): set workflow not to fail while deleting cache

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -113,5 +113,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh extension install actions/gh-actions-cache
+          set +e
           KEY="e2e-preparation-cache-pr${{ needs.docker_preparation.outputs.pr-number }}"
           gh actions-cache delete $KEY -R Ocelot-Social-Community/Ocelot-Social --confirm


### PR DESCRIPTION
## 🍰 Pullrequest
With the CI caching mechanism  jobs can no longer be restarted  since the deletion of the ci-cache fails (cleanup job).

### Todo
- [x] set the cleanup job not to fail
