### PR TITLE
fix(workflow): reset pkgdeps/git-tag-action to v3.0.0 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,7 +253,7 @@ jobs:
           echo "BUILD_COMMIT=${GITHUB_SHA}" >> $GITHUB_ENV
       - run: echo "BUILD_VERSION=${VERSION}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
       - name: package-version-to-git-tag + build number
-        uses: pkgdeps/git-tag-action@81b45ff87eb7f7bd49e76e2bed448990d4dd72b3 # v3.0.0
+        uses: pkgdeps/git-tag-action@8v3.0.0 # v3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_repo: ${{ github.repository }}


### PR DESCRIPTION
Using the latest commit hash did not work.

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
