### PR TITLE
feat(webapp): track online status

### DIFF
--- a/backend/src/middleware/permissionsMiddleware.ts
+++ b/backend/src/middleware/permissionsMiddleware.ts
@@ -462,6 +462,7 @@ export default shield(
       switchUserRole: isAdmin,
       markTeaserAsViewed: allow,
       saveCategorySettings: isAuthenticated,
+      updateOnlineStatus: isAuthenticated,
       CreateRoom: isAuthenticated,
       CreateMessage: isAuthenticated,
       MarkMessagesAsSeen: isAuthenticated,

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -54,6 +54,7 @@ export default {
   },
   invitedBy: { type: 'relationship', relationship: 'INVITED', target: 'User', direction: 'in' },
   lastActiveAt: { type: 'string', isoDate: true },
+  lastOnlineStatus: { type: 'string' },
   createdAt: { type: 'string', isoDate: true, default: () => new Date().toISOString() },
   updatedAt: {
     type: 'string',

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -55,6 +55,7 @@ export default {
   invitedBy: { type: 'relationship', relationship: 'INVITED', target: 'User', direction: 'in' },
   lastActiveAt: { type: 'string', isoDate: true },
   lastOnlineStatus: { type: 'string' },
+  awaySince: { type: 'string', isoDate: true },
   createdAt: { type: 'string', isoDate: true, default: () => new Date().toISOString() },
   updatedAt: {
     type: 'string',

--- a/backend/src/schema/resolvers/users.ts
+++ b/backend/src/schema/resolvers/users.ts
@@ -314,6 +314,26 @@ export default {
         session.close()
       }
     },
+    updateOnlineStatus: async (object, args, context, resolveInfo) => {
+      const { status } = args
+      const {
+        user: { id },
+      } = context
+
+      // Last Online Time is saved as `lastActiveAt`
+      const session = context.driver.session()
+      await session.writeTransaction((transaction) => {
+        return transaction.run(
+          `
+          MATCH (user:User {id: $id})
+            SET user.lastOnlineStatus = $status
+        `,
+          { id, status },
+        )
+      })
+
+      return true
+    },
   },
   User: {
     email: async (parent, params, context, resolveInfo) => {

--- a/backend/src/schema/types/enum/OnlineStatus.gql
+++ b/backend/src/schema/types/enum/OnlineStatus.gql
@@ -1,0 +1,4 @@
+enum OnlineStatus {
+  online
+  away
+}

--- a/backend/src/schema/types/type/User.gql
+++ b/backend/src/schema/types/type/User.gql
@@ -224,6 +224,8 @@ type Mutation {
   switchUserRole(role: UserRole!, id: ID!): User
 
   saveCategorySettings(activeCategories: [String]): Boolean
+  
+  updateOnlineStatus(status: OnlineStatus!): Boolean!
 
   requestPasswordReset(email: String!): Boolean!
   resetPassword(email: String!, nonce: String!, newPassword: String!): Boolean!

--- a/webapp/graphql/updateOnlineStatus.js
+++ b/webapp/graphql/updateOnlineStatus.js
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag'
+
+export const updateOnlineStatus = gql`
+  mutation ($status: OnlineStatus!) {
+    updateOnlineStatus(status: $status)
+  }
+`

--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -130,6 +130,7 @@ export default {
     { src: '~/plugins/vue-observe-visibility.js', ssr: false },
     { src: '~/plugins/v-mapbox.js', mode: 'client' },
     { src: '~/plugins/vue-advanced-chat.js', mode: 'client' },
+    { src: '~/plugins/onlineStatus.js', mode: 'client' },
   ],
 
   router: {

--- a/webapp/plugins/onlineStatus.js
+++ b/webapp/plugins/onlineStatus.js
@@ -1,0 +1,30 @@
+import { updateOnlineStatus as updateOnlineStatusMutation } from '~/graphql/updateOnlineStatus.js'
+
+let _app = null
+
+const updateOnlineStatus = async () => {
+  if (!_app.store.getters['auth/isAuthenticated']) {
+    return
+  }
+
+  const status = document.hidden ? 'away' : 'online'
+
+  const client = _app.apolloProvider.defaultClient
+
+  await client.mutate({
+    mutation: updateOnlineStatusMutation,
+    variables: { status },
+  })
+
+  // TODO
+  console.log(`call home as ${status} at ${new Date().toUTCString()}`)
+}
+
+export default ({ app }) => {
+  _app = app
+  if (process.client) {
+    window.addEventListener('visibilitychange', updateOnlineStatus)
+    setInterval(updateOnlineStatus, 30000)
+    updateOnlineStatus()
+  }
+}

--- a/webapp/plugins/onlineStatus.js
+++ b/webapp/plugins/onlineStatus.js
@@ -15,9 +15,6 @@ const updateOnlineStatus = async () => {
     mutation: updateOnlineStatusMutation,
     variables: { status },
   })
-
-  // TODO
-  console.log(`call home as ${status} at ${new Date().toUTCString()}`)
 }
 
 export default ({ app }) => {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Regularly update online status of user.
This saves a timestamp on the user as `lastActiveAt` and a status `lastOnlineStatus` which can either be `online` or àway`.

The combination of the `lastActiveAt` timestamp and the `lastOnlineStatus` allows to determine if the user is reachable via notification or an email is the way to go.

![image](https://github.com/user-attachments/assets/3cbfa5c4-814d-41bf-bb86-f0748f2c89ee)
In the screenshot you can see a call as `away` when the tab is switched and a call as `online` when the tab is activated again. The next entry is the regular ping every 30 seconds.

The `lastActiveAt` timestamp is set whenever the token of the user is seen querying the backend. A mechanic, which was already in place.

The Database looks like this:
![image](https://github.com/user-attachments/assets/9df4109b-01bd-4a51-b5f3-69424d4597d8)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- contributes to https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/8290

### Todo
<!-- In case some parts are still missing, list them here. -->
- [x] remove console.log
