### PR TITLE
feat(backend): observe posts

### DIFF
--- a/backend/src/graphql/posts.ts
+++ b/backend/src/graphql/posts.ts
@@ -47,6 +47,7 @@ export const createPostMutation = () => {
           lat
         }
         observedByMe
+        observingUsersCount
       }
     }
   `

--- a/backend/src/graphql/posts.ts
+++ b/backend/src/graphql/posts.ts
@@ -46,7 +46,7 @@ export const createPostMutation = () => {
           lng
           lat
         }
-        observedByMe
+        isObservedByMe
         observingUsersCount
       }
     }

--- a/backend/src/graphql/posts.ts
+++ b/backend/src/graphql/posts.ts
@@ -46,6 +46,7 @@ export const createPostMutation = () => {
           lng
           lat
         }
+        observedByMe
       }
     }
   `

--- a/backend/src/middleware/permissionsMiddleware.ts
+++ b/backend/src/middleware/permissionsMiddleware.ts
@@ -465,6 +465,7 @@ export default shield(
       CreateRoom: isAuthenticated,
       CreateMessage: isAuthenticated,
       MarkMessagesAsSeen: isAuthenticated,
+      toggleObservePost: isAuthenticated,
     },
     User: {
       email: or(isMyOwn, isAdmin),

--- a/backend/src/middleware/slugifyMiddleware.spec.ts
+++ b/backend/src/middleware/slugifyMiddleware.spec.ts
@@ -21,6 +21,9 @@ const { server } = createServer({
       driver,
       neode,
       user: authenticatedUser,
+      cypherParams: {
+        currentUserId: authenticatedUser ? authenticatedUser.id : null,
+      },
     }
   },
 })

