### PR TITLE
feat(other): change group description length min

### DIFF
--- a/backend/src/constants/groups.ts
+++ b/backend/src/constants/groups.ts
@@ -1,3 +1,3 @@
 // this file is duplicated in `backend/src/constants/group` and `webapp/constants/group.js`
-export const DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 50 // with removed HTML tags
+export const DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 3 // with removed HTML tags
 export const DESCRIPTION_EXCERPT_HTML_LENGTH = 250 // with removed HTML tags

--- a/backend/src/schema/resolvers/groups.spec.ts
+++ b/backend/src/schema/resolvers/groups.spec.ts
@@ -328,15 +328,15 @@ describe('in mode', () => {
 
         describe('description', () => {
           describe('length without HTML', () => {
-            describe('less then 100 chars', () => {
+            describe('less then 3 chars', () => {
               it('throws error: "Description too short!"', async () => {
                 const { errors } = await mutate({
                   mutation: createGroupMutation(),
                   variables: {
                     ...variables,
                     description:
-                      '0123456789' +
-                      '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0123456789</a>',
+                      '0' +
+                      '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0</a>',
                   },
                 })
                 expect(errors![0]).toHaveProperty('message', 'Description too short!')
@@ -2850,15 +2850,15 @@ describe('in mode', () => {
 
             describe('description', () => {
               describe('length without HTML', () => {
-                describe('less then 100 chars', () => {
+                describe('less then 3 chars', () => {
                   it('throws error: "Description too short!"', async () => {
                     const { errors } = await mutate({
                       mutation: updateGroupMutation(),
                       variables: {
                         id: 'my-group',
                         description:
-                          '0123456789' +
-                          '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0123456789</a>',
+                          '0' +
+                          '<a href="https://domain.org/0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789">0</a>',
                       },
                     })
                     expect(errors![0]).toHaveProperty('message', 'Description too short!')

--- a/webapp/constants/groups.js
+++ b/webapp/constants/groups.js
@@ -1,5 +1,5 @@
 // this file is duplicated in `backend/src/constants/group.js` and `webapp/constants/group.js`
 export const NAME_LENGTH_MIN = 3
 export const NAME_LENGTH_MAX = 50
-export const DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 50 // with removed HTML tags
+export const DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 3 // with removed HTML tags
 export const SHOW_GROUP_BUTTON_IN_HEADER = true


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Change group 'DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 3', was '50'.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
-->

- relates #6923 

### Todo

- [x] webapp, backend default:
  - [x] `DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 50`  →  `DESCRIPTION_WITHOUT_HTML_LENGTH_MIN = 3`
