### PR TITLE
fix(webapp): refine group muting locales

### DIFF
--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -485,8 +485,8 @@
     "categoriesTitle": "Themen der Gruppe",
     "changeMemberRole": "Die Rolle wurde auf „{role}“ geändert!",
     "contentMenu": {
-      "muteGroup": "Gruppe stummschalten",
-      "unmuteGroup": "Gruppe nicht mehr stummschalten",
+      "muteGroup": "Stummschalten",
+      "unmuteGroup": "Nicht stummschalten",
       "visitGroupPage": "Gruppe anzeigen"
     },
     "createNewGroup": {
@@ -562,8 +562,8 @@
       "hidden": "Geheim — Gruppe (auch der Name) komplett unsichtbar",
       "public": "Öffentlich — Gruppe und alle Beiträge für registrierte Nutzer sichtbar"
     },
-    "unmute": "Gruppe nicht mehr stummschalten",
-    "unmuted": "Gruppe nicht mehr stummgeschaltet",
+    "unmute": "Nicht stummschalten",
+    "unmuted": "Gruppe nicht stummgeschaltet",
     "update": "Änderung speichern",
     "updatedGroup": "Die Gruppendaten wurden geändert!"
   },

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -563,7 +563,7 @@
       "public": "Öffentlich — Gruppe und alle Beiträge für registrierte Nutzer sichtbar"
     },
     "unmute": "Nicht stummschalten",
-    "unmuted": "Gruppe nicht stummgeschaltet",
+    "unmuted": "Gruppe nicht mehr stummgeschaltet",
     "update": "Änderung speichern",
     "updatedGroup": "Die Gruppendaten wurden geändert!"
   },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Refine group muting locales.

Some locales are to long to fit nicely into the button.

<img width="299" alt="Bildschirmfoto 2025-04-12 um 10 10 50" src="https://github.com/user-attachments/assets/ae3a83ed-b8e9-4691-a51d-e3e6dde18f55" />

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->

- None

### Todo
<!-- In case some parts are still missing, list them here. -->

- [x] shorten locales to fit nicely into the button

<img width="304" alt="Bildschirmfoto 2025-04-12 um 10 33 07" src="https://github.com/user-attachments/assets/81ee8453-f732-4811-bcb7-7ab02fac9221" />
