### PR TITLE
fix(webapp): start search of user after three characters (chat new room, add group member)

### DIFF
--- a/webapp/components/generic/SelectUserSearch/SelectUserSearch.vue
+++ b/webapp/components/generic/SelectUserSearch/SelectUserSearch.vue
@@ -54,7 +54,7 @@ export default {
   },
   computed: {
     startSearch() {
-      return this.query && this.query.length > 3
+      return this.query && this.query.length >= 3
     },
   },
   methods: {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
In the search user component used in Group Admin and chat create new room searches after 4 characters.
This sets it to 3 characters

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #6635

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Search trigger after 3 characters