--- a/backend/src/schema/resolvers/comments.ts
+++ b/backend/src/schema/resolvers/comments.ts
@@ -25,6 +25,12 @@ export default {
             SET comment.createdAt = toString(datetime())
             SET comment.updatedAt = toString(datetime())
             MERGE (post)<-[:COMMENTS]-(comment)<-[:WROTE]-(author)
+            WITH post, author, comment
+            MERGE (post)<-[obs:OBSERVES]-(author)
+            ON CREATE SET
+              obs.active = true,
+              obs.createdAt = toString(datetime()),
+              obs.updatedAt = toString(datetime())      
             RETURN comment
           `,
           { userId: user.id, postId, params },

--- a/backend/src/schema/resolvers/observePosts.spec.ts
+++ b/backend/src/schema/resolvers/observePosts.spec.ts
@@ -29,7 +29,7 @@ const createCommentMutation = gql`
 const postQuery = gql`
   query Post($id: ID) {
     Post(id: $id) {
-      observedByMe
+      isObservedByMe
       observingUsersCount
     }
   }
@@ -88,7 +88,7 @@ describe('observing posts', () => {
       ).resolves.toMatchObject({
         data: {
           CreatePost: {
-            observedByMe: true,
+            isObservedByMe: true,
             observingUsersCount: 1,
           },
         },
@@ -112,7 +112,7 @@ describe('observing posts', () => {
         data: {
           Post: [
             {
-              observedByMe: false,
+              isObservedByMe: false,
               observingUsersCount: 1,
             },
           ],
@@ -139,7 +139,7 @@ describe('observing posts', () => {
         data: {
           Post: [
             {
-              observedByMe: true,
+              isObservedByMe: true,
               observingUsersCount: 2,
             },
           ],
@@ -157,7 +157,7 @@ describe('observing posts', () => {
     const toggleObservePostMutation = gql`
       mutation ($id: ID!, $value: Boolean!) {
         toggleObservePost(id: $id, value: $value) {
-          observedByMe
+          isObservedByMe
           observingUsersCount
         }
       }
@@ -176,7 +176,7 @@ describe('observing posts', () => {
         ).resolves.toMatchObject({
           data: {
             toggleObservePost: {
-              observedByMe: false,
+              isObservedByMe: false,
               observingUsersCount: 1,
             },
           },
@@ -205,7 +205,7 @@ describe('observing posts', () => {
           data: {
             Post: [
               {
-                observedByMe: false,
+                isObservedByMe: false,
                 observingUsersCount: 1,
               },
             ],
@@ -228,7 +228,7 @@ describe('observing posts', () => {
         ).resolves.toMatchObject({
           data: {
             toggleObservePost: {
-              observedByMe: true,
+              isObservedByMe: true,
               observingUsersCount: 2,
             },
           },

--- a/backend/src/schema/resolvers/observePosts.spec.ts
+++ b/backend/src/schema/resolvers/observePosts.spec.ts
@@ -129,7 +129,7 @@ describe('observing posts', () => {
 
       await expect(
         query({
-          query: 'query Post($id: ID) { Post(id: $id) { observedByMe } }',
+          query: postQuery,
           variables: { id: 'p2' },
         }),
       ).resolves.toMatchObject({

--- a/backend/src/schema/resolvers/observePosts.spec.ts
+++ b/backend/src/schema/resolvers/observePosts.spec.ts
@@ -1,0 +1,74 @@
+import { createTestClient } from 'apollo-server-testing'
+import Factory, { cleanDatabase } from '../../db/factories'
+import { getNeode, getDriver } from '../../db/neo4j'
+import createServer from '../../server'
+
+import { createPostMutation } from '../../graphql/posts'
+import CONFIG from '../../config'
+
+CONFIG.CATEGORIES_ACTIVE = false
+
+const driver = getDriver()
+const neode = getNeode()
+
+// let query
+let mutate
+let authenticatedUser
+let user
+
+beforeAll(async () => {
+  await cleanDatabase()
+
+  const { server } = createServer({
+    context: () => {
+      return {
+        driver,
+        neode,
+        user: authenticatedUser,
+        cypherParams: {
+          currentUserId: authenticatedUser ? authenticatedUser.id : null,
+        },
+      }
+    },
+  })
+  // query = createTestClient(server).query
+  mutate = createTestClient(server).mutate
+})
+
+afterAll(async () => {
+  await cleanDatabase()
+  driver.close()
+})
+
+describe('observing posts', () => {
+  beforeAll(async () => {
+    user = await Factory.build('user', {
+      id: 'user',
+      name: 'User',
+      about: 'I am a user',
+    })
+    authenticatedUser = await user.toJson()
+  })
+
+  describe('after creating the post', () => {
+    it('has the author of the post observing the post', async () => {
+      await expect(
+        mutate({
+          mutation: createPostMutation(),
+          variables: {
+            id: 'p2',
+            title: 'A post the author should observe',
+            content: 'The author of this post is expected to observe the post',
+          },
+        }),
+      ).resolves.toMatchObject({
+        data: {
+          CreatePost: {
+            observedByMe: true,
+          },
+        },
+        errors: undefined,
+      })
+    })
+  })
+})

--- a/backend/src/schema/resolvers/observePosts.spec.ts
+++ b/backend/src/schema/resolvers/observePosts.spec.ts
@@ -30,6 +30,7 @@ const postQuery = gql`
   query Post($id: ID) {
     Post(id: $id) {
       observedByMe
+      observingUsersCount
     }
   }
 `
@@ -88,6 +89,7 @@ describe('observing posts', () => {
         data: {
           CreatePost: {
             observedByMe: true,
+            observingUsersCount: 1,
           },
         },
         errors: undefined,
@@ -111,6 +113,7 @@ describe('observing posts', () => {
           Post: [
             {
               observedByMe: false,
+              observingUsersCount: 1,
             },
           ],
         },
@@ -137,6 +140,7 @@ describe('observing posts', () => {
           Post: [
             {
               observedByMe: true,
+              observingUsersCount: 2,
             },
           ],
         },
@@ -154,6 +158,7 @@ describe('observing posts', () => {
       mutation ($id: ID!, $value: Boolean!) {
         toggleObservePost(id: $id, value: $value) {
           observedByMe
+          observingUsersCount
         }
       }
     `
@@ -172,6 +177,7 @@ describe('observing posts', () => {
           data: {
             toggleObservePost: {
               observedByMe: false,
+              observingUsersCount: 1,
             },
           },
           errors: undefined,
@@ -200,6 +206,7 @@ describe('observing posts', () => {
             Post: [
               {
                 observedByMe: false,
+                observingUsersCount: 1,
               },
             ],
           },
@@ -222,6 +229,7 @@ describe('observing posts', () => {
           data: {
             toggleObservePost: {
               observedByMe: true,
+              observingUsersCount: 2,
             },
           },
           errors: undefined,

--- a/backend/src/schema/resolvers/posts.spec.ts
+++ b/backend/src/schema/resolvers/posts.spec.ts
@@ -28,6 +28,9 @@ beforeAll(async () => {
         driver,
         neode,
         user: authenticatedUser,
+        cypherParams: {
+          currentUserId: authenticatedUser ? authenticatedUser.id : null,
+        },
       }
     },
   })

--- a/backend/src/schema/resolvers/posts.ts
+++ b/backend/src/schema/resolvers/posts.ts
@@ -485,6 +485,7 @@ export default {
         shoutedCount:
           '<-[:SHOUTED]-(related:User) WHERE NOT related.deleted = true AND NOT related.disabled = true',
         emotionsCount: '<-[related:EMOTED]-(:User)',
+        observingUsersCount: '<-[related:OBSERVES]-(:User) WHERE related.active = true',
       },
       boolean: {
         shoutedByCurrentUser:

--- a/backend/src/schema/resolvers/posts.ts
+++ b/backend/src/schema/resolvers/posts.ts
@@ -492,7 +492,7 @@ export default {
           'MATCH(this)<-[:SHOUTED]-(related:User {id: $cypherParams.currentUserId}) RETURN COUNT(related) >= 1',
         viewedTeaserByCurrentUser:
           'MATCH (this)<-[:VIEWED_TEASER]-(u:User {id: $cypherParams.currentUserId}) RETURN COUNT(u) >= 1',
-        observedByMe:
+        isObservedByMe:
           'MATCH (this)<-[obs:OBSERVES]-(related:User {id: $cypherParams.currentUserId}) WHERE obs.active = true RETURN COUNT(related) >= 1',
       },
     }),

--- a/backend/src/schema/resolvers/posts.ts
+++ b/backend/src/schema/resolvers/posts.ts
@@ -144,6 +144,10 @@ export default {
             WITH post
             MATCH (author:User {id: $userId})
             MERGE (post)<-[:WROTE]-(author)
+            MERGE (post)<-[obs:OBSERVES]-(author)
+            SET obs.active = true
+            SET obs.createdAt = toString(datetime())
+            SET obs.updatedAt = toString(datetime())
             ${categoriesCypher}
             ${groupCypher}
             RETURN post {.*, postType: [l IN labels(post) WHERE NOT l = 'Post'] }
@@ -458,6 +462,8 @@ export default {
           'MATCH(this)<-[:SHOUTED]-(related:User {id: $cypherParams.currentUserId}) RETURN COUNT(related) >= 1',
         viewedTeaserByCurrentUser:
           'MATCH (this)<-[:VIEWED_TEASER]-(u:User {id: $cypherParams.currentUserId}) RETURN COUNT(u) >= 1',
+        observedByMe:
+          'MATCH (this)<-[obs:OBSERVES]-(related:User {id: $cypherParams.currentUserId}) WHERE obs.active = true RETURN COUNT(related) >= 1',
       },
     }),
     relatedContributions: async (parent, params, context, resolveInfo) => {

--- a/backend/src/schema/resolvers/postsInGroups.spec.ts
+++ b/backend/src/schema/resolvers/postsInGroups.spec.ts
@@ -52,6 +52,9 @@ beforeAll(async () => {
         driver,
         neode,
         user: authenticatedUser,
+        cypherParams: {
+          currentUserId: authenticatedUser ? authenticatedUser.id : null,
+        },
       }
     },
   })

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -190,7 +190,9 @@ type Post {
   observedByMe: Boolean!
     @cypher(
       statement: "MATCH (this)<-[obs:OBSERVES]-(u:User {id: $cypherParams.currentUserId}) WHERE obs.active = true RETURN COUNT(u) >= 1"
-    )
+  )
+  observingUsersCount: Int!
+    @cypher(statement: "MATCH (this)<-[obs:OBSERVES]-(u:User) WHERE obs.active = true RETURN COUNT(DISTINCT u)")  
 }
 
 input _PostInput {

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -187,7 +187,7 @@ type Post {
   eventEnd: String
   eventIsOnline: Boolean
 
-  observedByMe: Boolean!
+  isObservedByMe: Boolean!
     @cypher(
       statement: "MATCH (this)<-[obs:OBSERVES]-(u:User {id: $cypherParams.currentUserId}) WHERE obs.active = true RETURN COUNT(u) >= 1"
   )

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -244,6 +244,8 @@ type Mutation {
   shout(id: ID!, type: ShoutTypeEnum): Boolean!
   # Unshout the given Type and ID
   unshout(id: ID!, type: ShoutTypeEnum): Boolean!
+
+  toggleObservePost(id: ID!, value: Boolean!): Post!
 }
 
 type Query {

--- a/backend/src/schema/types/type/Post.gql
+++ b/backend/src/schema/types/type/Post.gql
@@ -186,6 +186,11 @@ type Post {
   eventStart: String
   eventEnd: String
   eventIsOnline: Boolean
+
+  observedByMe: Boolean!
+    @cypher(
+      statement: "MATCH (this)<-[obs:OBSERVES]-(u:User {id: $cypherParams.currentUserId}) WHERE obs.active = true RETURN COUNT(u) >= 1"
+    )
 }
 
 input _PostInput {

--- a/webapp/graphql/Fragments.js
+++ b/webapp/graphql/Fragments.js
@@ -67,6 +67,7 @@ export const postFragment = gql`
     }
     pinnedAt
     pinned
+    observedByMe
   }
 `
 

--- a/webapp/graphql/Fragments.js
+++ b/webapp/graphql/Fragments.js
@@ -67,7 +67,7 @@ export const postFragment = gql`
     }
     pinnedAt
     pinned
-    observedByMe
+    isObservedByMe
     observingUsersCount
   }
 `

--- a/webapp/graphql/Fragments.js
+++ b/webapp/graphql/Fragments.js
@@ -68,6 +68,7 @@ export const postFragment = gql`
     pinnedAt
     pinned
     observedByMe
+    observingUsersCount
   }
 `
 

--- a/webapp/graphql/PostMutations.js
+++ b/webapp/graphql/PostMutations.js
@@ -175,5 +175,12 @@ export default () => {
         }
       }
     `,
+    toggleObservePost: gql`
+      mutation ($id: ID!, $value: Boolean!) {
+        toggleObservePost(id: $id, value: $value) {
+          observedByMe
+        }
+      }
+    `,
   }
 }

--- a/webapp/graphql/PostMutations.js
+++ b/webapp/graphql/PostMutations.js
@@ -179,6 +179,7 @@ export default () => {
       mutation ($id: ID!, $value: Boolean!) {
         toggleObservePost(id: $id, value: $value) {
           observedByMe
+          observingUsersCount
         }
       }
     `,

--- a/webapp/graphql/PostMutations.js
+++ b/webapp/graphql/PostMutations.js
@@ -178,7 +178,7 @@ export default () => {
     toggleObservePost: gql`
       mutation ($id: ID!, $value: Boolean!) {
         toggleObservePost(id: $id, value: $value) {
-          observedByMe
+          isObservedByMe
           observingUsersCount
         }
       }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
We want to have the possibility to observe posts:
 * a newly created post is always observed by the author
 * the first comment to a post makes the commenting user observing the post
 * provides the `toggleObservePost` mutation to switch observation on and off
 * unit tests that show the correct behavior, e.g. commenting a post that I do not observe for  a second time, does not alter the state of observation
 * adds `observedByMe` property to the Post type
 * provides a blueprint for the mutation in the webapp

### Issues
- relates #8280 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
