### PR TITLE
feat(webapp): on open chat room page close or on change profile and click chat change small chat

### DIFF
--- a/webapp/components/Chat/Chat.vue
+++ b/webapp/components/Chat/Chat.vue
@@ -4,7 +4,7 @@
       <vue-advanced-chat
         :theme="theme"
         :current-user-id="currentUser.id"
-        :room-id="null"
+        :room-id="!singleRoom ? roomId : null"
         :template-actions="JSON.stringify(templatesText)"
         :menu-actions="JSON.stringify(menuActions)"
         :text-messages="JSON.stringify(textMessages)"
@@ -70,13 +70,20 @@ export default {
   props: {
     theme: {
       type: String,
+      default: 'light',
     },
-    singleRoomId: {
+    singleRoom: {
+      type: Boolean,
+      default: false,
+    },
+    roomId: {
       type: String,
       default: null,
     },
   },
   data() {
+    // Wolle console.log('this.singleRoom: ', this.singleRoom)
+    // console.log('this.roomId: ', this.roomId)
     return {
       menuActions: [
         // NOTE: if menuActions is empty, the related slot is not shown
@@ -139,8 +146,7 @@ export default {
       roomsLoaded: false,
       roomPage: 0,
       roomPageSize: 10,
-      singleRoom: !!this.singleRoomId || false,
-      selectedRoom: null,
+      selectedRoom: this.roomId,
       loadingRooms: true,
       messagesLoaded: false,
       messagePage: 0,
@@ -154,7 +160,7 @@ export default {
         .mutate({
           mutation: createRoom(),
           variables: {
-            userId: this.singleRoomId,
+            userId: this.roomId,
           },
         })
         .then(({ data: { CreateRoom } }) => {

--- a/webapp/components/Chat/Chat.vue
+++ b/webapp/components/Chat/Chat.vue
@@ -82,8 +82,6 @@ export default {
     },
   },
   data() {
-    // Wolle console.log('this.singleRoom: ', this.singleRoom)
-    // console.log('this.roomId: ', this.roomId)
     return {
       menuActions: [
         // NOTE: if menuActions is empty, the related slot is not shown

--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -13,15 +13,14 @@
     <client-only>
       <modal />
     </client-only>
-    <div v-if="$store.getters['chat/showChat'].showChat" class="chat-modul">
-      <chat
-        :singleRoomId="$store.getters['chat/showChat'].roomID"
-        @close-single-room="closeSingleRoom"
-      />
+    <div v-if="getShowChat.showChat" class="chat-modul">
+      <chat singleRoom :roomId="getShowChat.roomID" @close-single-room="closeSingleRoom" />
     </div>
   </div>
 </template>
+
 <script>
+import { mapGetters } from 'vuex'
 import seo from '~/mixins/seo'
 import mobile from '~/mixins/mobile'
 import HeaderMenu from '~/components/HeaderMenu/HeaderMenu'
@@ -37,6 +36,11 @@ export default {
     Chat,
   },
   mixins: [seo, mobile()],
+  computed: {
+    ...mapGetters({
+      getShowChat: 'chat/showChat',
+    }),
+  },
   methods: {
     closeSingleRoom() {
       this.$store.commit('chat/SET_OPEN_CHAT', { showChat: false, roomID: null })

--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -14,9 +14,9 @@
       <modal />
     </client-only>
     <div v-if="$store.getters['chat/showChat'].showChat" class="chat-modul">
-      <chat-module
-        v-on:close-single-room="closeSingleRoom"
+      <chat
         :singleRoomId="$store.getters['chat/showChat'].roomID"
+        @close-single-room="closeSingleRoom"
       />
     </div>
   </div>
@@ -27,14 +27,14 @@ import mobile from '~/mixins/mobile'
 import HeaderMenu from '~/components/HeaderMenu/HeaderMenu'
 import Modal from '~/components/Modal'
 import PageFooter from '~/components/PageFooter/PageFooter'
-import ChatModule from '~/components/Chat/Chat.vue'
+import Chat from '~/components/Chat/Chat.vue'
 
 export default {
   components: {
     HeaderMenu,
     Modal,
     PageFooter,
-    ChatModule,
+    Chat,
   },
   mixins: [seo, mobile()],
   methods: {

--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters, mapMutations } from 'vuex'
 import seo from '~/mixins/seo'
 import mobile from '~/mixins/mobile'
 import HeaderMenu from '~/components/HeaderMenu/HeaderMenu'
@@ -42,8 +42,11 @@ export default {
     }),
   },
   methods: {
+    ...mapMutations({
+      showChat: 'chat/SET_OPEN_CHAT',
+    }),
     closeSingleRoom() {
-      this.$store.commit('chat/SET_OPEN_CHAT', { showChat: false, roomID: null })
+      this.showChat({ showChat: false, roomID: null })
     },
   },
   beforeCreate() {

--- a/webapp/pages/chat.vue
+++ b/webapp/pages/chat.vue
@@ -6,9 +6,18 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex'
 import Chat from '../components/Chat/Chat.vue'
 
 export default {
   components: { Chat },
+  mounted() {
+    this.showChat({ showChat: false, roomID: null })
+  },
+  methods: {
+    ...mapMutations({
+      showChat: 'chat/SET_OPEN_CHAT',
+    }),
+  },
 }
 </script>

--- a/webapp/pages/chat.vue
+++ b/webapp/pages/chat.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <ds-heading tag="h1">{{ $t('chat.page.headline') }}</ds-heading>
-    <chat />
+    <chat :roomId="getShowChat.showChat ? getShowChat.roomID : null" />
   </div>
 </template>
 
 <script>
-import { mapMutations } from 'vuex'
+import { mapGetters, mapMutations } from 'vuex'
 import Chat from '../components/Chat/Chat.vue'
 
 export default {
@@ -14,10 +14,10 @@ export default {
   mounted() {
     this.showChat({ showChat: false, roomID: null })
   },
-  data() {
-    return {
-      // former,
-    }
+  computed: {
+    ...mapGetters({
+      getShowChat: 'chat/showChat',
+    }),
   },
   methods: {
     ...mapMutations({

--- a/webapp/pages/chat.vue
+++ b/webapp/pages/chat.vue
@@ -14,6 +14,11 @@ export default {
   mounted() {
     this.showChat({ showChat: false, roomID: null })
   },
+  data() {
+    return {
+      // former,
+    }
+  },
   methods: {
     ...mapMutations({
       showChat: 'chat/SET_OPEN_CHAT',

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -85,7 +85,7 @@
                 content: $t('chat.userProfileButton.tooltip', { name: userName }),
                 placement: 'bottom-start',
               }"
-              @click="showChat({ showChat: true, roomID: user.id })"
+              @click="showOrChangeChat(user.id)"
             >
               {{ $t('chat.userProfileButton.label') }}
             </base-button>
@@ -182,7 +182,7 @@
 
 <script>
 import uniqBy from 'lodash/uniqBy'
-import { mapMutations } from 'vuex'
+import { mapGetters, mapMutations } from 'vuex'
 import postListActions from '~/mixins/postListActions'
 import PostTeaser from '~/components/PostTeaser/PostTeaser.vue'
 import HcFollowButton from '~/components/Button/FollowButton'
@@ -254,6 +254,9 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      getShowChat: 'chat/showChat',
+    }),
     myProfile() {
       return this.$route.params.id === this.$store.getters['auth/user'].id
     },
@@ -402,6 +405,12 @@ export default {
     fetchAllConnections(type, count) {
       if (type === 'following') this.followingCount = count
       if (type === 'followedBy') this.followedByCount = count
+    },
+    async showOrChangeChat(roomID) {
+      if (this.getShowChat.showChat) {
+        await this.showChat({ showChat: false, roomID: null })
+      }
+      await this.showChat({ showChat: true, roomID })
     },
   },
   apollo: {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

On open chat room page close or on change profile and click chat change small chat.

- fixes #6589
- fixes #6551 

## 🤖 ToDo

- [x] Close mini chat when opening `/chat` page
  - [ ] select the former chat partner on the mini chat on the `/chat` page
    - [x] made new PR #6606 
    - [ ] room on `/chat` page is not selected yet
    - [ ] especially if the room is not loaded already
- [x] on clicking the chat button on a new user profile and → change mini chat partner to actual profile
- [x] clean up: search for `Wolle`