### PR TITLE
refactor(workflow): replace docker-compose by docker compose in workflow files

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -112,16 +112,16 @@ jobs:
           cp backend/.env.template backend/.env
 
       - name: backend | docker-compose
-        run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps neo4j backend
+        run: docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps neo4j backend
 
       - name: backend | Initialize Database
-        run: docker-compose exec -T backend yarn db:migrate init
+        run: docker compose exec -T backend yarn db:migrate init
 
       - name: backend | Migrate Database Up
-        run: docker-compose exec -T backend yarn db:migrate up
+        run: docker compose exec -T backend yarn db:migrate up
 
       - name: backend | Unit test incl. coverage check
-        run: docker-compose exec -T backend yarn test
+        run: docker compose exec -T backend yarn test
 
   cleanup:
     name: Cleanup

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -77,7 +77,7 @@ jobs:
           docker load < /tmp/images/neo4j.tar
           docker load < /tmp/images/backend.tar
           docker load < /tmp/images/webapp.tar
-          docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps webapp neo4j backend
+          docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps webapp neo4j backend
           sleep 90s
 
       - name: Full stack tests | run tests

--- a/.github/workflows/test-webapp.yml
+++ b/.github/workflows/test-webapp.yml
@@ -94,10 +94,10 @@ jobs:
           cp backend/.env.template backend/.env
 
       - name: backend | docker-compose
-        run: docker-compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps webapp
+        run: docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach --no-deps webapp
 
       - name: webapp | Unit tests incl. coverage check
-        run: docker-compose exec -T webapp yarn test
+        run: docker compose exec -T webapp yarn test
 
   cleanup:
     name: Cleanup

--- a/backend/src/schema/resolvers/posts.spec.ts
+++ b/backend/src/schema/resolvers/posts.spec.ts
@@ -632,8 +632,8 @@ describe('CreatePost', () => {
                 eventLocationName: 'Leipzig',
                 eventVenue: 'Connewitzer Kreuz',
                 eventLocation: {
-                  lng: 12.374733,
-                  lat: 51.340632,
+                  lng: 12.375101,
+                  lat: 51.34083,
                 },
               },
             },
@@ -947,8 +947,8 @@ describe('UpdatePost', () => {
                 eventLocationName: 'Leipzig',
                 eventVenue: 'Connewitzer Kreuz',
                 eventLocation: {
-                  lng: 12.374733,
-                  lat: 51.340632,
+                  lng: 12.375101,
+                  lat: 51.34083,
                 },
               },
             },

--- a/backend/src/schema/resolvers/users/location.spec.ts
+++ b/backend/src/schema/resolvers/users/location.spec.ts
@@ -38,8 +38,8 @@ const newlyCreatedNodesWithLocales = [
       nameRU: 'Вельцхайм',
       nameNL: 'Welzheim',
       namePL: 'Welzheim',
-      lng: 9.634741,
-      lat: 48.874924,
+      lng: 9.634519,
+      lat: 48.87682,
     },
     state: {
       id: expect.stringContaining('region'),

--- a/frontend/.github/workflows/frontend.deploy.docs.yml
+++ b/frontend/.github/workflows/frontend.deploy.docs.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@9a9194f87191a7e9055e3e9b95b8cfb13023bb08 # v4.1.7
 
     - name: vuepress-deploy
-      uses: jenkey2011/vuepress-deploy@master
+      uses: jenkey2011/vuepress-deploy@875651a25c97353b9dcfc78c0c59b7dc09b8dbda # v1.8.1
       env:
         ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         #TARGET_REPO: username/repo


### PR DESCRIPTION
## 🍰 Refactor
Due to Github Runners migration from docker compose v1 to v2 this summer (see [here](https://github.com/actions/runner-images/issues/9864#issuecomment-2114371013)) all our Dependabot bump PRs failed. (e.g. [the cheerio update](https://github.com/Ocelot-Social-Community/Ocelot-Social/actions/runs/10327804316/job/28593638175) in backend).

This PR migrates all our workflow files to using compose v1.