### PR TITLE
fix(docu): remove required but missing `frontend/.env`

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,6 @@ $ cp .env.template .env
 # in folder backend/
 $ cp .env.template .env
 
-# in folder frontend/
-$ cp .env.template .env
-```
-
 For Development:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,6 @@ services:
       # Application only envs
       #- HOST=0.0.0.0 # This is nuxt specific, alternative value is HOST=webapp
       #- GRAPHQL_URI=http://backend:4000
-    env_file:
-      - ./frontend/.env
 
   backend:
     image: ghcr.io/ocelot-social-community/ocelot-social/backend:${OCELOT_VERSION:-latest}


### PR DESCRIPTION
When you follow the documentation, your `docker compose up` will fail because a `.env` file is referenced that doesn't exist yet. The documentation mentions a `.env.template` file, so I guess that one was deleted but the documentation not updated.
