### PR TITLE
fix(webapp): fix wrong font in whole network comming from chat component

### DIFF
--- a/webapp/components/Chat/Chat.vue
+++ b/webapp/components/Chat/Chat.vue
@@ -462,10 +462,7 @@ export default {
   },
 }
 </script>
-<style lang="scss">
-body {
-  font-family: 'Quicksand', sans-serif;
-}
+<style lang="scss" scoped>
 .vac-avatar {
   background-size: cover;
   background-position: center center;


### PR DESCRIPTION
- Set style of chat component to 'scoped'

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Fix wrong font in whole network comming from chat component.

### Issues
<!-- Which Issues does this fix, which are related?
- relates #XXX
-->

- fixes #6669

### Todo
<!-- In case some parts are still missing, list them here. -->

- [x] remove font 'Quicksand' from the chat
