### PR TITLE
refactor(webapp): degroup sass packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -185,10 +185,6 @@ updates:
       applies-to: version-updates
       patterns:
         - "remark*"
-    sass:
-      applies-to: version-updates
-      patterns:
-        - "sass*"
     storybook:
       applies-to: version-updates
       patterns:


### PR DESCRIPTION
## 🍰 Pullrequest
In the dependabot configuration the grouping of all SASS related packages does not work for the update process.

### Issues
- relates #7958