### PR TITLE
refactor(webapp): degroup vue packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -134,7 +134,6 @@ updates:
     vue:
       applies-to: version-updates
       patterns:
-        - "vue*"
         - "@vue*"
 
 - package-ecosystem: docker


### PR DESCRIPTION
## 🍰 Pullrequest
In the dependabot configuration the grouping of all Vue related packages does not work for the update process.

### Issues
- relates #7951