### PR TITLE
fix(webapp): fixed padding for mobile in basic layout

### DIFF
--- a/webapp/layouts/blank.vue
+++ b/webapp/layouts/blank.vue
@@ -17,11 +17,11 @@ export default {
 </script>
 
 <style lang="scss">
-.ds-container > div {
+.layout-blank > .ds-container > div {
   padding: 5rem 2rem;
 }
 @media only screen and (max-width: 500px) {
-  .ds-container > div {
+  .layout-blank > .ds-container > div {
     padding: 3rem 0;
   }
 }

--- a/webapp/layouts/blank.vue
+++ b/webapp/layouts/blank.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="layout-blank">
     <ds-container>
-      <div style="padding: 5rem 2rem">
+      <div>
         <nuxt />
       </div>
     </ds-container>
@@ -15,3 +15,14 @@ export default {
   mixins: [seo],
 }
 </script>
+
+<style lang="scss">
+.ds-container > div {
+  padding: 5rem 2rem;
+}
+@media only screen and (max-width: 500px) {
+  .ds-container > div {
+    padding: 3rem 0;
+  }
+}
+</style>


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
the basic layout "blank" contained a hardcoded style attribute with a padding, which was a way too big for mobile.
This PR fixes the issue.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] Fix
