### PR TITLE
fix(backend): package.json migrate scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,9 +21,9 @@
     "db:data:badges": "ts-node --require tsconfig-paths/register src/db/badges.ts",
     "db:data:branding": "ts-node --require tsconfig-paths/register src/db/data-branding.ts",
     "db:data:categories": "ts-node --require tsconfig-paths/register src/db/categories.ts",
-    "db:migrate": "migrate --compiler 'ts:./src/db/compiler.ts' --migrations-dir ./src/db/migrations --store ./src/db/migrate/store.ts",
-    "db:migrate:create": "migrate --compiler 'ts:./src/db/compiler.ts' --migrations-dir ./src/db/migrations --template-file ./src/db/migrate/template.ts --date-format 'yyyymmddHHmmss' create",
-    "prod:migrate": "migrate --migrations-dir ./build/src/db/migrations --store ./build/src/db/migrate/store.js",
+    "db:migrate": "migrate up --compiler 'ts:./src/db/compiler.ts' --migrations-dir ./src/db/migrations --store ./src/db/migrate/store.ts",
+    "db:migrate:create": "migrate create --compiler 'ts:./src/db/compiler.ts' --migrations-dir ./src/db/migrations --template-file ./src/db/migrate/template.ts --date-format 'yyyymmddHHmmss'",
+    "prod:migrate": "migrate up --migrations-dir ./build/src/db/migrations --store ./build/src/db/migrate/store.js",
     "prod:db:data:branding": "node build/src/db/data-branding.js",
     "prod:db:data:categories": "node build/src/db/categories.js"
   },


### PR DESCRIPTION
I see merge conflicts again, so let's merge this independent change
already. I think this is probably due to a package update.

Error fixed is:
```
$ migrate --compiler 'ts:./src/db/compiler.ts' --migrations-dir ./src/db/migrations --store ./src/db/migrate/store.ts
error: unknown option `--compiler'
error Command failed with exit code 1.
```

