### PR TITLE
[WIP] discussion(backend): websocket online status

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -79,7 +79,6 @@ const createServer = (options?) => {
         console.log( 'onDisconnect', webSocket.identifier)
         delete webSocketList[webSocket.identifier]
         console.log('connected sockets: ', Object.keys(webSocketList).length)
-        // console.log('onDisconnect', webSocket, webSocket.rawHeaders)
       },
     },
     debug: !!CONFIG.DEBUG,


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

As of our discussion about a more precises online status information I did a small test to determine if we can track the online status over a graphql websocket connection

Long story short: it is possible with some uncertainties
![image](https://github.com/user-attachments/assets/315de420-1b7b-4c37-9531-45ddcdc034d3)

I use the existing webocket on our subscriptions. They are connected whenever a user is online.
You could also funnel all queries and mutations over such a socket using this: https://the-guild.dev/graphql/ws/get-started

Problem 1: There is no easy to obtain list of websockets actively listening
Problem 2: When creating such a list the jwt is not sufficient, since its shared between tabs, a random number has to be added

It is unclear if this would work in every environments, but it is certainly an option to find out if a user is online.
Browsers with no websocket support would be permanently offline? Can that also happen behind firewalls etc? 

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
