### PR TITLE
refactor(other): change set node version in readme files

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -20,7 +20,7 @@ Wait a little until your backend is up and running at [http://localhost:4000/](h
 
 For the local installation you need a recent version of
 [Node](https://nodejs.org/en/) (&gt;= `v16.19.0`). We are using
-`v19.4.0` and therefore we recommend to use the same version
+`v20.12.1` and therefore we recommend to use the same version
 ([see](https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/4082)
 some known problems with more recent node versions). You can use the
 [node version manager](https://github.com/nvm-sh/nvm) `nvm` to switch
@@ -29,8 +29,8 @@ between different local Node versions:
 ```bash
 # install Node
 $ cd backend
-$ nvm install v19.4.0
-$ nvm use v19.4.0
+$ nvm install v20.12.1
+$ nvm use v20.12.1
 ```
 
 Install node dependencies with [yarn](https://yarnpkg.com/en/):

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -10,8 +10,8 @@ between different local Node versions:
 ```bash
 # install Node
 $ cd webapp
-$ nvm install v19.4.0
-$ nvm use v19.4.0
+$ nvm install v20.12.1
+$ nvm use v20.12.1
 ```
 
 Install node dependencies with [yarn](https://yarnpkg.com/en/):


### PR DESCRIPTION
## 🍰 Pullrequest
Currently we have the Node version 2[0.12.1](url) set (see [.nvmrc](https://github.com/Ocelot-Social-Community/Ocelot-Social/blob/master/.nvmrc)).

This pull request updates that information in the readme files.
