### PR TITLE
feat(other): `@all` mention for network admins

### DIFF
--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { Editor, EditorContent } from 'tiptap'
 import { History } from 'tiptap-extensions'
 import linkify from 'linkify-it'
@@ -68,6 +69,10 @@ export default {
     }
   },
   computed: {
+    ...mapGetters({
+      currentUser: 'auth/user',
+      isAdmin: 'auth/isAdmin',
+    }),
     placeholder() {
       return this.$t('editor.placeholder')
     },
@@ -78,6 +83,15 @@ export default {
         extensions.push(
           new Mention({
             items: () => {
+              if (this.isAdmin)
+                return [
+                  ...this.users,
+                  {
+                    id: this.currentUser.id,
+                    slug: this.$t('editor.mention.atAllLabel'),
+                    dataMentionId: 'all',
+                  },
+                ]
               return this.users
             },
             onEnter: (props) => this.openSuggestionList(props, MENTION),
@@ -227,6 +241,7 @@ export default {
       const typeAttrs = {
         mention: {
           id: item.id,
+          dataMentionId: item.dataMentionId ?? item.id,
           label: item.slug,
         },
         hashtag: {

--- a/webapp/components/Editor/SuggestionList.vue
+++ b/webapp/components/Editor/SuggestionList.vue
@@ -30,6 +30,7 @@
 import { HASHTAG, MENTION } from '../../constants/editor'
 
 export default {
+  name: 'SuggestionList',
   props: {
     suggestionType: String,
     filteredItems: Array,

--- a/webapp/components/Editor/nodes/Mention.js
+++ b/webapp/components/Editor/nodes/Mention.js
@@ -14,7 +14,7 @@ export default class Mention extends TipTapMention {
           {
             class: this.options.mentionClass,
             href: `/profile/${node.attrs.id}`,
-            'data-mention-id': node.attrs.id,
+            'data-mention-id': node.attrs.dataMentionId,
             target: '_blank',
           },
           `${this.options.matcher.char}${node.attrs.label} `,

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -393,6 +393,7 @@
       "unorderedList": "Ungeordnete Liste"
     },
     "mention": {
+      "atAllLabel": "alle",
       "noUsersFound": "Keine Nutzer gefunden"
     },
     "placeholder": "Schreib etwas Inspirierendes …"

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -393,6 +393,7 @@
       "unorderedList": "Unordered list"
     },
     "mention": {
+      "atAllLabel": "all",
       "noUsersFound": "No users found"
     },
     "placeholder": "Leave your inspirational thoughts …"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

`@all` mention for network admins

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

- fixes #6593

### Todo

Only for network admins:

- [ ] webapp – editor:
  - [ ] add the `@all` mention to the mention menu:
    - [ ] add it at the beginning of the menu and seperate it by a seperation line
  - [ ] if the user choses `@all` it is placed as a link in the editor:
    -  [ ] ?what the link and id(?) shall be?
- [ ] backend:
  - [ ] if the `@all` mention is in the post content:
    - s[ ] end all users a notification:
      - [ ] ?sender is the admin?
