### PR TITLE
chore(frontend): run npm install

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ocelot-social-frontend",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ocelot-social-frontend",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@intlify/unplugin-vue-i18n": "^2.0.0",


### PR DESCRIPTION
Just running `npm install` leads to local changes. Why are they not checked in? I'm using the specified node version from `/.tool-versions` in the root directory.
