### PR TITLE
refactor(other): cypress: simplify cucumber preprocessor imports and some linting

### DIFF
--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -44,7 +44,7 @@ module.exports = defineConfig({
     chromeWebSecurity: false,
     baseUrl: 'http://localhost:3000',
     specPattern: '**/*.feature',
-    supportFile: false,
+    supportFile: 'cypress/support/e2e.js',
     retries:  0,
     video: false,
     viewportHeight: 720,

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -44,7 +44,7 @@ module.exports = defineConfig({
     chromeWebSecurity: false,
     baseUrl: 'http://localhost:3000',
     specPattern: '**/*.feature',
-    supportFile: 'cypress/support/e2e.js',
+    supportFile: false,
     retries:  0,
     video: false,
     viewportHeight: 720,

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,1 +1,0 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,1 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'

--- a/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_contains_goal_{string}_and_progress_{string}.js
+++ b/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_contains_goal_{string}_and_progress_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the donation info contains goal {string} and progress {string}', (goal, progress) => {
   cy.get('.top-info-bar')

--- a/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_contains_goal_{string}_and_progress_{string}.js
+++ b/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_contains_goal_{string}_and_progress_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the donation info contains goal {string} and progress {string}', (goal, progress) => {
   cy.get('.top-info-bar')

--- a/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_contains_goal_{string}_and_progress_{string}.js
+++ b/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_contains_goal_{string}_and_progress_{string}.js
@@ -1,8 +1,8 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("the donation info contains goal {string} and progress {string}", (goal, progress) => {
+defineStep('the donation info contains goal {string} and progress {string}', (goal, progress) => {
   cy.get('.top-info-bar')
     .should('contain', goal)
   cy.get('.top-info-bar')
     .should('contain', progress)
-});
+})

--- a/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_is_{string}.js
+++ b/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_is_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the donation info is {string}', (visibility) => {
   cy.get('.top-info-bar')

--- a/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_is_{string}.js
+++ b/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_is_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the donation info is {string}', (visibility) => {
   cy.get('.top-info-bar')

--- a/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_is_{string}.js
+++ b/cypress/support/step_definitions/Admin.DonationInfo/the_donation_info_is_{string}.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the donation info is {string}", (visibility) => {
+defineStep('the donation info is {string}', (visibility) => {
   cy.get('.top-info-bar')
     .should(visibility === 'visible' ? 'exist' : 'not.exist')
 })

--- a/cypress/support/step_definitions/Admin.PinPost/I_open_the_content_menu_of_post_{string}.js
+++ b/cypress/support/step_definitions/Admin.PinPost/I_open_the_content_menu_of_post_{string}.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I open the content menu of post {string}", (title) => {
+defineStep('I open the content menu of post {string}', (title) => {
   cy.contains('.post-teaser', title)
     .find('.content-menu .base-button')
     .click()

--- a/cypress/support/step_definitions/Admin.PinPost/I_open_the_content_menu_of_post_{string}.js
+++ b/cypress/support/step_definitions/Admin.PinPost/I_open_the_content_menu_of_post_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I open the content menu of post {string}', (title) => {
   cy.contains('.post-teaser', title)

--- a/cypress/support/step_definitions/Admin.PinPost/I_open_the_content_menu_of_post_{string}.js
+++ b/cypress/support/step_definitions/Admin.PinPost/I_open_the_content_menu_of_post_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I open the content menu of post {string}', (title) => {
   cy.contains('.post-teaser', title)

--- a/cypress/support/step_definitions/Admin.PinPost/the_post_with_title_{string}_has_a_ribbon_for_pinned_posts.js
+++ b/cypress/support/step_definitions/Admin.PinPost/the_post_with_title_{string}_has_a_ribbon_for_pinned_posts.js
@@ -1,9 +1,9 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the post with title {string} has a ribbon for pinned posts", (title) => {
-  cy.get(".post-teaser").contains(title)
+defineStep('the post with title {string} has a ribbon for pinned posts', (title) => {
+  cy.get('.post-teaser').contains(title)
     .parent()
     .parent()
-    .find(".ribbon.--pinned")
-    .should("contain", "Announcement")
+    .find('.ribbon.--pinned')
+    .should('contain', 'Announcement')
 })

--- a/cypress/support/step_definitions/Admin.PinPost/the_post_with_title_{string}_has_a_ribbon_for_pinned_posts.js
+++ b/cypress/support/step_definitions/Admin.PinPost/the_post_with_title_{string}_has_a_ribbon_for_pinned_posts.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post with title {string} has a ribbon for pinned posts', (title) => {
   cy.get('.post-teaser').contains(title)

--- a/cypress/support/step_definitions/Admin.PinPost/the_post_with_title_{string}_has_a_ribbon_for_pinned_posts.js
+++ b/cypress/support/step_definitions/Admin.PinPost/the_post_with_title_{string}_has_a_ribbon_for_pinned_posts.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post with title {string} has a ribbon for pinned posts', (title) => {
   cy.get('.post-teaser').contains(title)

--- a/cypress/support/step_definitions/Admin.PinPost/there_is_no_button_to_pin_a_post.js
+++ b/cypress/support/step_definitions/Admin.PinPost/there_is_no_button_to_pin_a_post.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('there is no button to pin a post', () => {
   cy.get('a.ds-menu-item-link')

--- a/cypress/support/step_definitions/Admin.PinPost/there_is_no_button_to_pin_a_post.js
+++ b/cypress/support/step_definitions/Admin.PinPost/there_is_no_button_to_pin_a_post.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('there is no button to pin a post', () => {
   cy.get('a.ds-menu-item-link')

--- a/cypress/support/step_definitions/Admin.PinPost/there_is_no_button_to_pin_a_post.js
+++ b/cypress/support/step_definitions/Admin.PinPost/there_is_no_button_to_pin_a_post.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("there is no button to pin a post", () => {
-  cy.get("a.ds-menu-item-link")
-    .should('contain', "Report Post") // sanity check
-    .should('not.contain', "Pin post")
+defineStep('there is no button to pin a post', () => {
+  cy.get('a.ds-menu-item-link')
+    .should('contain', 'Report Post') // sanity check
+    .should('not.contain', 'Pin post')
 })

--- a/cypress/support/step_definitions/Internationalization/I_see_a_button_with_the_label_{string}.js
+++ b/cypress/support/step_definitions/Internationalization/I_see_a_button_with_the_label_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a button with the label {string}', label => {
   cy.contains('button', label)

--- a/cypress/support/step_definitions/Internationalization/I_see_a_button_with_the_label_{string}.js
+++ b/cypress/support/step_definitions/Internationalization/I_see_a_button_with_the_label_{string}.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I see a button with the label {string}", label => {
-  cy.contains("button", label);
-});
+defineStep('I see a button with the label {string}', label => {
+  cy.contains('button', label)
+})

--- a/cypress/support/step_definitions/Internationalization/I_see_a_button_with_the_label_{string}.js
+++ b/cypress/support/step_definitions/Internationalization/I_see_a_button_with_the_label_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a button with the label {string}', label => {
   cy.contains('button', label)

--- a/cypress/support/step_definitions/Internationalization/I_select_{string}_in_the_language_menu.js
+++ b/cypress/support/step_definitions/Internationalization/I_select_{string}_in_the_language_menu.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I select {string} in the language menu', language => {
     cy.get('.locale-menu')

--- a/cypress/support/step_definitions/Internationalization/I_select_{string}_in_the_language_menu.js
+++ b/cypress/support/step_definitions/Internationalization/I_select_{string}_in_the_language_menu.js
@@ -1,8 +1,8 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I select {string} in the language menu", language => {
-    cy.get(".locale-menu")
-      .click();
-    cy.contains(".locale-menu-popover a", language)
-      .click();
-});
+defineStep('I select {string} in the language menu', language => {
+    cy.get('.locale-menu')
+      .click()
+    cy.contains('.locale-menu-popover a', language)
+      .click()
+})

--- a/cypress/support/step_definitions/Internationalization/I_select_{string}_in_the_language_menu.js
+++ b/cypress/support/step_definitions/Internationalization/I_select_{string}_in_the_language_menu.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I select {string} in the language menu', language => {
     cy.get('.locale-menu')

--- a/cypress/support/step_definitions/Internationalization/the_whole_user_interface_appears_in_{string}.js
+++ b/cypress/support/step_definitions/Internationalization/the_whole_user_interface_appears_in_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import locales from '../../../../webapp/locales'
 
 defineStep('the whole user interface appears in {string}', language => {

--- a/cypress/support/step_definitions/Internationalization/the_whole_user_interface_appears_in_{string}.js
+++ b/cypress/support/step_definitions/Internationalization/the_whole_user_interface_appears_in_{string}.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import locales from '../../../../webapp/locales'
 
-Then("the whole user interface appears in {string}", language => {
-  const { code } = locales.find((entry) => entry.name === language);
-  cy.get(`html[lang=${code}]`);
-  cy.getCookie("locale").should("have.property", "value", code);
-});
+defineStep('the whole user interface appears in {string}', language => {
+  const { code } = locales.find((entry) => entry.name === language)
+  cy.get(`html[lang=${code}]`)
+  cy.getCookie('locale').should('have.property', 'value', code)
+})

--- a/cypress/support/step_definitions/Internationalization/the_whole_user_interface_appears_in_{string}.js
+++ b/cypress/support/step_definitions/Internationalization/the_whole_user_interface_appears_in_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import locales from '../../../../webapp/locales'
 
 defineStep('the whole user interface appears in {string}', language => {

--- a/cypress/support/step_definitions/Moderation.HidePost/I_should_see_only_{int}_posts_on_the_newsfeed.js
+++ b/cypress/support/step_definitions/Moderation.HidePost/I_should_see_only_{int}_posts_on_the_newsfeed.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see only {int} posts on the newsfeed', posts => {
   cy.get('.post-teaser')

--- a/cypress/support/step_definitions/Moderation.HidePost/I_should_see_only_{int}_posts_on_the_newsfeed.js
+++ b/cypress/support/step_definitions/Moderation.HidePost/I_should_see_only_{int}_posts_on_the_newsfeed.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see only {int} posts on the newsfeed", posts => {
-  cy.get(".post-teaser")
-    .should("have.length", posts);
-});
+defineStep('I should see only {int} posts on the newsfeed', posts => {
+  cy.get('.post-teaser')
+    .should('have.length', posts)
+})
   

--- a/cypress/support/step_definitions/Moderation.HidePost/I_should_see_only_{int}_posts_on_the_newsfeed.js
+++ b/cypress/support/step_definitions/Moderation.HidePost/I_should_see_only_{int}_posts_on_the_newsfeed.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see only {int} posts on the newsfeed', posts => {
   cy.get('.post-teaser')

--- a/cypress/support/step_definitions/Moderation.HidePost/the_page_{string}_returns_a_404_error_with_a_message.js
+++ b/cypress/support/step_definitions/Moderation.HidePost/the_page_{string}_returns_a_404_error_with_a_message.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the page {string} returns a 404 error with a message:', (route, message) => {
   cy.request({

--- a/cypress/support/step_definitions/Moderation.HidePost/the_page_{string}_returns_a_404_error_with_a_message.js
+++ b/cypress/support/step_definitions/Moderation.HidePost/the_page_{string}_returns_a_404_error_with_a_message.js
@@ -1,14 +1,14 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the page {string} returns a 404 error with a message:", (route, message) => {
+defineStep('the page {string} returns a 404 error with a message:', (route, message) => {
   cy.request({
     url: route,
     failOnStatusCode: false
     })
-    .its("status")
-    .should("eq", 404);
+    .its('status')
+    .should('eq', 404)
   cy.visit(route, {
     failOnStatusCode: false
-    });
-  cy.get(".error-message").should("contain", message);
-});
+    })
+  cy.get('.error-message').should('contain', message)
+})

--- a/cypress/support/step_definitions/Moderation.HidePost/the_page_{string}_returns_a_404_error_with_a_message.js
+++ b/cypress/support/step_definitions/Moderation.HidePost/the_page_{string}_returns_a_404_error_with_a_message.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the page {string} returns a 404 error with a message:', (route, message) => {
   cy.request({

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_can_t_see_the_moderation_menu_item.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_can_t_see_the_moderation_menu_item.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then(`I can't see the moderation menu item`, () => {
+defineStep(`I can't see the moderation menu item`, () => {
   cy.get('.avatar-menu-popover')
     .find('a[href="/settings"]', 'Settings')
     .should('exist') // OK, the dropdown is actually open

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_can_t_see_the_moderation_menu_item.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_can_t_see_the_moderation_menu_item.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep(`I can't see the moderation menu item`, () => {
   cy.get('.avatar-menu-popover')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_can_t_see_the_moderation_menu_item.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_can_t_see_the_moderation_menu_item.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep(`I can't see the moderation menu item`, () => {
   cy.get('.avatar-menu-popover')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_can_visit_the_post_page.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_can_visit_the_post_page.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can visit the post page', () => {
   cy.contains('Fake news').click()

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_can_visit_the_post_page.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_can_visit_the_post_page.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I can visit the post page', () => {
+defineStep('I can visit the post page', () => {
   cy.contains('Fake news').click()
   cy.location('pathname').should('contain', '/post')
     .get('.base-card .title').should('contain', 'Fake news')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_can_visit_the_post_page.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_can_visit_the_post_page.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can visit the post page', () => {
   cy.contains('Fake news').click()

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_Report_Post_from_the_content_menu_of_the_post.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_Report_Post_from_the_content_menu_of_the_post.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on "Report Post" from the content menu of the post', () => {
   cy.contains('.base-card', 'The Truth about the Holocaust')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_Report_Post_from_the_content_menu_of_the_post.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_Report_Post_from_the_content_menu_of_the_post.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on "Report Post" from the content menu of the post', () => {
   cy.contains('.base-card', 'The Truth about the Holocaust')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_Report_Post_from_the_content_menu_of_the_post.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_Report_Post_from_the_content_menu_of_the_post.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I click on "Report Post" from the content menu of the post', () => {
+defineStep('I click on "Report Post" from the content menu of the post', () => {
   cy.contains('.base-card', 'The Truth about the Holocaust')
     .find('.content-menu .base-button')
     .click()

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I click on the author', () => {
+defineStep('I click on the author', () => {
   cy.get('[data-test="avatarUserLink"]')
     .click()
     .url().should('include', '/profile/')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on the author', () => {
   cy.get('[data-test="avatarUserLink"]')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on the author', () => {
   cy.get('[data-test="avatarUserLink"]')

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_avatar_menu_in_the_top_right_corner.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_avatar_menu_in_the_top_right_corner.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import 'cypress-network-idle'
 
 defineStep('I click on the avatar menu in the top right corner', () => {

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_avatar_menu_in_the_top_right_corner.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_avatar_menu_in_the_top_right_corner.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import 'cypress-network-idle'
 
 defineStep('I click on the avatar menu in the top right corner', () => {

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_avatar_menu_in_the_top_right_corner.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_avatar_menu_in_the_top_right_corner.js
@@ -1,7 +1,7 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
-import 'cypress-network-idle';
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
+import 'cypress-network-idle'
 
-When("I click on the avatar menu in the top right corner", () => {
-  cy.get(".avatar-menu").click();
-  cy.waitForNetworkIdle(2000);
-});
+defineStep('I click on the avatar menu in the top right corner', () => {
+  cy.get('.avatar-menu').click()
+  cy.waitForNetworkIdle(2000)
+})

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_confirm_the_reporting_dialog.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_confirm_the_reporting_dialog.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep(/^I confirm the reporting dialog .*:$/, message => {
   cy.contains(message) // wait for element to become visible

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_confirm_the_reporting_dialog.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_confirm_the_reporting_dialog.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep(/^I confirm the reporting dialog .*:$/, message => {
   cy.contains(message) // wait for element to become visible

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_confirm_the_reporting_dialog.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_confirm_the_reporting_dialog.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When(/^I confirm the reporting dialog .*:$/, message => {
+defineStep(/^I confirm the reporting dialog .*:$/, message => {
   cy.contains(message) // wait for element to become visible
   cy.get('.ds-modal')
     .within(() => {

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_from_the_user_who_muted_me.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_from_the_user_who_muted_me.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see all the reported posts including from the user who muted me', () => {
   cy.get('table tbody').within(() => {

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_from_the_user_who_muted_me.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_from_the_user_who_muted_me.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see all the reported posts including from the user who muted me', () => {
   cy.get('table tbody').within(() => {

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_from_the_user_who_muted_me.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_from_the_user_who_muted_me.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I see all the reported posts including from the user who muted me', () => {
+defineStep('I see all the reported posts including from the user who muted me', () => {
   cy.get('table tbody').within(() => {
     cy.contains('tr', 'Fake news')
   })

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see all the reported posts including the one from above', () => {
   cy.intercept({

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see all the reported posts including the one from above', () => {
   cy.intercept({

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I see all the reported posts including the one from above', () => {
+defineStep('I see all the reported posts including the one from above', () => {
   cy.intercept({
     method: 'POST',
     url: '/api',

--- a/cypress/support/step_definitions/Moderation.ReportContent/each_list_item_links_to_the_post_page.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/each_list_item_links_to_the_post_page.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('each list item links to the post page', () => {
-  cy.contains('The Truth about the Holocaust').click();
+defineStep('each list item links to the post page', () => {
+  cy.contains('The Truth about the Holocaust').click()
   cy.location('pathname').should('contain', '/post')
 })

--- a/cypress/support/step_definitions/Moderation.ReportContent/each_list_item_links_to_the_post_page.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/each_list_item_links_to_the_post_page.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('each list item links to the post page', () => {
   cy.contains('The Truth about the Holocaust').click()

--- a/cypress/support/step_definitions/Moderation.ReportContent/each_list_item_links_to_the_post_page.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/each_list_item_links_to_the_post_page.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('each list item links to the post page', () => {
   cy.contains('The Truth about the Holocaust').click()

--- a/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
@@ -1,4 +1,3 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../commands'
 import './../../factories'
 import 'cypress-network-idle'

--- a/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
@@ -3,7 +3,7 @@ import './../../commands'
 import './../../factories'
 import 'cypress-network-idle'
 
-Given('somebody reported the following posts:', table => {
+defineStep('somebody reported the following posts:', table => {
   const reportIdRegex = /^[0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12}$/
   cy.intercept({
     method: 'POST',

--- a/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
@@ -1,3 +1,4 @@
+import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../commands'
 import './../../factories'
 import 'cypress-network-idle'

--- a/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/somebody_reported_the_following_posts.js
@@ -1,4 +1,4 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import './../../commands'
 import './../../factories'
 import 'cypress-network-idle'

--- a/cypress/support/step_definitions/Moderation.ReportContent/there_is_an_annoying_user_who_has_muted_me.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/there_is_an_annoying_user_who_has_muted_me.js
@@ -1,15 +1,15 @@
-import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Given("there is an annoying user who has muted me", () => {
+defineStep('there is an annoying user who has muted me', () => {
   cy.neode()
-    .firstOf("User", {
+    .firstOf('User', {
       role: 'moderator'
     })
     .then(mutedUser => {
       cy.neode()
-        .firstOf("User", {
+        .firstOf('User', {
           id: 'user'
         })
-      .relateTo(mutedUser, "muted");
-    });
-});
+      .relateTo(mutedUser, 'muted')
+    })
+})

--- a/cypress/support/step_definitions/Moderation.ReportContent/there_is_an_annoying_user_who_has_muted_me.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/there_is_an_annoying_user_who_has_muted_me.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('there is an annoying user who has muted me', () => {
   cy.neode()

--- a/cypress/support/step_definitions/Moderation.ReportContent/there_is_an_annoying_user_who_has_muted_me.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/there_is_an_annoying_user_who_has_muted_me.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('there is an annoying user who has muted me', () => {
   cy.neode()

--- a/cypress/support/step_definitions/Notification.Mention/I_start_to_write_a_new_post_with_the_title_{string}_beginning_with.js
+++ b/cypress/support/step_definitions/Notification.Mention/I_start_to_write_a_new_post_with_the_title_{string}_beginning_with.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I start to write a new post with the title {string} beginning with:', (title, intro) => {
   cy.get('input[name="title"]')

--- a/cypress/support/step_definitions/Notification.Mention/I_start_to_write_a_new_post_with_the_title_{string}_beginning_with.js
+++ b/cypress/support/step_definitions/Notification.Mention/I_start_to_write_a_new_post_with_the_title_{string}_beginning_with.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I start to write a new post with the title {string} beginning with:', (title, intro) => {
   cy.get('input[name="title"]')

--- a/cypress/support/step_definitions/Notification.Mention/I_start_to_write_a_new_post_with_the_title_{string}_beginning_with.js
+++ b/cypress/support/step_definitions/Notification.Mention/I_start_to_write_a_new_post_with_the_title_{string}_beginning_with.js
@@ -1,8 +1,8 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I start to write a new post with the title {string} beginning with:", (title, intro) => {
+defineStep('I start to write a new post with the title {string} beginning with:', (title, intro) => {
   cy.get('input[name="title"]')
-    .type(title);
-  cy.get(".ProseMirror")
-    .type(intro);
-});
+    .type(title)
+  cy.get('.ProseMirror')
+    .type(intro)
+})

--- a/cypress/support/step_definitions/Notification.Mention/mention_{string}_in_the_text.js
+++ b/cypress/support/step_definitions/Notification.Mention/mention_{string}_in_the_text.js
@@ -1,9 +1,9 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("mention {string} in the text", mention => {
-  cy.get(".ProseMirror")
-    .type(" @");
-  cy.get(".suggestion-list__item")
+defineStep('mention {string} in the text', mention => {
+  cy.get('.ProseMirror')
+    .type(' @')
+  cy.get('.suggestion-list__item')
     .contains(mention)
-    .click();
-});
+    .click()
+})

--- a/cypress/support/step_definitions/Notification.Mention/mention_{string}_in_the_text.js
+++ b/cypress/support/step_definitions/Notification.Mention/mention_{string}_in_the_text.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('mention {string} in the text', mention => {
   cy.get('.ProseMirror')

--- a/cypress/support/step_definitions/Notification.Mention/mention_{string}_in_the_text.js
+++ b/cypress/support/step_definitions/Notification.Mention/mention_{string}_in_the_text.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('mention {string} in the text', mention => {
   cy.get('.ProseMirror')

--- a/cypress/support/step_definitions/Notification.Mention/open_the_notification_menu_and_click_on_the_first_item.js
+++ b/cypress/support/step_definitions/Notification.Mention/open_the_notification_menu_and_click_on_the_first_item.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('open the notification menu and click on the first item', () => {
   cy.get('.notifications-menu')

--- a/cypress/support/step_definitions/Notification.Mention/open_the_notification_menu_and_click_on_the_first_item.js
+++ b/cypress/support/step_definitions/Notification.Mention/open_the_notification_menu_and_click_on_the_first_item.js
@@ -1,10 +1,10 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("open the notification menu and click on the first item", () => {
-  cy.get(".notifications-menu")
+defineStep('open the notification menu and click on the first item', () => {
+  cy.get('.notifications-menu')
     .invoke('show')
-    .click(); // "invoke('show')" because of the delay for show the menu
-  cy.get(".notification .link")
+    .click() // 'invoke('show')' because of the delay for show the menu
+  cy.get('.notification .link')
     .first()
-    .click({force: true});
-});  
+    .click({force: true})
+})

--- a/cypress/support/step_definitions/Notification.Mention/open_the_notification_menu_and_click_on_the_first_item.js
+++ b/cypress/support/step_definitions/Notification.Mention/open_the_notification_menu_and_click_on_the_first_item.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('open the notification menu and click on the first item', () => {
   cy.get('.notifications-menu')

--- a/cypress/support/step_definitions/Notification.Mention/see_{int}_unread_notifications_in_the_top_menu.js
+++ b/cypress/support/step_definitions/Notification.Mention/see_{int}_unread_notifications_in_the_top_menu.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('see {int} unread notifications in the top menu', count => {
   cy.get('.notifications-menu')

--- a/cypress/support/step_definitions/Notification.Mention/see_{int}_unread_notifications_in_the_top_menu.js
+++ b/cypress/support/step_definitions/Notification.Mention/see_{int}_unread_notifications_in_the_top_menu.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('see {int} unread notifications in the top menu', count => {
   cy.get('.notifications-menu')

--- a/cypress/support/step_definitions/Notification.Mention/see_{int}_unread_notifications_in_the_top_menu.js
+++ b/cypress/support/step_definitions/Notification.Mention/see_{int}_unread_notifications_in_the_top_menu.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("see {int} unread notifications in the top menu", count => {
-  cy.get(".notifications-menu")
-    .should("contain", count);
-});
+defineStep('see {int} unread notifications in the top menu', count => {
+  cy.get('.notifications-menu')
+    .should('contain', count)
+})

--- a/cypress/support/step_definitions/Notification.Mention/the_notification_menu_button_links_to_the_all_notifications_page.js
+++ b/cypress/support/step_definitions/Notification.Mention/the_notification_menu_button_links_to_the_all_notifications_page.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the notification menu button links to the all notifications page", () => {
-  cy.get(".notifications-menu")
-    .click();
-  cy.location("pathname")
-    .should("contain", "/notifications");
-});
+defineStep('the notification menu button links to the all notifications page', () => {
+  cy.get('.notifications-menu')
+    .click()
+  cy.location('pathname')
+    .should('contain', '/notifications')
+})

--- a/cypress/support/step_definitions/Notification.Mention/the_notification_menu_button_links_to_the_all_notifications_page.js
+++ b/cypress/support/step_definitions/Notification.Mention/the_notification_menu_button_links_to_the_all_notifications_page.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the notification menu button links to the all notifications page', () => {
   cy.get('.notifications-menu')

--- a/cypress/support/step_definitions/Notification.Mention/the_notification_menu_button_links_to_the_all_notifications_page.js
+++ b/cypress/support/step_definitions/Notification.Mention/the_notification_menu_button_links_to_the_all_notifications_page.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the notification menu button links to the all notifications page', () => {
   cy.get('.notifications-menu')

--- a/cypress/support/step_definitions/Notification.Mention/the_unread_counter_is_removed.js
+++ b/cypress/support/step_definitions/Notification.Mention/the_unread_counter_is_removed.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the unread counter is removed', () => {
   cy.get('.notifications-menu .counter-icon')

--- a/cypress/support/step_definitions/Notification.Mention/the_unread_counter_is_removed.js
+++ b/cypress/support/step_definitions/Notification.Mention/the_unread_counter_is_removed.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the unread counter is removed", () => {
+defineStep('the unread counter is removed', () => {
   cy.get('.notifications-menu .counter-icon')
-    .should('not.exist');
-});
+    .should('not.exist')
+})

--- a/cypress/support/step_definitions/Notification.Mention/the_unread_counter_is_removed.js
+++ b/cypress/support/step_definitions/Notification.Mention/the_unread_counter_is_removed.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the unread counter is removed', () => {
   cy.get('.notifications-menu .counter-icon')

--- a/cypress/support/step_definitions/Post.Comment/I_comment_the_following.js
+++ b/cypress/support/step_definitions/Post.Comment/I_comment_the_following.js
@@ -1,7 +1,7 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I comment the following:", text => {
-  const comment = text.replace("\n", " ")
+defineStep('I comment the following:', text => {
+  const comment = text.replace('\n', ' ')
   cy.task('pushValue', { name: 'lastComment', value: comment })
-  cy.get(".editor .ProseMirror").type(comment);
-});
+  cy.get('.editor .ProseMirror').type(comment)
+})

--- a/cypress/support/step_definitions/Post.Comment/I_comment_the_following.js
+++ b/cypress/support/step_definitions/Post.Comment/I_comment_the_following.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I comment the following:', text => {
   const comment = text.replace('\n', ' ')

--- a/cypress/support/step_definitions/Post.Comment/I_comment_the_following.js
+++ b/cypress/support/step_definitions/Post.Comment/I_comment_the_following.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I comment the following:', text => {
   const comment = text.replace('\n', ' ')

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_an_abbreviated_version_of_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_an_abbreviated_version_of_my_comment.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see an abbreviated version of my comment', () => {
   cy.get('article.comment-card')

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_an_abbreviated_version_of_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_an_abbreviated_version_of_my_comment.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see an abbreviated version of my comment', () => {
   cy.get('article.comment-card')

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_an_abbreviated_version_of_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_an_abbreviated_version_of_my_comment.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see an abbreviated version of my comment", () => {
-  cy.get("article.comment-card")
-    .should("contain", "show more")
-});
+defineStep('I should see an abbreviated version of my comment', () => {
+  cy.get('article.comment-card')
+    .should('contain', 'show more')
+})

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_my_comment.js
@@ -1,13 +1,13 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see my comment", () => {
-  cy.get("article.comment-card p")
-    .should("contain", "Ocelot.social rocks")
-    .get(".user-teaser span.slug")
-    .should("contain", "@peter-pan") // specific enough
-    .get(".profile-avatar img")
-    .should("have.attr", "src")
-    .and("contain", 'https://') // some url
-    .get(".user-teaser > .info > .text")
-    .should("contain", "today at");
-});
+defineStep('I should see my comment', () => {
+  cy.get('article.comment-card p')
+    .should('contain', 'Ocelot.social rocks')
+    .get('.user-teaser span.slug')
+    .should('contain', '@peter-pan') // specific enough
+    .get('.profile-avatar img')
+    .should('have.attr', 'src')
+    .and('contain', 'https://') // some url
+    .get('.user-teaser > .info > .text')
+    .should('contain', 'today at')
+})

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_my_comment.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see my comment', () => {
   cy.get('article.comment-card p')

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_my_comment.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see my comment', () => {
   cy.get('article.comment-card p')

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_the_entirety_of_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_the_entirety_of_my_comment.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see the entirety of my comment", () => {
-  cy.get("article.comment-card")
-    .should("not.contain", "show more")
-});
+defineStep('I should see the entirety of my comment', () => {
+  cy.get('article.comment-card')
+    .should('not.contain', 'show more')
+})

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_the_entirety_of_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_the_entirety_of_my_comment.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the entirety of my comment', () => {
   cy.get('article.comment-card')

--- a/cypress/support/step_definitions/Post.Comment/I_should_see_the_entirety_of_my_comment.js
+++ b/cypress/support/step_definitions/Post.Comment/I_should_see_the_entirety_of_my_comment.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the entirety of my comment', () => {
   cy.get('article.comment-card')

--- a/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
+++ b/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I type in a comment with {int} characters', size => {
   var c = ''

--- a/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
+++ b/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I type in a comment with {int} characters', size => {
   var c = ''

--- a/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
+++ b/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
@@ -1,7 +1,7 @@
 
 defineStep('I type in a comment with {int} characters', size => {
   var c = ''
-  for (var i = 0 i < size i++) {
+  for (var i = 0; i < size; i++) {
     c += 'c'
   }
   cy.get('.editor .ProseMirror').type(c)

--- a/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
+++ b/cypress/support/step_definitions/Post.Comment/I_type_in_a_comment_with_{int}_characters.js
@@ -1,9 +1,9 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I type in a comment with {int} characters", size => {
-  var c="";
-  for (var i = 0; i < size; i++) {
-    c += "c"
+defineStep('I type in a comment with {int} characters', size => {
+  var c = ''
+  for (var i = 0 i < size i++) {
+    c += 'c'
   }
-  cy.get(".editor .ProseMirror").type(c);
-});
+  cy.get('.editor .ProseMirror').type(c)
+})

--- a/cypress/support/step_definitions/Post.Comment/it_should_create_a_mention_in_the_CommentForm.js
+++ b/cypress/support/step_definitions/Post.Comment/it_should_create_a_mention_in_the_CommentForm.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("it should create a mention in the CommentForm", () => {
-  cy.get(".ProseMirror a")
+defineStep('it should create a mention in the CommentForm', () => {
+  cy.get('.ProseMirror a')
     .should('have.class', 'mention')
     .should('contain', '@peter-pan')
 })

--- a/cypress/support/step_definitions/Post.Comment/it_should_create_a_mention_in_the_CommentForm.js
+++ b/cypress/support/step_definitions/Post.Comment/it_should_create_a_mention_in_the_CommentForm.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('it should create a mention in the CommentForm', () => {
   cy.get('.ProseMirror a')

--- a/cypress/support/step_definitions/Post.Comment/it_should_create_a_mention_in_the_CommentForm.js
+++ b/cypress/support/step_definitions/Post.Comment/it_should_create_a_mention_in_the_CommentForm.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('it should create a mention in the CommentForm', () => {
   cy.get('.ProseMirror a')

--- a/cypress/support/step_definitions/Post.Comment/my_comment_should_be_successfully_created.js
+++ b/cypress/support/step_definitions/Post.Comment/my_comment_should_be_successfully_created.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('my comment should be successfully created', () => {
   cy.get('.iziToast-message').contains('Comment submitted!')

--- a/cypress/support/step_definitions/Post.Comment/my_comment_should_be_successfully_created.js
+++ b/cypress/support/step_definitions/Post.Comment/my_comment_should_be_successfully_created.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('my comment should be successfully created', () => {
   cy.get('.iziToast-message').contains('Comment submitted!')

--- a/cypress/support/step_definitions/Post.Comment/my_comment_should_be_successfully_created.js
+++ b/cypress/support/step_definitions/Post.Comment/my_comment_should_be_successfully_created.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("my comment should be successfully created", () => {
-  cy.get(".iziToast-message").contains("Comment submitted!");
-});
+defineStep('my comment should be successfully created', () => {
+  cy.get('.iziToast-message').contains('Comment submitted!')
+})

--- a/cypress/support/step_definitions/Post.Comment/the_editor_should_be_cleared.js
+++ b/cypress/support/step_definitions/Post.Comment/the_editor_should_be_cleared.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the editor should be cleared', () => {
   cy.get('.ProseMirror p').should('have.class', 'is-empty')

--- a/cypress/support/step_definitions/Post.Comment/the_editor_should_be_cleared.js
+++ b/cypress/support/step_definitions/Post.Comment/the_editor_should_be_cleared.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the editor should be cleared', () => {
   cy.get('.ProseMirror p').should('have.class', 'is-empty')

--- a/cypress/support/step_definitions/Post.Comment/the_editor_should_be_cleared.js
+++ b/cypress/support/step_definitions/Post.Comment/the_editor_should_be_cleared.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the editor should be cleared", () => {
-  cy.get(".ProseMirror p").should("have.class", "is-empty");
-});
+defineStep('the editor should be cleared', () => {
+  cy.get('.ProseMirror p').should('have.class', 'is-empty')
+})

--- a/cypress/support/step_definitions/Post.Create/I_choose_{string}_as_the_title.js
+++ b/cypress/support/step_definitions/Post.Create/I_choose_{string}_as_the_title.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I choose {string} as the title', title => {
   const lastPost = {}

--- a/cypress/support/step_definitions/Post.Create/I_choose_{string}_as_the_title.js
+++ b/cypress/support/step_definitions/Post.Create/I_choose_{string}_as_the_title.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I choose {string} as the title', title => {
   const lastPost = {}

--- a/cypress/support/step_definitions/Post.Create/I_choose_{string}_as_the_title.js
+++ b/cypress/support/step_definitions/Post.Create/I_choose_{string}_as_the_title.js
@@ -1,8 +1,8 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I choose {string} as the title", title => {
+defineStep('I choose {string} as the title', title => {
   const lastPost = {}
-  lastPost.title = title.replace("\n", " ");
+  lastPost.title = title.replace('\n', ' ')
   cy.task('pushValue', { name: 'lastPost', value: lastPost })
-  cy.get('input[name="title"]').type(lastPost.title);
-});
+  cy.get('input[name="title"]').type(lastPost.title)
+})

--- a/cypress/support/step_definitions/Post.Create/the_post_was_saved_successfully.js
+++ b/cypress/support/step_definitions/Post.Create/the_post_was_saved_successfully.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post was saved successfully', () => {
   cy.task('getValue', 'lastPost').then(lastPost => {

--- a/cypress/support/step_definitions/Post.Create/the_post_was_saved_successfully.js
+++ b/cypress/support/step_definitions/Post.Create/the_post_was_saved_successfully.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the post was saved successfully", () => {
+defineStep('the post was saved successfully', () => {
   cy.task('getValue', 'lastPost').then(lastPost => {
-    cy.get(".base-card > .title").should("contain", lastPost.title);
-    cy.get(".content").should("contain", lastPost.content);
+    cy.get('.base-card > .title').should('contain', lastPost.title)
+    cy.get('.content').should('contain', lastPost.content)
   })
-});
+})

--- a/cypress/support/step_definitions/Post.Create/the_post_was_saved_successfully.js
+++ b/cypress/support/step_definitions/Post.Create/the_post_was_saved_successfully.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post was saved successfully', () => {
   cy.task('getValue', 'lastPost').then(lastPost => {

--- a/cypress/support/step_definitions/Post.Images/I_add_all_required_fields.js
+++ b/cypress/support/step_definitions/Post.Images/I_add_all_required_fields.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I add all required fields", () => {
+defineStep('I add all required fields', () => {
   cy.get('input[name="title"]')
     .type('new post')
-    .get(".editor .ProseMirror")
+    .get('.editor .ProseMirror')
     .type('new post content')
-  })
+})

--- a/cypress/support/step_definitions/Post.Images/I_add_all_required_fields.js
+++ b/cypress/support/step_definitions/Post.Images/I_add_all_required_fields.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I add all required fields', () => {
   cy.get('input[name="title"]')

--- a/cypress/support/step_definitions/Post.Images/I_add_all_required_fields.js
+++ b/cypress/support/step_definitions/Post.Images/I_add_all_required_fields.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I add all required fields', () => {
   cy.get('input[name="title"]')

--- a/cypress/support/step_definitions/Post.Images/I_should_be_able_to_{string}_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/I_should_be_able_to_{string}_a_teaser_image.js
@@ -1,29 +1,28 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should be able to {string} a teaser image", condition => {
-  let postTeaserImage = ""
+defineStep('I should be able to {string} a teaser image', condition => {
+  let postTeaserImage = ''
 
   switch(condition){
-    case "change":
-      postTeaserImage = "humanconnection.png"
-      cy.get(".delete-image-button")
+    case 'change':
+      postTeaserImage = 'humanconnection.png'
+      cy.get('.delete-image-button')
         .click()
-      cy.get("#postdropzone").selectFile(
-        { contents: `cypress/fixtures/${postTeaserImage}`, fileName: postTeaserImage, mimeType: "image/png" },
-        { action: "drag-drop", force: true }
-      ).wait(750);
-      break;
-    case "add":
-      postTeaserImage = "onourjourney.png"
-      cy.get("#postdropzone").selectFile(
-        { contents: `cypress/fixtures/${postTeaserImage}`, fileName: postTeaserImage, mimeType: "image/png" },
-        { action: "drag-drop", force: true }
-      ).wait(750);
-      break;
-    case "remove":
-      cy.get(".delete-image-button")
+      cy.get('#postdropzone').selectFile(
+        { contents: `cypress/fixtures/${postTeaserImage}`, fileName: postTeaserImage, mimeType: 'image/png' },
+        { action: 'drag-drop', force: true }
+      ).wait(750)
+      break
+    case 'add':
+      postTeaserImage = 'onourjourney.png'
+      cy.get('#postdropzone').selectFile(
+        { contents: `cypress/fixtures/${postTeaserImage}`, fileName: postTeaserImage, mimeType: 'image/png' },
+        { action: 'drag-drop', force: true }
+      ).wait(750)
+      break
+    case 'remove':
+      cy.get('.delete-image-button')
         .click()
-      break;
+      break
   }
-  
 })

--- a/cypress/support/step_definitions/Post.Images/I_should_be_able_to_{string}_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/I_should_be_able_to_{string}_a_teaser_image.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should be able to {string} a teaser image', condition => {
   let postTeaserImage = ''

--- a/cypress/support/step_definitions/Post.Images/I_should_be_able_to_{string}_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/I_should_be_able_to_{string}_a_teaser_image.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should be able to {string} a teaser image', condition => {
   let postTeaserImage = ''

--- a/cypress/support/step_definitions/Post.Images/my_post_has_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/my_post_has_a_teaser_image.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('my post has a teaser image', () => {
   cy.get('.contribution-form .image')

--- a/cypress/support/step_definitions/Post.Images/my_post_has_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/my_post_has_a_teaser_image.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('my post has a teaser image', () => {
   cy.get('.contribution-form .image')

--- a/cypress/support/step_definitions/Post.Images/my_post_has_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/my_post_has_a_teaser_image.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('my post has a teaser image', () => {
+defineStep('my post has a teaser image', () => {
   cy.get('.contribution-form .image')
     .should('exist')
     .and('have.attr', 'src')

--- a/cypress/support/step_definitions/Post.Images/the_first_image_should_not_be_displayed_anymore.js
+++ b/cypress/support/step_definitions/Post.Images/the_first_image_should_not_be_displayed_anymore.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the first image should not be displayed anymore', () => {
   cy.get('.hero-image')

--- a/cypress/support/step_definitions/Post.Images/the_first_image_should_not_be_displayed_anymore.js
+++ b/cypress/support/step_definitions/Post.Images/the_first_image_should_not_be_displayed_anymore.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the first image should not be displayed anymore', () => {
   cy.get('.hero-image')

--- a/cypress/support/step_definitions/Post.Images/the_first_image_should_not_be_displayed_anymore.js
+++ b/cypress/support/step_definitions/Post.Images/the_first_image_should_not_be_displayed_anymore.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the first image should not be displayed anymore", () => {
-  cy.get(".hero-image")
+defineStep('the first image should not be displayed anymore', () => {
+  cy.get('.hero-image')
     .children()
     .get('.hero-image > .image')
     .should('have.length', 1)

--- a/cypress/support/step_definitions/Post.Images/the_post_was_saved_successfully_with_the_{string}_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/the_post_was_saved_successfully_with_the_{string}_teaser_image.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post was saved successfully with the {string} teaser image', condition => {
   cy.get('.base-card > .title')

--- a/cypress/support/step_definitions/Post.Images/the_post_was_saved_successfully_with_the_{string}_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/the_post_was_saved_successfully_with_the_{string}_teaser_image.js
@@ -1,11 +1,11 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the post was saved successfully with the {string} teaser image", condition => {
-  cy.get(".base-card > .title")
-    .should("contain", condition === 'updated' ? 'to be updated' : 'new post')
-    .get(".content")
-    .should("contain", condition === 'updated' ? 'successfully updated' : 'new post content')
+defineStep('the post was saved successfully with the {string} teaser image', condition => {
+  cy.get('.base-card > .title')
+    .should('contain', condition === 'updated' ? 'to be updated' : 'new post')
+    .get('.content')
+    .should('contain', condition === 'updated' ? 'successfully updated' : 'new post content')
     .get('.post-page img')
-    .should("have.attr", "src")
-    .and("contains", condition === 'updated' ? 'humanconnection' : 'onourjourney')
+    .should('have.attr', 'src')
+    .and('contains', condition === 'updated' ? 'humanconnection' : 'onourjourney')
 })

--- a/cypress/support/step_definitions/Post.Images/the_post_was_saved_successfully_with_the_{string}_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/the_post_was_saved_successfully_with_the_{string}_teaser_image.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post was saved successfully with the {string} teaser image', condition => {
   cy.get('.base-card > .title')

--- a/cypress/support/step_definitions/Post.Images/the_{string}_post_was_saved_successfully_without_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/the_{string}_post_was_saved_successfully_without_a_teaser_image.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the {string} post was saved successfully without a teaser image', condition => {
   cy.get(".base-card > .title")

--- a/cypress/support/step_definitions/Post.Images/the_{string}_post_was_saved_successfully_without_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/the_{string}_post_was_saved_successfully_without_a_teaser_image.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('the {string} post was saved successfully without a teaser image', condition => {
+defineStep('the {string} post was saved successfully without a teaser image', condition => {
   cy.get(".base-card > .title")
     .should("contain", condition === 'updated' ? 'to be updated' : 'new post')
     .get(".content")

--- a/cypress/support/step_definitions/Post.Images/the_{string}_post_was_saved_successfully_without_a_teaser_image.js
+++ b/cypress/support/step_definitions/Post.Images/the_{string}_post_was_saved_successfully_without_a_teaser_image.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the {string} post was saved successfully without a teaser image', condition => {
   cy.get(".base-card > .title")

--- a/cypress/support/step_definitions/Post/the_post_shows_up_on_the_newsfeed_at_position_{int}.js
+++ b/cypress/support/step_definitions/Post/the_post_shows_up_on_the_newsfeed_at_position_{int}.js
@@ -1,8 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the post shows up on the newsfeed at position {int}", index => {
-  const selector = `.post-teaser:nth-child(${index}) > .base-card`;
-  cy.get(selector).should("contain", 'previously created post');
-  cy.get(selector).should("contain", 'with some content');
-  
-});
+defineStep('the post shows up on the newsfeed at position {int}', index => {
+  const selector = `.post-teaser:nth-child(${index}) > .base-card`
+  cy.get(selector).should('contain', 'previously created post')
+  cy.get(selector).should('contain', 'with some content')
+})

--- a/cypress/support/step_definitions/Post/the_post_shows_up_on_the_newsfeed_at_position_{int}.js
+++ b/cypress/support/step_definitions/Post/the_post_shows_up_on_the_newsfeed_at_position_{int}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post shows up on the newsfeed at position {int}', index => {
   const selector = `.post-teaser:nth-child(${index}) > .base-card`

--- a/cypress/support/step_definitions/Post/the_post_shows_up_on_the_newsfeed_at_position_{int}.js
+++ b/cypress/support/step_definitions/Post/the_post_shows_up_on_the_newsfeed_at_position_{int}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the post shows up on the newsfeed at position {int}', index => {
   const selector = `.post-teaser:nth-child(${index}) > .base-card`

--- a/cypress/support/step_definitions/Search/I_select_a_post_entry.js
+++ b/cypress/support/step_definitions/Search/I_select_a_post_entry.js
@@ -1,7 +1,7 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I select a post entry", () => {
-  cy.get(".searchable-input .search-post")
+defineStep('I select a post entry', () => {
+  cy.get('.searchable-input .search-post')
     .first()
-    .trigger("click");
-});
+    .trigger('click')
+})

--- a/cypress/support/step_definitions/Search/I_select_a_post_entry.js
+++ b/cypress/support/step_definitions/Search/I_select_a_post_entry.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I select a post entry', () => {
   cy.get('.searchable-input .search-post')

--- a/cypress/support/step_definitions/Search/I_select_a_post_entry.js
+++ b/cypress/support/step_definitions/Search/I_select_a_post_entry.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I select a post entry', () => {
   cy.get('.searchable-input .search-post')

--- a/cypress/support/step_definitions/Search/I_select_a_user_entry.js
+++ b/cypress/support/step_definitions/Search/I_select_a_user_entry.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I select a user entry", () => {
-  cy.get(".searchable-input .user-teaser")
+defineStep('I select a user entry', () => {
+  cy.get('.searchable-input .user-teaser')
     .first()
-    .trigger("click");
+    .trigger('click')
 })

--- a/cypress/support/step_definitions/Search/I_select_a_user_entry.js
+++ b/cypress/support/step_definitions/Search/I_select_a_user_entry.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I select a user entry', () => {
   cy.get('.searchable-input .user-teaser')

--- a/cypress/support/step_definitions/Search/I_select_a_user_entry.js
+++ b/cypress/support/step_definitions/Search/I_select_a_user_entry.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I select a user entry', () => {
   cy.get('.searchable-input .user-teaser')

--- a/cypress/support/step_definitions/Search/I_should_have_one_item_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_have_one_item_in_the_select_dropdown.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should have one item in the select dropdown', () => {
   cy.get('.searchable-input .ds-select-dropdown').should($li => {

--- a/cypress/support/step_definitions/Search/I_should_have_one_item_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_have_one_item_in_the_select_dropdown.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should have one item in the select dropdown', () => {
   cy.get('.searchable-input .ds-select-dropdown').should($li => {

--- a/cypress/support/step_definitions/Search/I_should_have_one_item_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_have_one_item_in_the_select_dropdown.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should have one item in the select dropdown", () => {
-  cy.get(".searchable-input .ds-select-dropdown").should($li => {
-    expect($li).to.have.length(1);
-  });
-});
+defineStep('I should have one item in the select dropdown', () => {
+  cy.get('.searchable-input .ds-select-dropdown').should($li => {
+    expect($li).to.have.length(1)
+  })
+})

--- a/cypress/support/step_definitions/Search/I_should_not_see_posts_without_the_searched-for_term_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_not_see_posts_without_the_searched-for_term_in_the_select_dropdown.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should not see posts without the searched-for term in the select dropdown', () => {
   cy.get('.ds-select-dropdown')

--- a/cypress/support/step_definitions/Search/I_should_not_see_posts_without_the_searched-for_term_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_not_see_posts_without_the_searched-for_term_in_the_select_dropdown.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should not see posts without the searched-for term in the select dropdown', () => {
   cy.get('.ds-select-dropdown')

--- a/cypress/support/step_definitions/Search/I_should_not_see_posts_without_the_searched-for_term_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_not_see_posts_without_the_searched-for_term_in_the_select_dropdown.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should not see posts without the searched-for term in the select dropdown", () => {
-  cy.get(".ds-select-dropdown")
-    .should("not.contain","No searched for content");
-});
+defineStep('I should not see posts without the searched-for term in the select dropdown', () => {
+  cy.get('.ds-select-dropdown')
+    .should('not.contain','No searched for content')
+})

--- a/cypress/support/step_definitions/Search/I_should_see_posts_with_the_searched-for_term_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_see_posts_with_the_searched-for_term_in_the_select_dropdown.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see posts with the searched-for term in the select dropdown', () => {
   cy.get('.ds-select-dropdown')

--- a/cypress/support/step_definitions/Search/I_should_see_posts_with_the_searched-for_term_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_see_posts_with_the_searched-for_term_in_the_select_dropdown.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see posts with the searched-for term in the select dropdown', () => {
   cy.get('.ds-select-dropdown')

--- a/cypress/support/step_definitions/Search/I_should_see_posts_with_the_searched-for_term_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_see_posts_with_the_searched-for_term_in_the_select_dropdown.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see posts with the searched-for term in the select dropdown", () => {
-  cy.get(".ds-select-dropdown")
-    .should("contain","101 Essays that will change the way you think");
-});
+defineStep('I should see posts with the searched-for term in the select dropdown', () => {
+  cy.get('.ds-select-dropdown')
+    .should('contain','101 Essays that will change the way you think')
+})

--- a/cypress/support/step_definitions/Search/I_should_see_the_following_posts_on_the_search_results_page.js
+++ b/cypress/support/step_definitions/Search/I_should_see_the_following_posts_on_the_search_results_page.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the following posts on the search results page:', table => {
   table.hashes().forEach(({ title }) => {  

--- a/cypress/support/step_definitions/Search/I_should_see_the_following_posts_on_the_search_results_page.js
+++ b/cypress/support/step_definitions/Search/I_should_see_the_following_posts_on_the_search_results_page.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the following posts on the search results page:', table => {
   table.hashes().forEach(({ title }) => {  

--- a/cypress/support/step_definitions/Search/I_should_see_the_following_posts_on_the_search_results_page.js
+++ b/cypress/support/step_definitions/Search/I_should_see_the_following_posts_on_the_search_results_page.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see the following posts on the search results page:", table => {
+defineStep('I should see the following posts on the search results page:', table => {
   table.hashes().forEach(({ title }) => {  
-    cy.get(".post-teaser")
-      .should("contain",title)
-  });
-});
+    cy.get('.post-teaser')
+      .should('contain',title)
+  })
+})

--- a/cypress/support/step_definitions/Search/I_should_see_the_following_users_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_see_the_following_users_in_the_select_dropdown.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the following users in the select dropdown:', table => {
   cy.get('.search-heading').should('contain', 'Users')

--- a/cypress/support/step_definitions/Search/I_should_see_the_following_users_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_see_the_following_users_in_the_select_dropdown.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the following users in the select dropdown:', table => {
   cy.get('.search-heading').should('contain', 'Users')

--- a/cypress/support/step_definitions/Search/I_should_see_the_following_users_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/Search/I_should_see_the_following_users_in_the_select_dropdown.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see the following users in the select dropdown:", table => {
-  cy.get(".search-heading").should("contain", "Users");
+defineStep('I should see the following users in the select dropdown:', table => {
+  cy.get('.search-heading').should('contain', 'Users')
   table.hashes().forEach(({ slug }) => {
-    cy.get(".ds-select-dropdown").should("contain", slug);
-  });
-});
+    cy.get('.ds-select-dropdown').should('contain', slug)
+  })
+})

--- a/cypress/support/step_definitions/Search/I_type_{string}_and_press_Enter.js
+++ b/cypress/support/step_definitions/Search/I_type_{string}_and_press_Enter.js
@@ -1,8 +1,8 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I type {string} and press Enter", value => {
-  cy.get(".searchable-input .ds-select input")
+defineStep('I type {string} and press Enter', value => {
+  cy.get('.searchable-input .ds-select input')
     .focus()
     .type(value)
-    .type("{enter}", { force: true });
-});
+    .type('{enter}', { force: true })
+})

--- a/cypress/support/step_definitions/Search/I_type_{string}_and_press_Enter.js
+++ b/cypress/support/step_definitions/Search/I_type_{string}_and_press_Enter.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I type {string} and press Enter', value => {
   cy.get('.searchable-input .ds-select input')

--- a/cypress/support/step_definitions/Search/I_type_{string}_and_press_Enter.js
+++ b/cypress/support/step_definitions/Search/I_type_{string}_and_press_Enter.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I type {string} and press Enter', value => {
   cy.get('.searchable-input .ds-select input')

--- a/cypress/support/step_definitions/Search/I_type_{string}_and_press_escape.js
+++ b/cypress/support/step_definitions/Search/I_type_{string}_and_press_escape.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I type {string} and press escape', value => {
   cy.get('.searchable-input .ds-select input')

--- a/cypress/support/step_definitions/Search/I_type_{string}_and_press_escape.js
+++ b/cypress/support/step_definitions/Search/I_type_{string}_and_press_escape.js
@@ -1,8 +1,8 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I type {string} and press escape", value => {
-  cy.get(".searchable-input .ds-select input")
+defineStep('I type {string} and press escape', value => {
+  cy.get('.searchable-input .ds-select input')
     .focus()
     .type(value)
-    .type("{esc}");
-});
+    .type('{esc}')
+})

--- a/cypress/support/step_definitions/Search/I_type_{string}_and_press_escape.js
+++ b/cypress/support/step_definitions/Search/I_type_{string}_and_press_escape.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I type {string} and press escape', value => {
   cy.get('.searchable-input .ds-select input')

--- a/cypress/support/step_definitions/Search/the_search_field_should_clear.js
+++ b/cypress/support/step_definitions/Search/the_search_field_should_clear.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search field should clear', () => {
   cy.get('.searchable-input .ds-select input')

--- a/cypress/support/step_definitions/Search/the_search_field_should_clear.js
+++ b/cypress/support/step_definitions/Search/the_search_field_should_clear.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search field should clear', () => {
   cy.get('.searchable-input .ds-select input')

--- a/cypress/support/step_definitions/Search/the_search_field_should_clear.js
+++ b/cypress/support/step_definitions/Search/the_search_field_should_clear.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the search field should clear", () => {
-  cy.get(".searchable-input .ds-select input")
-    .should("have.text", "");
-});
+defineStep('the search field should clear', () => {
+  cy.get('.searchable-input .ds-select input')
+    .should('have.text', '')
+})

--- a/cypress/support/step_definitions/Search/the_search_parameter_equals_{string}.js
+++ b/cypress/support/step_definitions/Search/the_search_parameter_equals_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search parameter equals {string}', search => {
   cy.location('search')

--- a/cypress/support/step_definitions/Search/the_search_parameter_equals_{string}.js
+++ b/cypress/support/step_definitions/Search/the_search_parameter_equals_{string}.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the search parameter equals {string}", search => {
-  cy.location("search")
-    .should("eq", search);
-});
+defineStep('the search parameter equals {string}', search => {
+  cy.location('search')
+    .should('eq', search)
+})

--- a/cypress/support/step_definitions/Search/the_search_parameter_equals_{string}.js
+++ b/cypress/support/step_definitions/Search/the_search_parameter_equals_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search parameter equals {string}', search => {
   cy.location('search')

--- a/cypress/support/step_definitions/User.Authentication/I_am_logged_in_with_username_{string}.js
+++ b/cypress/support/step_definitions/User.Authentication/I_am_logged_in_with_username_{string}.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I am logged in with username {string}", name => {
-  cy.get(".avatar-menu").click();
-  cy.get(".avatar-menu-popover").contains(name);
-  cy.get(".avatar-menu").click(); // Close menu again
-});
+defineStep('I am logged in with username {string}', name => {
+  cy.get('.avatar-menu').click()
+  cy.get('.avatar-menu-popover').contains(name)
+  cy.get('.avatar-menu').click() // Close menu again
+})

--- a/cypress/support/step_definitions/User.Authentication/I_am_logged_in_with_username_{string}.js
+++ b/cypress/support/step_definitions/User.Authentication/I_am_logged_in_with_username_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I am logged in with username {string}', name => {
   cy.get('.avatar-menu').click()

--- a/cypress/support/step_definitions/User.Authentication/I_am_logged_in_with_username_{string}.js
+++ b/cypress/support/step_definitions/User.Authentication/I_am_logged_in_with_username_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I am logged in with username {string}', name => {
   cy.get('.avatar-menu').click()

--- a/cypress/support/step_definitions/User.Block/I_block_the_user_{string}.js
+++ b/cypress/support/step_definitions/User.Block/I_block_the_user_{string}.js
@@ -1,11 +1,11 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I block the user {string}", name => {
+defineStep('I block the user {string}', name => {
   cy.neode()
-    .firstOf("User", { name })
+    .firstOf('User', { name })
     .then(blockedUser => {
       cy.neode()
-        .firstOf("User", {id: "id-of-peter-pan"})
-        .relateTo(blockedUser, "blocked");
-    });
-});
+        .firstOf('User', {id: 'id-of-peter-pan'})
+        .relateTo(blockedUser, 'blocked')
+    })
+})

--- a/cypress/support/step_definitions/User.Block/I_block_the_user_{string}.js
+++ b/cypress/support/step_definitions/User.Block/I_block_the_user_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I block the user {string}', name => {
   cy.neode()

--- a/cypress/support/step_definitions/User.Block/I_block_the_user_{string}.js
+++ b/cypress/support/step_definitions/User.Block/I_block_the_user_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I block the user {string}', name => {
   cy.neode()

--- a/cypress/support/step_definitions/User.Block/I_should_not_see_{string}_button.js
+++ b/cypress/support/step_definitions/User.Block/I_should_not_see_{string}_button.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should not see {string} button', button => {
   cy.get('.base-card .action-buttons')

--- a/cypress/support/step_definitions/User.Block/I_should_not_see_{string}_button.js
+++ b/cypress/support/step_definitions/User.Block/I_should_not_see_{string}_button.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should not see {string} button', button => {
   cy.get('.base-card .action-buttons')

--- a/cypress/support/step_definitions/User.Block/I_should_not_see_{string}_button.js
+++ b/cypress/support/step_definitions/User.Block/I_should_not_see_{string}_button.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I should not see {string} button', button => {
+defineStep('I should not see {string} button', button => {
   cy.get('.base-card .action-buttons')
     .should('have.length', 1)
 })

--- a/cypress/support/step_definitions/User.Block/I_should_see_no_users_in_my_blocked_users_list.js
+++ b/cypress/support/step_definitions/User.Block/I_should_see_no_users_in_my_blocked_users_list.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see no users in my blocked users list', () => {
   cy.get('.ds-placeholder')

--- a/cypress/support/step_definitions/User.Block/I_should_see_no_users_in_my_blocked_users_list.js
+++ b/cypress/support/step_definitions/User.Block/I_should_see_no_users_in_my_blocked_users_list.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see no users in my blocked users list', () => {
   cy.get('.ds-placeholder')

--- a/cypress/support/step_definitions/User.Block/I_should_see_no_users_in_my_blocked_users_list.js
+++ b/cypress/support/step_definitions/User.Block/I_should_see_no_users_in_my_blocked_users_list.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see no users in my blocked users list", () => {
+defineStep('I should see no users in my blocked users list', () => {
   cy.get('.ds-placeholder')
-    .should('contain', "So far, you have not blocked anybody.")
+    .should('contain', 'So far, you have not blocked anybody.')
 })

--- a/cypress/support/step_definitions/User.Block/I_should_see_the_{string}_button.js
+++ b/cypress/support/step_definitions/User.Block/I_should_see_the_{string}_button.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the {string} button', button => {
   cy.get('.base-card .action-buttons .base-button')

--- a/cypress/support/step_definitions/User.Block/I_should_see_the_{string}_button.js
+++ b/cypress/support/step_definitions/User.Block/I_should_see_the_{string}_button.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I should see the {string} button', button => {
+defineStep('I should see the {string} button', button => {
   cy.get('.base-card .action-buttons .base-button')
     .should('contain', button)
 })

--- a/cypress/support/step_definitions/User.Block/I_should_see_the_{string}_button.js
+++ b/cypress/support/step_definitions/User.Block/I_should_see_the_{string}_button.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the {string} button', button => {
   cy.get('.base-card .action-buttons .base-button')

--- a/cypress/support/step_definitions/User.Block/I_{string}_see_{string}_from_the_content_menu_in_the_user_info_box.js
+++ b/cypress/support/step_definitions/User.Block/I_{string}_see_{string}_from_the_content_menu_in_the_user_info_box.js
@@ -1,7 +1,7 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I {string} see {string} from the content menu in the user info box", (condition, link) => {
-  cy.get(".user-content-menu .base-button").click()
-  cy.get(".popover .ds-menu-item-link")
+defineStep('I {string} see {string} from the content menu in the user info box', (condition, link) => {
+  cy.get('.user-content-menu .base-button').click()
+  cy.get('.popover .ds-menu-item-link')
     .should(condition === 'should' ? 'contain' : 'not.contain', link)
 })

--- a/cypress/support/step_definitions/User.Block/I_{string}_see_{string}_from_the_content_menu_in_the_user_info_box.js
+++ b/cypress/support/step_definitions/User.Block/I_{string}_see_{string}_from_the_content_menu_in_the_user_info_box.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I {string} see {string} from the content menu in the user info box', (condition, link) => {
   cy.get('.user-content-menu .base-button').click()

--- a/cypress/support/step_definitions/User.Block/I_{string}_see_{string}_from_the_content_menu_in_the_user_info_box.js
+++ b/cypress/support/step_definitions/User.Block/I_{string}_see_{string}_from_the_content_menu_in_the_user_info_box.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I {string} see {string} from the content menu in the user info box', (condition, link) => {
   cy.get('.user-content-menu .base-button').click()

--- a/cypress/support/step_definitions/User.Block/a_user_has_blocked_me.js
+++ b/cypress/support/step_definitions/User.Block/a_user_has_blocked_me.js
@@ -1,15 +1,15 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("a user has blocked me", () => {
+defineStep('a user has blocked me', () => {
   cy.neode()
-    .firstOf("User", {
-      name: "Peter Pan"
+    .firstOf('User', {
+      name: 'Peter Pan'
     })
     .then(blockedUser => {
       cy.neode()
-        .firstOf("User", {
+        .firstOf('User', {
           name: 'Harassing User'
         })
-        .relateTo(blockedUser, "blocked");
-    });
-});
+        .relateTo(blockedUser, 'blocked')
+    })
+})

--- a/cypress/support/step_definitions/User.Block/a_user_has_blocked_me.js
+++ b/cypress/support/step_definitions/User.Block/a_user_has_blocked_me.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('a user has blocked me', () => {
   cy.neode()

--- a/cypress/support/step_definitions/User.Block/a_user_has_blocked_me.js
+++ b/cypress/support/step_definitions/User.Block/a_user_has_blocked_me.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('a user has blocked me', () => {
   cy.neode()

--- a/cypress/support/step_definitions/User.Block/they_should_not_see_the_comment_form.js
+++ b/cypress/support/step_definitions/User.Block/they_should_not_see_the_comment_form.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they should not see the comment form', () => {
   cy.get('.base-card').children().should('not.have.class', 'comment-form')

--- a/cypress/support/step_definitions/User.Block/they_should_not_see_the_comment_form.js
+++ b/cypress/support/step_definitions/User.Block/they_should_not_see_the_comment_form.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("they should not see the comment form", () => {
-  cy.get(".base-card").children().should('not.have.class', 'comment-form')
+defineStep('they should not see the comment form', () => {
+  cy.get('.base-card').children().should('not.have.class', 'comment-form')
 })

--- a/cypress/support/step_definitions/User.Block/they_should_not_see_the_comment_form.js
+++ b/cypress/support/step_definitions/User.Block/they_should_not_see_the_comment_form.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they should not see the comment form', () => {
   cy.get('.base-card').children().should('not.have.class', 'comment-form')

--- a/cypress/support/step_definitions/User.Block/they_should_see_a_text_explaining_why_commenting_is_not_possible.js
+++ b/cypress/support/step_definitions/User.Block/they_should_see_a_text_explaining_why_commenting_is_not_possible.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they should see a text explaining why commenting is not possible', () => {
   cy.get('.ds-placeholder').should('contain', 'Commenting is not possible at this time on this post.')

--- a/cypress/support/step_definitions/User.Block/they_should_see_a_text_explaining_why_commenting_is_not_possible.js
+++ b/cypress/support/step_definitions/User.Block/they_should_see_a_text_explaining_why_commenting_is_not_possible.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they should see a text explaining why commenting is not possible', () => {
   cy.get('.ds-placeholder').should('contain', 'Commenting is not possible at this time on this post.')

--- a/cypress/support/step_definitions/User.Block/they_should_see_a_text_explaining_why_commenting_is_not_possible.js
+++ b/cypress/support/step_definitions/User.Block/they_should_see_a_text_explaining_why_commenting_is_not_possible.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("they should see a text explaining why commenting is not possible", () => {
-  cy.get('.ds-placeholder').should('contain', "Commenting is not possible at this time on this post.")
+defineStep('they should see a text explaining why commenting is not possible', () => {
+  cy.get('.ds-placeholder').should('contain', 'Commenting is not possible at this time on this post.')
 })

--- a/cypress/support/step_definitions/User.Mute/I_mute_the_user_{string}.js
+++ b/cypress/support/step_definitions/User.Mute/I_mute_the_user_{string}.js
@@ -1,13 +1,13 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I mute the user {string}", name => {
+defineStep('I mute the user {string}', name => {
   cy.neode()
-    .firstOf("User", { name })
+    .firstOf('User', { name })
     .then(mutedUser => {
       cy.neode()
-        .firstOf("User", {
-          name: "Peter Pan"
+        .firstOf('User', {
+          name: 'Peter Pan'
         })
-        .relateTo(mutedUser, "muted");
-    });
-});
+        .relateTo(mutedUser, 'muted')
+    })
+})

--- a/cypress/support/step_definitions/User.Mute/I_mute_the_user_{string}.js
+++ b/cypress/support/step_definitions/User.Mute/I_mute_the_user_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I mute the user {string}', name => {
   cy.neode()

--- a/cypress/support/step_definitions/User.Mute/I_mute_the_user_{string}.js
+++ b/cypress/support/step_definitions/User.Mute/I_mute_the_user_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I mute the user {string}', name => {
   cy.neode()

--- a/cypress/support/step_definitions/User.Mute/the_list_of_posts_of_this_user_is_empty.js
+++ b/cypress/support/step_definitions/User.Mute/the_list_of_posts_of_this_user_is_empty.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the list of posts of this user is empty", () => {
-  cy.get(".base-card").not(".post-link");
-  cy.get(".main-container").find(".ds-space.hc-empty");
-});
+defineStep('the list of posts of this user is empty', () => {
+  cy.get('.base-card').not('.post-link')
+  cy.get('.main-container').find('.ds-space.hc-empty')
+})

--- a/cypress/support/step_definitions/User.Mute/the_list_of_posts_of_this_user_is_empty.js
+++ b/cypress/support/step_definitions/User.Mute/the_list_of_posts_of_this_user_is_empty.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the list of posts of this user is empty', () => {
   cy.get('.base-card').not('.post-link')

--- a/cypress/support/step_definitions/User.Mute/the_list_of_posts_of_this_user_is_empty.js
+++ b/cypress/support/step_definitions/User.Mute/the_list_of_posts_of_this_user_is_empty.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the list of posts of this user is empty', () => {
   cy.get('.base-card').not('.post-link')

--- a/cypress/support/step_definitions/User.Mute/the_search_should_contain_the_annoying_user.js
+++ b/cypress/support/step_definitions/User.Mute/the_search_should_contain_the_annoying_user.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search should contain the annoying user', () => {
   cy.get('.searchable-input .ds-select-dropdown')

--- a/cypress/support/step_definitions/User.Mute/the_search_should_contain_the_annoying_user.js
+++ b/cypress/support/step_definitions/User.Mute/the_search_should_contain_the_annoying_user.js
@@ -1,13 +1,13 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the search should contain the annoying user", () => {
-  cy.get(".searchable-input .ds-select-dropdown")
+defineStep('the search should contain the annoying user', () => {
+  cy.get('.searchable-input .ds-select-dropdown')
     .should($li => {
-      expect($li).to.have.length(1);
+      expect($li).to.have.length(1)
     })
-  cy.get(".ds-select-dropdown .user-teaser .slug")
-    .should("contain", '@annoying-user');
-  cy.get(".searchable-input .ds-select input")
+  cy.get('.ds-select-dropdown .user-teaser .slug')
+    .should('contain', '@annoying-user')
+  cy.get('.searchable-input .ds-select input')
     .focus()
-    .type("{esc}");
+    .type('{esc}')
 })

--- a/cypress/support/step_definitions/User.Mute/the_search_should_contain_the_annoying_user.js
+++ b/cypress/support/step_definitions/User.Mute/the_search_should_contain_the_annoying_user.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search should contain the annoying user', () => {
   cy.get('.searchable-input .ds-select-dropdown')

--- a/cypress/support/step_definitions/User.Mute/the_search_should_not_contain_posts_by_the_annoying_user.js
+++ b/cypress/support/step_definitions/User.Mute/the_search_should_not_contain_posts_by_the_annoying_user.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search should not contain posts by the annoying user', () => {
   cy.get('.searchable-input .ds-select-dropdown').should($li => {

--- a/cypress/support/step_definitions/User.Mute/the_search_should_not_contain_posts_by_the_annoying_user.js
+++ b/cypress/support/step_definitions/User.Mute/the_search_should_not_contain_posts_by_the_annoying_user.js
@@ -1,10 +1,10 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the search should not contain posts by the annoying user", () => {
-  cy.get(".searchable-input .ds-select-dropdown").should($li => {
-    expect($li).to.have.length(1);
+defineStep('the search should not contain posts by the annoying user', () => {
+  cy.get('.searchable-input .ds-select-dropdown').should($li => {
+    expect($li).to.have.length(1)
   })
-  cy.get(".ds-select-dropdown")
-    .should("not.have.class", '.search-post')
-    .should("not.contain", 'Spam')
-});
+  cy.get('.ds-select-dropdown')
+    .should('not.have.class', '.search-post')
+    .should('not.contain', 'Spam')
+})

--- a/cypress/support/step_definitions/User.Mute/the_search_should_not_contain_posts_by_the_annoying_user.js
+++ b/cypress/support/step_definitions/User.Mute/the_search_should_not_contain_posts_by_the_annoying_user.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the search should not contain posts by the annoying user', () => {
   cy.get('.searchable-input .ds-select-dropdown').should($li => {

--- a/cypress/support/step_definitions/User.SettingNotifications/I_click_on_element_with_ID_{string}.js
+++ b/cypress/support/step_definitions/User.SettingNotifications/I_click_on_element_with_ID_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on element with ID {string}', (id) => {
   cy.get('#' + id).click()

--- a/cypress/support/step_definitions/User.SettingNotifications/I_click_on_element_with_ID_{string}.js
+++ b/cypress/support/step_definitions/User.SettingNotifications/I_click_on_element_with_ID_{string}.js
@@ -1,5 +1,5 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I click on element with ID {string}", (id) => {
+defineStep('I click on element with ID {string}', (id) => {
   cy.get('#' + id).click()
 })

--- a/cypress/support/step_definitions/User.SettingNotifications/I_click_on_element_with_ID_{string}.js
+++ b/cypress/support/step_definitions/User.SettingNotifications/I_click_on_element_with_ID_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on element with ID {string}', (id) => {
   cy.get('#' + id).click()

--- a/cypress/support/step_definitions/User.SettingNotifications/I_click_save.js
+++ b/cypress/support/step_definitions/User.SettingNotifications/I_click_save.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click save', () => {
   cy.get('.save-button').click()

--- a/cypress/support/step_definitions/User.SettingNotifications/I_click_save.js
+++ b/cypress/support/step_definitions/User.SettingNotifications/I_click_save.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click save', () => {
   cy.get('.save-button').click()

--- a/cypress/support/step_definitions/User.SettingNotifications/I_click_save.js
+++ b/cypress/support/step_definitions/User.SettingNotifications/I_click_save.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I click save", () => {
-  cy.get(".save-button").click()
+defineStep('I click save', () => {
+  cy.get('.save-button').click()
 })

--- a/cypress/support/step_definitions/UserProfile.Avatar/I_cannot_upload_a_picture.js
+++ b/cypress/support/step_definitions/UserProfile.Avatar/I_cannot_upload_a_picture.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I cannot upload a picture', () => {
   cy.get('.base-card')

--- a/cypress/support/step_definitions/UserProfile.Avatar/I_cannot_upload_a_picture.js
+++ b/cypress/support/step_definitions/UserProfile.Avatar/I_cannot_upload_a_picture.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I cannot upload a picture", () => {
-  cy.get(".base-card")
+defineStep('I cannot upload a picture', () => {
+  cy.get('.base-card')
     .children()
-    .should("not.have.id", "customdropzone")
-    .should("have.class", "profile-avatar");
-});
+    .should('not.have.id', 'customdropzone')
+    .should('have.class', 'profile-avatar')
+})

--- a/cypress/support/step_definitions/UserProfile.Avatar/I_cannot_upload_a_picture.js
+++ b/cypress/support/step_definitions/UserProfile.Avatar/I_cannot_upload_a_picture.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I cannot upload a picture', () => {
   cy.get('.base-card')

--- a/cypress/support/step_definitions/UserProfile.Avatar/I_should_be_able_to_change_my_profile_picture.js
+++ b/cypress/support/step_definitions/UserProfile.Avatar/I_should_be_able_to_change_my_profile_picture.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should be able to change my profile picture', () => {
   const avatarUpload = 'onourjourney.png'

--- a/cypress/support/step_definitions/UserProfile.Avatar/I_should_be_able_to_change_my_profile_picture.js
+++ b/cypress/support/step_definitions/UserProfile.Avatar/I_should_be_able_to_change_my_profile_picture.js
@@ -1,15 +1,15 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should be able to change my profile picture", () => {
-  const avatarUpload = "onourjourney.png";
+defineStep('I should be able to change my profile picture', () => {
+  const avatarUpload = 'onourjourney.png'
 
-  cy.get("#customdropzone").selectFile(
-    { contents: `cypress/fixtures/${avatarUpload}`, fileName: avatarUpload, mimeType: "image/png" },
-    { action: "drag-drop" }
-  );
-  cy.get(".profile-page-avatar img")
-    .should("have.attr", "src")
-    .and("contains", "onourjourney");
-  cy.contains(".iziToast-message", "Upload successful")
-    .should("have.length",1);
-});
+  cy.get('#customdropzone').selectFile(
+    { contents: `cypress/fixtures/${avatarUpload}`, fileName: avatarUpload, mimeType: 'image/png' },
+    { action: 'drag-drop' }
+  )
+  cy.get('.profile-page-avatar img')
+    .should('have.attr', 'src')
+    .and('contains', 'onourjourney')
+  cy.contains('.iziToast-message', 'Upload successful')
+    .should('have.length',1)
+})

--- a/cypress/support/step_definitions/UserProfile.Avatar/I_should_be_able_to_change_my_profile_picture.js
+++ b/cypress/support/step_definitions/UserProfile.Avatar/I_should_be_able_to_change_my_profile_picture.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should be able to change my profile picture', () => {
   const avatarUpload = 'onourjourney.png'

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_can_login_successfully.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_can_login_successfully.js
@@ -1,7 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I can login successfully", () => {
-  // cy.reload();
-  cy.get(".iziToast-wrapper")
-     .should("contain", "You are logged in!");
-});
+defineStep('I can login successfully', () => {
+  cy.get('.iziToast-wrapper')
+     .should('contain', 'You are logged in!')
+})

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_can_login_successfully.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_can_login_successfully.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can login successfully', () => {
   cy.get('.iziToast-wrapper')

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_can_login_successfully.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_can_login_successfully.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can login successfully', () => {
   cy.get('.iziToast-wrapper')

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_login_anymore.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_login_anymore.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I cannot login anymore', password => {
   cy.get('.iziToast-wrapper')

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_login_anymore.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_login_anymore.js
@@ -1,7 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I cannot login anymore", password => {
-  //cy.reload();
-  cy.get(".iziToast-wrapper")
-    .should("contain", "Incorrect email address or password.");
-});
+defineStep('I cannot login anymore', password => {
+  cy.get('.iziToast-wrapper')
+    .should('contain', 'Incorrect email address or password.')
+})

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_login_anymore.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_login_anymore.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I cannot login anymore', password => {
   cy.get('.iziToast-wrapper')

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_submit_the_form.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_submit_the_form.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I cannot submit the form", () => {
-  cy.get("button[type=submit]")
-    .should('be.disabled');
-});
+defineStep('I cannot submit the form', () => {
+  cy.get('button[type=submit]')
+    .should('be.disabled')
+})

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_submit_the_form.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_submit_the_form.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I cannot submit the form', () => {
   cy.get('button[type=submit]')

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_submit_the_form.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_cannot_submit_the_form.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I cannot submit the form', () => {
   cy.get('button[type=submit]')

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_fill_the_password_form_with.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_fill_the_password_form_with.js
@@ -1,11 +1,11 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I fill the password form with:", table => {
-  table = table.rowsHash();
-  cy.get("input[id=oldPassword]")
-    .type(table["Your old password"])
-    .get("input[id=password]")
-    .type(table["Your new password"])
-    .get("input[id=passwordConfirmation]")
-    .type(table["Confirm new password"]);
-});
+defineStep('I fill the password form with:', table => {
+  table = table.rowsHash()
+  cy.get('input[id=oldPassword]')
+    .type(table['Your old password'])
+    .get('input[id=password]')
+    .type(table['Your new password'])
+    .get('input[id=passwordConfirmation]')
+    .type(table['Confirm new password'])
+})

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_fill_the_password_form_with.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_fill_the_password_form_with.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I fill the password form with:', table => {
   table = table.rowsHash()

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_fill_the_password_form_with.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_fill_the_password_form_with.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I fill the password form with:', table => {
   table = table.rowsHash()

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_submit_the_form.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_submit_the_form.js
@@ -1,5 +1,5 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I submit the form", () => {
-  cy.get("form").submit();
-});
+defineStep('I submit the form', () => {
+  cy.get('form').submit()
+})

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_submit_the_form.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_submit_the_form.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I submit the form', () => {
   cy.get('form').submit()

--- a/cypress/support/step_definitions/UserProfile.ChangePassword/I_submit_the_form.js
+++ b/cypress/support/step_definitions/UserProfile.ChangePassword/I_submit_the_form.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I submit the form', () => {
   cy.get('form').submit()

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_can_see_my_new_name_{string}_when_I_click_on_my_profile_picture_in_the_top_right.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_can_see_my_new_name_{string}_when_I_click_on_my_profile_picture_in_the_top_right.js
@@ -1,10 +1,10 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I can see my new name {string} when I click on my profile picture in the top right', name => {
+defineStep('I can see my new name {string} when I click on my profile picture in the top right', name => {
   cy.get(".avatar-menu").then(($menu) => {
     if (!$menu.is(':visible')){
-      cy.scrollTo("top");
-      cy.wait(500);
+      cy.scrollTo("top")
+      cy.wait(500)
     }
   })
   cy.get('.avatar-menu').click() // open

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_can_see_my_new_name_{string}_when_I_click_on_my_profile_picture_in_the_top_right.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_can_see_my_new_name_{string}_when_I_click_on_my_profile_picture_in_the_top_right.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can see my new name {string} when I click on my profile picture in the top right', name => {
   cy.get(".avatar-menu").then(($menu) => {

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_can_see_my_new_name_{string}_when_I_click_on_my_profile_picture_in_the_top_right.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_can_see_my_new_name_{string}_when_I_click_on_my_profile_picture_in_the_top_right.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can see my new name {string} when I click on my profile picture in the top right', name => {
   cy.get(".avatar-menu").then(($menu) => {

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_have_the_following_self-description.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_have_the_following_self-description.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I have the following self-description:', text => {
     cy.get('textarea[id=about]')

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_have_the_following_self-description.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_have_the_following_self-description.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I have the following self-description:', text => {
+defineStep('I have the following self-description:', text => {
     cy.get('textarea[id=about]')
       .clear()
       .type(text)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_have_the_following_self-description.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_have_the_following_self-description.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I have the following self-description:', text => {
     cy.get('textarea[id=about]')

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_location.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_location.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I save {string} as my location', location => {
     cy.get('input[id=city]').type(location)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_location.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_location.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I save {string} as my location', location => {
     cy.get('input[id=city]').type(location)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_location.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_location.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I save {string} as my location', location => {
+defineStep('I save {string} as my location', location => {
     cy.get('input[id=city]').type(location)
     cy.get('.ds-select-option')
       .contains(location)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_new_name.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_new_name.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I save {string} as my new name', name => {
+defineStep('I save {string} as my new name', name => {
   cy.get('input[id=name]')
     .clear()
     .type(name)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_new_name.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_new_name.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I save {string} as my new name', name => {
   cy.get('input[id=name]')

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_new_name.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/I_save_{string}_as_my_new_name.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I save {string} as my new name', name => {
   cy.get('input[id=name]')

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_the_following_text_in_the_info_box_below_my_avatar.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_the_following_text_in_the_info_box_below_my_avatar.js
@@ -1,5 +1,5 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('they can see the following text in the info box below my avatar:', text => {
+defineStep('they can see the following text in the info box below my avatar:', text => {
   cy.contains(text)
 })

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_the_following_text_in_the_info_box_below_my_avatar.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_the_following_text_in_the_info_box_below_my_avatar.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they can see the following text in the info box below my avatar:', text => {
   cy.contains(text)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_the_following_text_in_the_info_box_below_my_avatar.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_the_following_text_in_the_info_box_below_my_avatar.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they can see the following text in the info box below my avatar:', text => {
   cy.contains(text)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_{string}_in_the_info_box_below_my_avatar.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_{string}_in_the_info_box_below_my_avatar.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they can see {string} in the info box below my avatar', location => {
   cy.contains(location)

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_{string}_in_the_info_box_below_my_avatar.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_{string}_in_the_info_box_below_my_avatar.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('they can see {string} in the info box below my avatar', location => {
+defineStep('they can see {string} in the info box below my avatar', location => {
   cy.contains(location)
 })

--- a/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_{string}_in_the_info_box_below_my_avatar.js
+++ b/cypress/support/step_definitions/UserProfile.NameDescriptionLocation/they_can_see_{string}_in_the_info_box_below_my_avatar.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they can see {string} in the info box below my avatar', location => {
   cy.contains(location)

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I add a social media link', () => {
   cy.get('[data-test="add-save-button"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I add a social media link', () => {
   cy.get('[data-test="add-save-button"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I add a social media link', () => {
+defineStep('I add a social media link', () => {
   cy.get('[data-test="add-save-button"]')
     .click()
     .get('#editSocialMedia')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_can_cancel_editing.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_can_cancel_editing.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can cancel editing', () => {
   cy.get('button#cancel')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_can_cancel_editing.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_can_cancel_editing.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can cancel editing', () => {
   cy.get('button#cancel')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_can_cancel_editing.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_can_cancel_editing.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I can cancel editing', () => {
+defineStep('I can cancel editing', () => {
   cy.get('button#cancel')
     .click()
     .get('input#editSocialMedia')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_a_social_media_link.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I delete a social media link', () => {
   cy.get(".base-button[title='Delete']")

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_a_social_media_link.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I delete a social media link', () => {
   cy.get(".base-button[title='Delete']")

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_a_social_media_link.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I delete a social media link', () => {
+defineStep('I delete a social media link', () => {
   cy.get(".base-button[title='Delete']")
     .click()
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I delete the social media link {string}', (link) => {
   cy.get('[data-test="delete-button"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I delete the social media link {string}', (link) => {
   cy.get('[data-test="delete-button"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I delete the social media link {string}', (link) => {
+defineStep('I delete the social media link {string}', (link) => {
   cy.get('[data-test="delete-button"]')
     .click()
   cy.get('[data-test="confirm-modal"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I edit and save the link', () => {
+defineStep('I edit and save the link', () => {
   cy.get('input#editSocialMedia')
     .clear()
     .type('https://freeradical.zone/tinkerbell')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I edit and save the link', () => {
   cy.get('input#editSocialMedia')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I edit and save the link', () => {
   cy.get('input#editSocialMedia')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_a_social_media_link.js
@@ -1,6 +1,6 @@
-import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Given('I have added a social media link', () => {
+defineStep('I have added a social media link', () => {
   cy.visit('/settings/my-social-media')
     .get('button')
     .contains('Add link')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_a_social_media_link.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I have added a social media link', () => {
   cy.visit('/settings/my-social-media')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_a_social_media_link.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I have added a social media link', () => {
   cy.visit('/settings/my-social-media')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
@@ -1,6 +1,6 @@
-import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Given('I have added the social media link {string}', (link) => {
+defineStep('I have added the social media link {string}', (link) => {
   cy.visit('/settings/my-social-media')
     .get('[data-test="add-save-button"]')
     .click()

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I have added the social media link {string}', (link) => {
   cy.visit('/settings/my-social-media')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I have added the social media link {string}', (link) => {
   cy.visit('/settings/my-social-media')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I start editing a social media link', () => {
   cy.get('[data-test="edit-button"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I start editing a social media link', () => {
   cy.get('[data-test="edit-button"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I start editing a social media link', () => {
+defineStep('I start editing a social media link', () => {
   cy.get('[data-test="edit-button"]')
     .click()
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_social_media_link_shows_up_on_the_page.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_social_media_link_shows_up_on_the_page.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the new social media link shows up on the page', () => {
   cy.get('a[href="https://freeradical.zone/peter-pan"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_social_media_link_shows_up_on_the_page.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_social_media_link_shows_up_on_the_page.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('the new social media link shows up on the page', () => {
+defineStep('the new social media link shows up on the page', () => {
   cy.get('a[href="https://freeradical.zone/peter-pan"]')
     .should('have.length', 1)
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_social_media_link_shows_up_on_the_page.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_social_media_link_shows_up_on_the_page.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the new social media link shows up on the page', () => {
   cy.get('a[href="https://freeradical.zone/peter-pan"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_url_is_displayed.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_url_is_displayed.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the new url is displayed', () => {
   cy.get("a[href='https://freeradical.zone/tinkerbell']")

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_url_is_displayed.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_url_is_displayed.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the new url is displayed', () => {
   cy.get("a[href='https://freeradical.zone/tinkerbell']")

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_url_is_displayed.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_new_url_is_displayed.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('the new url is displayed', () => {
+defineStep('the new url is displayed', () => {
   cy.get("a[href='https://freeradical.zone/tinkerbell']")
     .should('have.length', 1)
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_old_url_is_not_displayed.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_old_url_is_not_displayed.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the old url is not displayed', () => {
   cy.get("a[href='https://freeradical.zone/peter-pan']")

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_old_url_is_not_displayed.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_old_url_is_not_displayed.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the old url is not displayed', () => {
   cy.get("a[href='https://freeradical.zone/peter-pan']")

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/the_old_url_is_not_displayed.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/the_old_url_is_not_displayed.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('the old url is not displayed', () => {
+defineStep('the old url is not displayed', () => {
   cy.get("a[href='https://freeradical.zone/peter-pan']")
     .should('have.length', 0)
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('they should be able to see my social media links', () => {
+defineStep('they should be able to see my social media links', () => {
   cy.get('[data-test="social-media-list-headline"]')
     .contains('Peter Pan')
     .get('a[href="https://freeradical.zone/peter-pan"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they should be able to see my social media links', () => {
   cy.get('[data-test="social-media-list-headline"]')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they should be able to see my social media links', () => {
   cy.get('[data-test="social-media-list-headline"]')

--- a/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
+++ b/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
@@ -1,4 +1,4 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import encode from '../../../../backend/build/src/jwt/encode'
 
 defineStep('I am logged in as {string}', slug => {

--- a/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
+++ b/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
@@ -1,7 +1,7 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import encode from '../../../../backend/build/src/jwt/encode'
 
-Given('I am logged in as {string}', slug => {
+defineStep('I am logged in as {string}', slug => {
   cy.neode()
     .firstOf('User', { slug })
     .then(user => {
@@ -15,4 +15,4 @@ Given('I am logged in as {string}', slug => {
     .then(user => {
       cy.setCookie('ocelot-social-token', encode(user))
     })
-});
+})

--- a/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
+++ b/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
@@ -1,3 +1,4 @@
+import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import encode from '../../../../backend/build/src/jwt/encode'
 
 defineStep('I am logged in as {string}', slug => {

--- a/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
+++ b/cypress/support/step_definitions/common/I_am_logged_in_as_{string}.js
@@ -1,4 +1,3 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import encode from '../../../../backend/build/src/jwt/encode'
 
 defineStep('I am logged in as {string}', slug => {

--- a/cypress/support/step_definitions/common/I_am_on_page_{string}.js
+++ b/cypress/support/step_definitions/common/I_am_on_page_{string}.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I am on page {string}", page => {
-  cy.location("pathname")
-    .should("match", new RegExp(page));
-});
+defineStep('I am on page {string}', page => {
+  cy.location('pathname')
+    .should('match', new RegExp(page))
+})

--- a/cypress/support/step_definitions/common/I_am_on_page_{string}.js
+++ b/cypress/support/step_definitions/common/I_am_on_page_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I am on page {string}', page => {
   cy.location('pathname')

--- a/cypress/support/step_definitions/common/I_am_on_page_{string}.js
+++ b/cypress/support/step_definitions/common/I_am_on_page_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I am on page {string}', page => {
   cy.location('pathname')

--- a/cypress/support/step_definitions/common/I_can_see_the_following_table.js
+++ b/cypress/support/step_definitions/common/I_can_see_the_following_table.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then('I can see the following table:', table => {
+defineStep('I can see the following table:', table => {
   const headers = table.raw()[0]
   headers.forEach((expected, i) => {
     cy.get('thead th')

--- a/cypress/support/step_definitions/common/I_can_see_the_following_table.js
+++ b/cypress/support/step_definitions/common/I_can_see_the_following_table.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can see the following table:', table => {
   const headers = table.raw()[0]

--- a/cypress/support/step_definitions/common/I_can_see_the_following_table.js
+++ b/cypress/support/step_definitions/common/I_can_see_the_following_table.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I can see the following table:', table => {
   const headers = table.raw()[0]

--- a/cypress/support/step_definitions/common/I_choose_the_following_text_as_content.js
+++ b/cypress/support/step_definitions/common/I_choose_the_following_text_as_content.js
@@ -1,9 +1,9 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I choose the following text as content:", text => {
+defineStep('I choose the following text as content:', text => {
   cy.task('getValue', 'lastPost').then(lastPost => {
-    lastPost.content = text.replace("\n", " ");
+    lastPost.content = text.replace('\n', ' ')
     cy.task('pushValue', { name: 'lastPost', value: lastPost })
-    cy.get(".editor .ProseMirror").type(lastPost.content);
+    cy.get('.editor .ProseMirror').type(lastPost.content)
   })
-});
+})

--- a/cypress/support/step_definitions/common/I_choose_the_following_text_as_content.js
+++ b/cypress/support/step_definitions/common/I_choose_the_following_text_as_content.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I choose the following text as content:', text => {
   cy.task('getValue', 'lastPost').then(lastPost => {

--- a/cypress/support/step_definitions/common/I_choose_the_following_text_as_content.js
+++ b/cypress/support/step_definitions/common/I_choose_the_following_text_as_content.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I choose the following text as content:', text => {
   cy.task('getValue', 'lastPost').then(lastPost => {

--- a/cypress/support/step_definitions/common/I_click_on_{string}.js
+++ b/cypress/support/step_definitions/common/I_click_on_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on {string}', element => {
   const elementSelectors = {

--- a/cypress/support/step_definitions/common/I_click_on_{string}.js
+++ b/cypress/support/step_definitions/common/I_click_on_{string}.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I click on {string}", element => {
+defineStep('I click on {string}', element => {
   const elementSelectors = {
     'submit button': 'button[name=submit]',
     'create post button': '.post-add-button',
@@ -15,5 +15,5 @@ When("I click on {string}", element => {
 
   cy.get(elementSelectors[element])
     .click()
-    .wait(750);
-});
+    .wait(750)
+})

--- a/cypress/support/step_definitions/common/I_click_on_{string}.js
+++ b/cypress/support/step_definitions/common/I_click_on_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on {string}', element => {
   const elementSelectors = {

--- a/cypress/support/step_definitions/common/I_click_on_{string}_from_the_content_menu_in_the_user_info_box.js
+++ b/cypress/support/step_definitions/common/I_click_on_{string}_from_the_content_menu_in_the_user_info_box.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on {string} from the content menu in the user info box',
   button => {

--- a/cypress/support/step_definitions/common/I_click_on_{string}_from_the_content_menu_in_the_user_info_box.js
+++ b/cypress/support/step_definitions/common/I_click_on_{string}_from_the_content_menu_in_the_user_info_box.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on {string} from the content menu in the user info box',
   button => {

--- a/cypress/support/step_definitions/common/I_click_on_{string}_from_the_content_menu_in_the_user_info_box.js
+++ b/cypress/support/step_definitions/common/I_click_on_{string}_from_the_content_menu_in_the_user_info_box.js
@@ -1,12 +1,12 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I click on {string} from the content menu in the user info box",
+defineStep('I click on {string} from the content menu in the user info box',
   button => {
-    cy.get(".user-content-menu .base-button").click();
-    cy.get(".popover .ds-menu-item-link")
+    cy.get('.user-content-menu .base-button').click()
+    cy.get('.popover .ds-menu-item-link')
       .contains(button)
       .click({
         force: true
-      });
+      })
     }
-);
+)

--- a/cypress/support/step_definitions/common/I_click_the_checkbox_show_donations_progress_bar_and_save.js
+++ b/cypress/support/step_definitions/common/I_click_the_checkbox_show_donations_progress_bar_and_save.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import 'cypress-network-idle'
 
 defineStep('I click the checkbox show donations progress bar and save', () => {

--- a/cypress/support/step_definitions/common/I_click_the_checkbox_show_donations_progress_bar_and_save.js
+++ b/cypress/support/step_definitions/common/I_click_the_checkbox_show_donations_progress_bar_and_save.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import 'cypress-network-idle'
 
 defineStep('I click the checkbox show donations progress bar and save', () => {

--- a/cypress/support/step_definitions/common/I_click_the_checkbox_show_donations_progress_bar_and_save.js
+++ b/cypress/support/step_definitions/common/I_click_the_checkbox_show_donations_progress_bar_and_save.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
-import 'cypress-network-idle';
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
+import 'cypress-network-idle'
 
-Then("I click the checkbox show donations progress bar and save", () => {
-  cy.get("#showDonations").click()
-  cy.get(".donations-info-button").click()
+defineStep('I click the checkbox show donations progress bar and save', () => {
+  cy.get('#showDonations').click()
+  cy.get('.donations-info-button').click()
   cy.waitForNetworkIdle(2000)
 })

--- a/cypress/support/step_definitions/common/I_fill_in_my_credentials_{string}_{string}.js
+++ b/cypress/support/step_definitions/common/I_fill_in_my_credentials_{string}_{string}.js
@@ -1,12 +1,12 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I fill in my credentials {string} {string}", (email,password) => {
-  cy.get("input[name=email]")
-    .trigger("focus")
+defineStep('I fill in my credentials {string} {string}', (email,password) => {
+  cy.get('input[name=email]')
+    .trigger('focus')
     .type('{selectall}{backspace}')
     .type(email)
-    .get("input[name=password]")
-    .trigger("focus")
+    .get('input[name=password]')
+    .trigger('focus')
     .type('{selectall}{backspace}')
-    .type(password);
-});
+    .type(password)
+})

--- a/cypress/support/step_definitions/common/I_fill_in_my_credentials_{string}_{string}.js
+++ b/cypress/support/step_definitions/common/I_fill_in_my_credentials_{string}_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I fill in my credentials {string} {string}', (email,password) => {
   cy.get('input[name=email]')

--- a/cypress/support/step_definitions/common/I_fill_in_my_credentials_{string}_{string}.js
+++ b/cypress/support/step_definitions/common/I_fill_in_my_credentials_{string}_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I fill in my credentials {string} {string}', (email,password) => {
   cy.get('input[name=email]')

--- a/cypress/support/step_definitions/common/I_follow_the_user_{string}.js
+++ b/cypress/support/step_definitions/common/I_follow_the_user_{string}.js
@@ -1,13 +1,13 @@
-import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Given("I follow the user {string}", name => {
+defineStep('I follow the user {string}', name => {
   cy.neode()
-    .firstOf("User", {name})
+    .firstOf('User', {name})
     .then(followed => {
       cy.neode()
-        .firstOf("User", {
-          name: "Peter Pan"
+        .firstOf('User', {
+          name: 'Peter Pan'
         })
-        .relateTo(followed, "following");
-    });
-});
+        .relateTo(followed, 'following')
+    })
+})

--- a/cypress/support/step_definitions/common/I_follow_the_user_{string}.js
+++ b/cypress/support/step_definitions/common/I_follow_the_user_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I follow the user {string}', name => {
   cy.neode()

--- a/cypress/support/step_definitions/common/I_follow_the_user_{string}.js
+++ b/cypress/support/step_definitions/common/I_follow_the_user_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I follow the user {string}', name => {
   cy.neode()

--- a/cypress/support/step_definitions/common/I_get_removed_from_his_follower_collection.js
+++ b/cypress/support/step_definitions/common/I_get_removed_from_his_follower_collection.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I get removed from his follower collection", () => {
-  cy.get(".base-card")
-    .not(".post-link");
-  cy.get(".main-container")
-    .contains(".base-card","is not followed by anyone");
-  });
+defineStep('I get removed from his follower collection', () => {
+  cy.get('.base-card')
+    .not('.post-link')
+  cy.get('.main-container')
+    .contains('.base-card','is not followed by anyone')
+  })

--- a/cypress/support/step_definitions/common/I_get_removed_from_his_follower_collection.js
+++ b/cypress/support/step_definitions/common/I_get_removed_from_his_follower_collection.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I get removed from his follower collection', () => {
   cy.get('.base-card')

--- a/cypress/support/step_definitions/common/I_get_removed_from_his_follower_collection.js
+++ b/cypress/support/step_definitions/common/I_get_removed_from_his_follower_collection.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I get removed from his follower collection', () => {
   cy.get('.base-card')

--- a/cypress/support/step_definitions/common/I_log_out.js
+++ b/cypress/support/step_definitions/common/I_log_out.js
@@ -1,15 +1,15 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I log out", () => {
-  cy.get(".avatar-menu").then(($menu) => {
+defineStep('I log out', () => {
+  cy.get('.avatar-menu').then(($menu) => {
     if (!$menu.is(':visible')){
-      cy.scrollTo("top");
-      cy.wait(500);
+      cy.scrollTo('top')
+      cy.wait(500)
     }
   })
-  cy.get(".avatar-menu")
-    .click();
-  cy.get(".avatar-menu-popover")
+  cy.get('.avatar-menu')
+    .click()
+  cy.get('.avatar-menu-popover')
     .find('a[href="/logout"]')
-    .click();
-});
+    .click()
+})

--- a/cypress/support/step_definitions/common/I_log_out.js
+++ b/cypress/support/step_definitions/common/I_log_out.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I log out', () => {
   cy.get('.avatar-menu').then(($menu) => {

--- a/cypress/support/step_definitions/common/I_log_out.js
+++ b/cypress/support/step_definitions/common/I_log_out.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I log out', () => {
   cy.get('.avatar-menu').then(($menu) => {

--- a/cypress/support/step_definitions/common/I_navigate_to_my_{string}_settings_page.js
+++ b/cypress/support/step_definitions/common/I_navigate_to_my_{string}_settings_page.js
@@ -1,10 +1,10 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I navigate to my {string} settings page", settingsPage => {
-  cy.get(".avatar-menu-trigger").click();
-  cy.get(".avatar-menu-popover")
-    .find("a[href]")
-    .contains("Settings")
-    .click();
-  cy.contains(".ds-menu-item-link", settingsPage).click();
-});
+defineStep('I navigate to my {string} settings page', settingsPage => {
+  cy.get('.avatar-menu-trigger').click()
+  cy.get('.avatar-menu-popover')
+    .find('a[href]')
+    .contains('Settings')
+    .click()
+  cy.contains('.ds-menu-item-link', settingsPage).click()
+})

--- a/cypress/support/step_definitions/common/I_navigate_to_my_{string}_settings_page.js
+++ b/cypress/support/step_definitions/common/I_navigate_to_my_{string}_settings_page.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I navigate to my {string} settings page', settingsPage => {
   cy.get('.avatar-menu-trigger').click()

--- a/cypress/support/step_definitions/common/I_navigate_to_my_{string}_settings_page.js
+++ b/cypress/support/step_definitions/common/I_navigate_to_my_{string}_settings_page.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I navigate to my {string} settings page', settingsPage => {
   cy.get('.avatar-menu-trigger').click()

--- a/cypress/support/step_definitions/common/I_navigate_to_page_{string}.js
+++ b/cypress/support/step_definitions/common/I_navigate_to_page_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import 'cypress-network-idle'
 
 defineStep('I navigate to page {string}', page => {

--- a/cypress/support/step_definitions/common/I_navigate_to_page_{string}.js
+++ b/cypress/support/step_definitions/common/I_navigate_to_page_{string}.js
@@ -1,7 +1,7 @@
-import { Given } from "@badeball/cypress-cucumber-preprocessor";
-import 'cypress-network-idle';
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
+import 'cypress-network-idle'
 
-Given("I navigate to page {string}", page => {
-  cy.visit(page);
+defineStep('I navigate to page {string}', page => {
+  cy.visit(page)
   cy.waitForNetworkIdle(2000)
-});
+})

--- a/cypress/support/step_definitions/common/I_navigate_to_page_{string}.js
+++ b/cypress/support/step_definitions/common/I_navigate_to_page_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import 'cypress-network-idle'
 
 defineStep('I navigate to page {string}', page => {

--- a/cypress/support/step_definitions/common/I_refresh_the_page.js
+++ b/cypress/support/step_definitions/common/I_refresh_the_page.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I refresh the page', () => {
   cy.visit('/')

--- a/cypress/support/step_definitions/common/I_refresh_the_page.js
+++ b/cypress/support/step_definitions/common/I_refresh_the_page.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I refresh the page', () => {
   cy.visit('/')

--- a/cypress/support/step_definitions/common/I_refresh_the_page.js
+++ b/cypress/support/step_definitions/common/I_refresh_the_page.js
@@ -1,6 +1,6 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When('I refresh the page', () => {
+defineStep('I refresh the page', () => {
   cy.visit('/')
-    .reload();
-});
+    .reload()
+})

--- a/cypress/support/step_definitions/common/I_search_for_{string}.js
+++ b/cypress/support/step_definitions/common/I_search_for_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I search for {string}', value => {
   cy.intercept({

--- a/cypress/support/step_definitions/common/I_search_for_{string}.js
+++ b/cypress/support/step_definitions/common/I_search_for_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I search for {string}', value => {
   cy.intercept({

--- a/cypress/support/step_definitions/common/I_search_for_{string}.js
+++ b/cypress/support/step_definitions/common/I_search_for_{string}.js
@@ -1,12 +1,12 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I search for {string}", value => {
+defineStep('I search for {string}', value => {
   cy.intercept({
-    method: "POST",
-    url: "http://localhost:3000/api",
-  }).as("graphqlRequest");
-  cy.get(".searchable-input .ds-select input")
+    method: 'POST',
+    url: 'http://localhost:3000/api',
+  }).as('graphqlRequest')
+  cy.get('.searchable-input .ds-select input')
     .focus()
-    .type(value);
-  cy.wait("@graphqlRequest");
-});
+    .type(value)
+  cy.wait('@graphqlRequest')
+})

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
@@ -1,9 +1,9 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I see a toaster with status {string}", (status) => {
+defineStep('I see a toaster with status {string}', (status) => {
   switch (status) {
-    case "success":
-      cy.get(".iziToast.iziToast-color-green").should("be.visible");
-      break;
+    case 'success':
+      cy.get('.iziToast.iziToast-color-green').should('be.visible')
+      break
   }
 })

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a toaster with status {string}', (status) => {
   switch (status) {

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a toaster with status {string}', (status) => {
   switch (status) {

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_{string}.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I see a toaster with {string}", (title) => {
-  cy.get(".iziToast-message").should("contain", title);
+defineStep('I see a toaster with {string}', (title) => {
+  cy.get('.iziToast-message').should('contain', title)
 })

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a toaster with {string}', (title) => {
   cy.get('.iziToast-message').should('contain', title)

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a toaster with {string}', (title) => {
   cy.get('.iziToast-message').should('contain', title)

--- a/cypress/support/step_definitions/common/I_see_a_{string}_message.js
+++ b/cypress/support/step_definitions/common/I_see_a_{string}_message.js
@@ -1,5 +1,5 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I see a {string} message:", (_type, message) => {
-  cy.contains(message);
-});
+defineStep('I see a {string} message:', (_type, message) => {
+  cy.contains(message)
+})

--- a/cypress/support/step_definitions/common/I_see_a_{string}_message.js
+++ b/cypress/support/step_definitions/common/I_see_a_{string}_message.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a {string} message:', (_type, message) => {
   cy.contains(message)

--- a/cypress/support/step_definitions/common/I_see_a_{string}_message.js
+++ b/cypress/support/step_definitions/common/I_see_a_{string}_message.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see a {string} message:', (_type, message) => {
   cy.contains(message)

--- a/cypress/support/step_definitions/common/I_should_see_the_following_posts_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/common/I_should_see_the_following_posts_in_the_select_dropdown.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the following posts in the select dropdown:', table => {
   table.hashes().forEach(({ title }) => {

--- a/cypress/support/step_definitions/common/I_should_see_the_following_posts_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/common/I_should_see_the_following_posts_in_the_select_dropdown.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I should see the following posts in the select dropdown:', table => {
   table.hashes().forEach(({ title }) => {

--- a/cypress/support/step_definitions/common/I_should_see_the_following_posts_in_the_select_dropdown.js
+++ b/cypress/support/step_definitions/common/I_should_see_the_following_posts_in_the_select_dropdown.js
@@ -1,8 +1,8 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("I should see the following posts in the select dropdown:", table => {
+defineStep('I should see the following posts in the select dropdown:', table => {
   table.hashes().forEach(({ title }) => {
-    cy.get(".ds-select-dropdown")
-      .should("contain", title);
-  });
-});
+    cy.get('.ds-select-dropdown')
+      .should('contain', title)
+  })
+})

--- a/cypress/support/step_definitions/common/I_wait_for_{int}_milliseconds.js
+++ b/cypress/support/step_definitions/common/I_wait_for_{int}_milliseconds.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I wait for {int} milliseconds', time => {
   cy.wait(time)

--- a/cypress/support/step_definitions/common/I_wait_for_{int}_milliseconds.js
+++ b/cypress/support/step_definitions/common/I_wait_for_{int}_milliseconds.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I wait for {int} milliseconds', time => {
   cy.wait(time)

--- a/cypress/support/step_definitions/common/I_wait_for_{int}_milliseconds.js
+++ b/cypress/support/step_definitions/common/I_wait_for_{int}_milliseconds.js
@@ -1,5 +1,5 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("I wait for {int} milliseconds", time => {
+defineStep('I wait for {int} milliseconds', time => {
   cy.wait(time)
-});
+})

--- a/cypress/support/step_definitions/common/the_checkbox_with_ID_{string}_should_{string}.js
+++ b/cypress/support/step_definitions/common/the_checkbox_with_ID_{string}_should_{string}.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the checkbox with ID {string} should {string}', (id, value) => {
   cy.get('#' + id).should(value)

--- a/cypress/support/step_definitions/common/the_checkbox_with_ID_{string}_should_{string}.js
+++ b/cypress/support/step_definitions/common/the_checkbox_with_ID_{string}_should_{string}.js
@@ -1,5 +1,5 @@
-import { When } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-When("the checkbox with ID {string} should {string}", (id, value) => {
+defineStep('the checkbox with ID {string} should {string}', (id, value) => {
   cy.get('#' + id).should(value)
 })

--- a/cypress/support/step_definitions/common/the_checkbox_with_ID_{string}_should_{string}.js
+++ b/cypress/support/step_definitions/common/the_checkbox_with_ID_{string}_should_{string}.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the checkbox with ID {string} should {string}', (id, value) => {
   cy.get('#' + id).should(value)

--- a/cypress/support/step_definitions/common/the_first_post_on_the_newsfeed_has_the_title.js
+++ b/cypress/support/step_definitions/common/the_first_post_on_the_newsfeed_has_the_title.js
@@ -1,3 +1,4 @@
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the first post on the newsfeed has the title:', title => {
   cy.get('.post-teaser:first')

--- a/cypress/support/step_definitions/common/the_first_post_on_the_newsfeed_has_the_title.js
+++ b/cypress/support/step_definitions/common/the_first_post_on_the_newsfeed_has_the_title.js
@@ -1,6 +1,6 @@
-import { Then } from "@badeball/cypress-cucumber-preprocessor";
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
-Then("the first post on the newsfeed has the title:", title => {
-  cy.get(".post-teaser:first")
-    .should("contain", title);
-});
+defineStep('the first post on the newsfeed has the title:', title => {
+  cy.get('.post-teaser:first')
+    .should('contain', title)
+})

--- a/cypress/support/step_definitions/common/the_first_post_on_the_newsfeed_has_the_title.js
+++ b/cypress/support/step_definitions/common/the_first_post_on_the_newsfeed_has_the_title.js
@@ -1,4 +1,3 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('the first post on the newsfeed has the title:', title => {
   cy.get('.post-teaser:first')

--- a/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
+++ b/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
@@ -1,4 +1,3 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
 defineStep('the following {string} are in the database:', (table,data) => {

--- a/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
+++ b/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
@@ -1,4 +1,4 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
 defineStep('the following {string} are in the database:', (table,data) => {

--- a/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
+++ b/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
@@ -1,3 +1,4 @@
+import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
 defineStep('the following {string} are in the database:', (table,data) => {

--- a/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
+++ b/cypress/support/step_definitions/common/the_following_{string}_are_in_the_database.js
@@ -1,7 +1,7 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
-Given('the following {string} are in the database:', (table,data) => {
+defineStep('the following {string} are in the database:', (table,data) => {
   switch(table){
     case 'posts':
       data.hashes().forEach( entry => {
@@ -13,29 +13,29 @@ Given('the following {string} are in the database:', (table,data) => {
         },{
           ...entry,
           tagIds: entry.tagIds ? entry.tagIds.split(',').map(item => item.trim()) : [],
-        });
+        })
       })
       break
     case 'comments':
       data.hashes().forEach( entry => {
         cy.factory()
-          .build('comment', entry, entry);
+          .build('comment', entry, entry)
       })
       break
     case 'users':
       data.hashes().forEach( entry => {
-        cy.factory().build('user', entry, entry);
-      });
+        cy.factory().build('user', entry, entry)
+      })
       break
     case 'tags':
       data.hashes().forEach( entry => {
         cy.factory().build('tag', entry, entry)
-      });
+      })
       break
     case 'donations':
       data.hashes().forEach( entry => {
         cy.factory().build('donations', entry, entry)
-      });
+      })
       break
   }
 })

--- a/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
+++ b/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
@@ -1,3 +1,4 @@
+import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
 defineStep('{string} wrote a post {string}', (author, title) => {

--- a/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
+++ b/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
@@ -1,11 +1,11 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
-Given('{string} wrote a post {string}', (author, title) => {
+defineStep('{string} wrote a post {string}', (author, title) => {
   cy.factory()
     .build('post', {
       title,
     }, {
       authorId: author,
-    });
-});
+    })
+})

--- a/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
+++ b/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
@@ -1,4 +1,4 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
+import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
 defineStep('{string} wrote a post {string}', (author, title) => {

--- a/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
+++ b/cypress/support/step_definitions/common/{string}_wrote_a_post_{string}.js
@@ -1,4 +1,3 @@
-import { Given } from '@badeball/cypress-cucumber-preprocessor'
 import './../../factories'
 
 defineStep('{string} wrote a post {string}', (author, title) => {


### PR DESCRIPTION
## 🍰 Pullrequest

The [cypress-cucumber-preprocessor](https://github.com/badeball/cypress-cucumber-preprocessor) utliziled in our Cypress setup to process the Cucumber part implements a generic method `defineStep` to simlify step definition independent from specific keywords (`Given`, `Then`, `When`, `And`, `But`).  
To simlify our step definitions we shoulduse it in general.  

Since all step definition files have been touched in this pull request, a little linting has been done on the side to refactor code quality.

