### PR TITLE
fix(workflow): remove the requirement for non-existent job in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ jobs:
   github_tag:
     name: Tag latest version on Github
     runs-on: ubuntu-latest
-    needs: [upload_to_dockerhub]
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

remove the requirement for non-existent job in publish workflow.

Motivation: The workflow fails on master still, since it has no run-condition
See https://github.com/Ocelot-Social-Community/Ocelot-Social/actions/runs/13617378876

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
