### PR TITLE
feat(other): release script also update helmchart versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "docs:dev": "NODE_OPTIONS=--openssl-legacy-provider vuepress dev .",
     "cypress:run": "cypress run --e2e --browser electron --config-file ./cypress/cypress.config.js",
     "cypress:open": "cypress open --e2e --browser electron --config-file ./cypress/cypress.config.js",
-    "release": "yarn version --no-git-tag-version --no-commit-hooks --no-commit && auto-changelog --latest-version $(node -p -e \"require('./package.json').version\") && cd backend && yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $(node -p -e \"require('./../package.json').version\") && cd ../frontend && yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $(node -p -e \"require('./../package.json').version\") && cd ../webapp && yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $(node -p -e \"require('./../package.json').version\") && cd ../webapp/maintenance/source && yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $(node -p -e \"require('./../../../package.json').version\")"
+    "release": "./scripts/release.sh"
   },
   "devDependencies": {
     "@babel/core": "^7.26.9",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# base setup
+SCRIPT_PATH=$(realpath $0)
+SCRIPT_DIR=$(dirname $SCRIPT_PATH)
+ROOT_DIR=$SCRIPT_DIR/..
+
+# Update Version
+cd $ROOT_DIR
+yarn version --no-git-tag-version --no-commit-hooks --no-commit
+VERSION_NEW=$(node -p -e "require('$ROOT_DIR/package.json').version")
+
+## packages
+cd backend
+yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $VERSION_NEW
+cd $ROOT_DIR/frontend
+yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $VERSION_NEW
+cd $ROOT_DIR/webapp
+yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $VERSION_NEW
+cd $ROOT_DIR/webapp/maintenance/source
+yarn version --no-git-tag-version --no-commit-hooks --no-commit --new-version $VERSION_NEW
+
+## helm
+sed -i -e 's/appVersion: ".*"/appVersion: "'"$VERSION_NEW"'"/g' $ROOT_DIR/deployment/helm/charts/ocelot-neo4j/Chart.yaml
+sed -i -e 's/appVersion: ".*"/appVersion: "'"$VERSION_NEW"'"/g' $ROOT_DIR/deployment/helm/charts/ocelot-social/Chart.yaml
+
+# generate changelog
+cd $ROOT_DIR
+yarn run auto-changelog --latest-version $VERSION_NEW


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

release script also update helmchart versions

To have congruence a release also updates the helmchart version. This utilizes sed to replace the coresponding string. The `sed` command is not present on windows and could prevent a windows user to use the release functionality out of the box.

The release functionality is also externalized into its own script `scripts/release.sh`.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
