### PR TITLE
refactor(backend): lint - import/no-deprecated

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -41,7 +41,7 @@ module.exports = {
     ],
     // import
     'import/export': 'error',
-    // 'import/no-deprecated': 'error',
+    'import/no-deprecated': 'error',
     'import/no-empty-named-blocks': 'error',
     'import/no-extraneous-dependencies': 'error',
     'import/no-mutable-exports': 'error',
@@ -114,7 +114,7 @@ module.exports = {
     'n/no-callback-literal': 'error',
     // 'n/no-deprecated-api': 'error', // part of n/recommended
     // 'n/no-exports-assign': 'error', // part of n/recommended
-    'n/no-extraneous-import': 'off', // TODO // part of n/recommended
+    'n/no-extraneous-import': 'off', // same as import/no-extraneous-dependencies // part of n/recommended
     // 'n/no-extraneous-require': 'error', // part of n/recommended
     'n/no-hide-core-modules': 'error',
     'n/no-missing-import': 'off', // not compatible with typescript // part of n/recommended

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,7 +43,6 @@
     "babel-jest": "~29.7.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "bcryptjs": "~2.4.3",
-    "body-parser": "^1.20.3",
     "cheerio": "~1.0.0",
     "cors": "~2.8.5",
     "cross-env": "~7.0.3",

--- a/backend/src/db/migrations-examples/20200123150105-merge_duplicate_user_accounts.ts
+++ b/backend/src/db/migrations-examples/20200123150105-merge_duplicate_user_accounts.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-deprecated */
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable promise/prefer-await-to-callbacks */
 import { throwError, concat } from 'rxjs'

--- a/backend/src/db/migrations-examples/20200123150110-merge_duplicate_location_nodes.ts
+++ b/backend/src/db/migrations-examples/20200123150110-merge_duplicate_location_nodes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-deprecated */
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable promise/prefer-await-to-callbacks */
 import { throwError, concat } from 'rxjs'

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import bodyParser from 'body-parser'
 import express from 'express'
 import { RedisPubSub } from 'graphql-redis-subscriptions'
 import { PubSub } from 'graphql-subscriptions'
+
 import { graphqlUploadExpress } from 'graphql-upload'
 import helmet from 'helmet'
 import Redis from 'ioredis'
@@ -95,8 +96,8 @@ const createServer = (options?) => {
     ) as any,
   )
   app.use(express.static('public'))
-  app.use(bodyParser.json({ limit: '10mb' }) as any)
-  app.use(bodyParser.urlencoded({ limit: '10mb', extended: true }) as any)
+  app.use(express.json({ limit: '10mb' }) as any)
+  app.use(express.urlencoded({ limit: '10mb', extended: true }) as any)
   app.use(graphqlUploadExpress())
   server.applyMiddleware({ app, path: '/' })
   const httpServer = http.createServer(app)

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -3174,7 +3174,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-body-parser@1.20.3, body-parser@^1.18.3, body-parser@^1.20.3:
+body-parser@1.20.3, body-parser@^1.18.3:
   version "1.20.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.3.tgz#1953431221c6fb5cd63c4b36d53fab0928e548c6"
   integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

lint - import/no-deprecated

As of `express >= 4.16.0` bodyparser is no longer needed https://stackoverflow.com/a/59892173

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
