### PR TITLE
refactor(webapp): replace deprecated jest methods in webapp unit tests

### DIFF
--- a/webapp/components/DonationInfo/DonationInfo.spec.js
+++ b/webapp/components/DonationInfo/DonationInfo.spec.js
@@ -46,7 +46,7 @@ describe('DonationInfo.vue', () => {
 
         // it looks to me that toLocaleString for some reason is not working as expected
         it.skip('creates a label from the given amounts and a translation string', () => {
-          expect(mocks.$t).nthCalledWith(1, 'donations.amount-of-total', {
+          expect(mocks.$t).toHaveBeenNthCalledWith(1, 'donations.amount-of-total', {
             amount: '10.000',
             total: '50.000',
           })
@@ -55,7 +55,7 @@ describe('DonationInfo.vue', () => {
 
       describe('given english locale', () => {
         it('creates a label from the given amounts and a translation string', () => {
-          expect(mocks.$t).toBeCalledWith(
+          expect(mocks.$t).toHaveBeenCalledWith(
             'donations.amount-of-total',
             expect.objectContaining({
               amount: '10,000',

--- a/webapp/components/Group/GroupMember.spec.js
+++ b/webapp/components/Group/GroupMember.spec.js
@@ -94,20 +94,20 @@ describe('GroupMember', () => {
 
       describe('with server error', () => {
         it('toasts an error message', () => {
-          expect(toastErrorMock).toBeCalledWith('Oh no!')
+          expect(toastErrorMock).toHaveBeenCalledWith('Oh no!')
         })
       })
 
       describe('with server success', () => {
         it('calls the API', () => {
-          expect(apolloMock).toBeCalledWith({
+          expect(apolloMock).toHaveBeenCalledWith({
             mutation: changeGroupMemberRoleMutation(),
             variables: { groupId: 'group-id', userId: 'user', roleInGroup: 'admin' },
           })
         })
 
         it('toasts a success message', () => {
-          expect(toastSuccessMock).toBeCalledWith('group.changeMemberRole')
+          expect(toastSuccessMock).toHaveBeenCalledWith('group.changeMemberRole')
         })
       })
     })
@@ -150,7 +150,7 @@ describe('GroupMember', () => {
         })
 
         it('toasts an error message', () => {
-          expect(toastErrorMock).toBeCalledWith('Oh no!!')
+          expect(toastErrorMock).toHaveBeenCalledWith('Oh no!!')
         })
 
         it('closes the modal', () => {
@@ -165,7 +165,7 @@ describe('GroupMember', () => {
         })
 
         it('calls the API', () => {
-          expect(apolloMock).toBeCalledWith({
+          expect(apolloMock).toHaveBeenCalledWith({
             mutation: removeUserFromGroupMutation(),
             variables: { groupId: 'group-id', userId: 'user' },
           })
@@ -176,7 +176,7 @@ describe('GroupMember', () => {
         })
 
         it('toasts a success message', () => {
-          expect(toastSuccessMock).toBeCalledWith('group.memberRemoved')
+          expect(toastSuccessMock).toHaveBeenCalledWith('group.memberRemoved')
         })
 
         it('closes the modal', () => {

--- a/webapp/components/LoginForm/LoginForm.spec.js
+++ b/webapp/components/LoginForm/LoginForm.spec.js
@@ -75,8 +75,8 @@ describe('LoginForm', () => {
         describe('no categories saved', () => {
           it('resets the categories', async () => {
             await fillIn(Wrapper())
-            expect(storeMocks.mutations['posts/RESET_CATEGORIES']).toBeCalled()
-            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).not.toBeCalled()
+            expect(storeMocks.mutations['posts/RESET_CATEGORIES']).toHaveBeenCalled()
+            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).not.toHaveBeenCalled()
           })
         })
 
@@ -84,11 +84,11 @@ describe('LoginForm', () => {
           it('sets the categories', async () => {
             authUserMock.mockReturnValue({ activeCategories: ['cat1', 'cat9', 'cat12'] })
             await fillIn(Wrapper())
-            expect(storeMocks.mutations['posts/RESET_CATEGORIES']).toBeCalled()
-            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toBeCalledTimes(3)
-            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toBeCalledWith({}, 'cat1')
-            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toBeCalledWith({}, 'cat9')
-            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toBeCalledWith({}, 'cat12')
+            expect(storeMocks.mutations['posts/RESET_CATEGORIES']).toHaveBeenCalled()
+            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toHaveBeenCalledTimes(3)
+            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toHaveBeenCalledWith({}, 'cat1')
+            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toHaveBeenCalledWith({}, 'cat9')
+            expect(storeMocks.mutations['posts/TOGGLE_CATEGORY']).toHaveBeenCalledWith({}, 'cat12')
           })
         })
       })

--- a/webapp/components/PostTeaser/PostTeaser.spec.js
+++ b/webapp/components/PostTeaser/PostTeaser.spec.js
@@ -73,7 +73,7 @@ describe('PostTeaser', () => {
     it('has no validation errors', () => {
       const spy = jest.spyOn(global.console, 'error')
       Wrapper()
-      expect(spy).not.toBeCalled()
+      expect(spy).not.toHaveBeenCalled()
       spy.mockReset()
     })
 

--- a/webapp/pages/index.spec.js
+++ b/webapp/pages/index.spec.js
@@ -114,11 +114,11 @@ describe('PostIndex', () => {
       })
 
       it('resets the category filter', () => {
-        expect(mutations['posts/RESET_CATEGORIES']).toBeCalled()
+        expect(mutations['posts/RESET_CATEGORIES']).toHaveBeenCalled()
       })
 
       it('sets the category', () => {
-        expect(mutations['posts/TOGGLE_CATEGORY']).toBeCalledWith({}, 'cat3')
+        expect(mutations['posts/TOGGLE_CATEGORY']).toHaveBeenCalledWith({}, 'cat3')
       })
     })
   })

--- a/webapp/pages/login.spec.js
+++ b/webapp/pages/login.spec.js
@@ -71,7 +71,7 @@ describe('Login.vue', () => {
       asyncData = true
       tosVersion = '0.0.4'
       wrapper = await Wrapper()
-      expect(redirect).toBeCalledWith('/')
+      expect(redirect).toHaveBeenCalledWith('/')
     })
   })
 })

--- a/webapp/pages/logout.spec.js
+++ b/webapp/pages/logout.spec.js
@@ -36,8 +36,8 @@ describe('logout.vue', () => {
     })
 
     it('logs out and redirects to login', () => {
-      expect(mocks.$store.dispatch).toBeCalledWith('auth/logout')
-      expect(mocks.$router.replace).toBeCalledWith('/login')
+      expect(mocks.$store.dispatch).toHaveBeenCalledWith('auth/logout')
+      expect(mocks.$router.replace).toHaveBeenCalledWith('/login')
     })
   })
 })

--- a/webapp/pages/map.spec.js
+++ b/webapp/pages/map.spec.js
@@ -114,19 +114,19 @@ describe('map', () => {
       })
 
       it('initializes on style load', () => {
-        expect(mapOnMock).toBeCalledWith('style.load', expect.any(Function))
+        expect(mapOnMock).toHaveBeenCalledWith('style.load', expect.any(Function))
       })
 
       it('initializes on mouseenter', () => {
-        expect(mapOnMock).toBeCalledWith('mouseenter', 'markers', expect.any(Function))
+        expect(mapOnMock).toHaveBeenCalledWith('mouseenter', 'markers', expect.any(Function))
       })
 
       it('initializes on mouseleave', () => {
-        expect(mapOnMock).toBeCalledWith('mouseleave', 'markers', expect.any(Function))
+        expect(mapOnMock).toHaveBeenCalledWith('mouseleave', 'markers', expect.any(Function))
       })
 
       it('calls add map control', () => {
-        expect(mapAddControlMock).toBeCalled()
+        expect(mapAddControlMock).toHaveBeenCalled()
       })
 
       describe('trigger style load event', () => {
@@ -137,7 +137,7 @@ describe('map', () => {
         })
 
         it('calls loadMarkersIconsAndAddMarkers', () => {
-          expect(spy).toBeCalled()
+          expect(spy).toHaveBeenCalled()
         })
       })
 

--- a/webapp/pages/password-reset.spec.js
+++ b/webapp/pages/password-reset.spec.js
@@ -68,7 +68,7 @@ describe('password-reset.vue', () => {
       asyncData = true
       isLoggedIn = true
       wrapper = await Wrapper()
-      expect(redirect).toBeCalledWith('/')
+      expect(redirect).toHaveBeenCalledWith('/')
     })
   })
 })

--- a/webapp/pages/post/edit/_id.spec.js
+++ b/webapp/pages/post/edit/_id.spec.js
@@ -76,7 +76,7 @@ describe('post/_id.vue', () => {
       authorId = 'some-author'
       userId = 'some-user'
       wrapper = await Wrapper()
-      expect(error).toBeCalledWith({ message: 'error-pages.cannot-edit-post', statusCode: 403 })
+      expect(error).toHaveBeenCalledWith({ message: 'error-pages.cannot-edit-post', statusCode: 403 })
     })
 
     it('renders with asyncData of same user', async () => {

--- a/webapp/pages/post/edit/_id.spec.js
+++ b/webapp/pages/post/edit/_id.spec.js
@@ -76,7 +76,10 @@ describe('post/_id.vue', () => {
       authorId = 'some-author'
       userId = 'some-user'
       wrapper = await Wrapper()
-      expect(error).toHaveBeenCalledWith({ message: 'error-pages.cannot-edit-post', statusCode: 403 })
+      expect(error).toHaveBeenCalledWith({
+        message: 'error-pages.cannot-edit-post',
+        statusCode: 403,
+      })
     })
 
     it('renders with asyncData of same user', async () => {

--- a/webapp/pages/registration.spec.js
+++ b/webapp/pages/registration.spec.js
@@ -327,7 +327,7 @@ describe('Registration', () => {
       asyncData = true
       isLoggedIn = true
       wrapper = await Wrapper()
-      expect(redirect).toBeCalledWith('/')
+      expect(redirect).toHaveBeenCalledWith('/')
     })
 
     // copied from webapp/components/Registration/Signup.spec.js as testing template

--- a/webapp/pages/terms-and-conditions-confirm.spec.js
+++ b/webapp/pages/terms-and-conditions-confirm.spec.js
@@ -71,7 +71,7 @@ describe('terms-and-conditions-confirm.vue', () => {
       asyncData = true
       tosAgree = true
       wrapper = await Wrapper()
-      expect(redirect).toBeCalledWith('/')
+      expect(redirect).toHaveBeenCalledWith('/')
     })
   })
 })


### PR DESCRIPTION
## 🍰 Pullrequest
In the webapp Jest v29.5 is used.
Several method from our unit tests are deprecated in this Jest versin

### Todo
Replace deprecatedmethods with current equivalent
- [X] `toBeCalled` --> `toHaveBeenCalled`
- [x] `toBeCalledWith` --> `toHaveBeenCalledWith`
- [x] `toBeCalledTimes` --> `toHaveBeenCalledTimes`

### Issues
- blocked-by #6809