### PR TITLE
fix(backend): fix geodata in mapbox-related resolver test

### DIFF
--- a/backend/src/schema/resolvers/users/location.spec.ts
+++ b/backend/src/schema/resolvers/users/location.spec.ts
@@ -38,8 +38,8 @@ const newlyCreatedNodesWithLocales = [
       nameRU: 'Вельцхайм',
       nameNL: 'Welzheim',
       namePL: 'Welzheim',
-      lng: 9.634519,
-      lat: 48.87682,
+      lng: 9.634301,
+      lat: 48.874393,
     },
     state: {
       id: expect.stringContaining('region'),


### PR DESCRIPTION
## 🍰 Pullrequest
A longer known recurring issue:

```
FAIL src/schema/resolvers/users/location.spec.ts
  ● userMiddleware › UpdateUser › creates a Location node with localized city/state/country names

    expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

    @@ -1,11 +1,11 @@
      Array [
        Object {
          "city": Object {
            "id": StringContaining "place",
    -       "lat": 48.87682,
    -       "lng": 9.634519,
    +       "lat": 48.874393,
    +       "lng": 9.634301,
            "name": "Welzheim",
            "nameDE": "Welzheim",
            "nameEN": "Welzheim",
            "nameES": "Welzheim",
            "nameFR": "Welzheim",

      219 |           }
      220 |         }),
    > 221 |       ).toEqual(newlyCreatedNodesWithLocales)
          |         ^
      222 |     })
      223 |   })
      224 | })

      at src/schema/resolvers/users/location.spec.ts:221:9
      at fulfilled (src/schema/resolvers/users/location.spec.ts:28:58)
```

The geo data (for a city center) received by calling `https://api.mapbox.com/geocoding/v5/mapbox.places` changeo over time.
For now we repeatedly adapt the test data to the changed data.

### Todo
- [ ] As recommended in[ this comment](https://github.com/mapbox/mapbox-gl-js/issues/10644#issuecomment-832121565) from the **mapbox-gl-js** issue https://github.com/mapbox/mapbox-gl-js/issues/10644 we could contact Mapbox Support about this problem.