### PR TITLE
refactor(other): replace data-test attributes in e2e tests

### DIFF
--- a/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_click_on_the_author.js
@@ -1,7 +1,9 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I click on the author', () => {
-  cy.get('[data-test="avatarUserLink"]')
+  cy.get('.user-teaser')
+    .find('a[href*="/profile/"]')
+    .first()
     .click()
     .url().should('include', '/profile/')
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_add_a_social_media_link.js
@@ -1,10 +1,11 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I add a social media link', () => {
-  cy.get('[data-test="add-save-button"]')
+  const buttonSelector = 'button.--filled'
+  cy.get(buttonSelector)
     .click()
     .get('#editSocialMedia')
     .type('https://freeradical.zone/peter-pan')
-    .get('[data-test="add-save-button"]')
+    .get(buttonSelector)
     .click()
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_delete_the_social_media_link_{string}.js
@@ -1,11 +1,12 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I delete the social media link {string}', (link) => {
-  cy.get('[data-test="delete-button"]')
+  cy.get('.ds-list-item-content > button.--icon-only')
+    .eq(1)
     .click()
-  cy.get('[data-test="confirm-modal"]')
-    .should("be.visible")
-  cy.get('[data-test="confirm-button"]')
+  cy.get('.ds-modal')
+    .should('be.visible')
+    .get('button.confirm')
     .click()
   cy.get('.ds-list-item-content > a')
     .should('not.exist')

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_edit_and_save_the_link.js
@@ -4,6 +4,6 @@ defineStep('I edit and save the link', () => {
   cy.get('input#editSocialMedia')
     .clear()
     .type('https://freeradical.zone/tinkerbell')
-    .get('[data-test="add-save-button"]')
+    .get('button.--filled')
     .click()
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_have_added_the_social_media_link_{string}.js
@@ -2,11 +2,11 @@ import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I have added the social media link {string}', (link) => {
   cy.visit('/settings/my-social-media')
-    .get('[data-test="add-save-button"]')
+    .get('button.--filled')
     .click()
     .get('#editSocialMedia')
     .type(link)
-    .get('[data-test="add-save-button"]')
+    .get('button.--filled')
     .click()
   cy.get('.ds-list-item-content > a')
     .contains(link)

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/I_start_editing_a_social_media_link.js
@@ -1,6 +1,7 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I start editing a social media link', () => {
-  cy.get('[data-test="edit-button"]')
+  cy.get('.ds-list-item-content > button.--icon-only')
+    .first()
     .click()
 })

--- a/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
+++ b/cypress/support/step_definitions/UserProfile.SocialMedia/they_should_be_able_to_see_my_social_media_links.js
@@ -1,8 +1,8 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('they should be able to see my social media links', () => {
-  cy.get('[data-test="social-media-list-headline"]')
+  cy.get('.social-media-bc')
+    .scrollIntoView()
     .contains('Peter Pan')
     .get('a[href="https://freeradical.zone/peter-pan"]')
-    .should('have.length', 1)
 })

--- a/webapp/components/Modal/ConfirmModal.vue
+++ b/webapp/components/Modal/ConfirmModal.vue
@@ -15,7 +15,6 @@
         :danger="!modalData.buttons.confirm.danger"
         :icon="modalData.buttons.cancel.icon"
         @click="cancel"
-        data-test="cancel-button"
       >
         {{ $t(modalData.buttons.cancel.textIdent) }}
       </base-button>
@@ -26,7 +25,6 @@
         :icon="modalData.buttons.confirm.icon"
         :loading="loading"
         @click="confirm"
-        data-test="confirm-button"
       >
         {{ $t(modalData.buttons.confirm.textIdent) }}
       </base-button>


### PR DESCRIPTION
## 🍰 Pullrequest
The [changes to the E2E workflow to decrease SUT boot up time](https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/8495) mean that we can no longer use the `data-test` attributes for element selection.
They are relpaced now.

### Issues
- relates #8495

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
