### PR TITLE
feat(webapp): default language configurable

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -124,6 +124,11 @@ const options = {
   CATEGORIES_ACTIVE: process.env.CATEGORIES_ACTIVE === 'true' || false,
 }
 
+const language = {
+  LANGUAGE_DEFAULT: process.env.LANGUAGE_DEFAULT ?? 'en',
+  LANGUAGE_FALLBACK: process.env.LANGUAGE_FALLBACK ?? 'en',
+}
+
 // Check if all required configs are present
 Object.entries(required).map((entry) => {
   if (!entry[1]) {
@@ -141,6 +146,7 @@ export default {
   ...redis,
   ...s3,
   ...options,
+  ...language,
 }
 
 export { nodemailerTransportOptions }

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -126,7 +126,6 @@ const options = {
 
 const language = {
   LANGUAGE_DEFAULT: process.env.LANGUAGE_DEFAULT ?? 'en',
-  LANGUAGE_FALLBACK: process.env.LANGUAGE_FALLBACK ?? 'en',
 }
 
 // Check if all required configs are present

--- a/backend/src/emails/sendEmail.ts
+++ b/backend/src/emails/sendEmail.ts
@@ -39,7 +39,7 @@ const email = new Email({
   transport,
   i18n: {
     locales: ['en', 'de'],
-    defaultLocale: 'en',
+    defaultLocale: CONFIG.LANGUAGE_DEFAULT,
     retryInDefaultLocale: false,
     directory: path.join(__dirname, 'locales'),
     updateFiles: false,

--- a/webapp/config/index.js
+++ b/webapp/config/index.js
@@ -40,11 +40,16 @@ const options = {
   NETWORK_NAME: process.env.NETWORK_NAME || 'Ocelot.social',
 }
 
+const language = {
+  LANGUAGE_DEFAULT: process.env.LANGUAGE_DEFAULT || 'en',
+}
+
 const CONFIG = {
   ...environment,
   ...server,
   ...sentry,
   ...options,
+  ...language,
 }
 
 // override process.env with the values here since they contain default values

--- a/webapp/config/index.js
+++ b/webapp/config/index.js
@@ -42,6 +42,7 @@ const options = {
 
 const language = {
   LANGUAGE_DEFAULT: process.env.LANGUAGE_DEFAULT || 'en',
+  LANGUAGE_FALLBACK: process.env.LANGUAGE_FALLBACK || 'en',
 }
 
 const CONFIG = {

--- a/webapp/plugins/i18n.js
+++ b/webapp/plugins/i18n.js
@@ -72,7 +72,7 @@ export default ({ app, req, cookie, store }) => {
     },
   })
 
-  let userLocale = 'en'
+  let userLocale = app.$env.LANGUAGE_DEFAULT
   const localeCookie = app.$cookies.get(key)
   /* const userSettings = store.getters['auth/userSettings']
   if (userSettings && userSettings.uiLanguage) {
@@ -94,17 +94,19 @@ export default ({ app, req, cookie, store }) => {
   }
 
   const availableLocales = locales.filter((lang) => !!lang.enabled)
-  const locale = find(availableLocales, ['code', userLocale]) ? userLocale : 'en'
+  const locale = find(availableLocales, ['code', userLocale])
+    ? userLocale
+    : app.$env.LANGUAGE_FALLBACK
 
   // register the fallback locales
-  registerTranslation({ Vue, locale: 'en' })
-  if (locale !== 'en') {
+  registerTranslation({ Vue, locale: app.$env.LANGUAGE_FALLBACK })
+  if (locale !== app.$env.LANGUAGE_FALLBACK) {
     registerTranslation({ Vue, locale })
   }
 
   // Set the start locale to use
   Vue.i18n.set(locale)
-  Vue.i18n.fallback('en')
+  Vue.i18n.fallback(app.$env.LANGUAGE_FALLBACK)
 
   if (process.browser) {
     store.subscribe((mutation) => {

--- a/webapp/plugins/i18n.js
+++ b/webapp/plugins/i18n.js
@@ -48,6 +48,7 @@ export default ({ app, req, cookie, store }) => {
       })
     }
 
+    /*
     const user = store.getters['auth/user']
     const token = store.getters['auth/token']
     // persist language if it differs from last value
@@ -57,48 +58,39 @@ export default ({ app, req, cookie, store }) => {
       //   uiLanguage: localeInStore
       // }, { root: true })
     }
+    */
   }
 
-  // const i18nStore = new Vuex.Store({
-  //   strict: debug
-  // })
-
   Vue.use(vuexI18n.plugin, store, {
-    onTranslationNotFound: function (locale, key) {
-      if (debug) {
+    onTranslationNotFound:
+      debug &&
+      function (locale, key) {
         /* eslint-disable-next-line no-console */
         console.warn(`vuex-i18n :: Key '${key}' not found for locale '${locale}'`)
-      }
-    },
+      },
   })
 
   let userLocale = app.$env.LANGUAGE_DEFAULT
   const localeCookie = app.$cookies.get(key)
-  /* const userSettings = store.getters['auth/userSettings']
-  if (userSettings && userSettings.uiLanguage) {
-    // try to get saved user preference
-    userLocale = userSettings.uiLanguage
-  } else */
+
   if (!isEmpty(localeCookie)) {
     userLocale = localeCookie
   } else {
     try {
-      userLocale = process.browser
-        ? navigator.language || navigator.userLanguage
-        : req.headers['accept-language'].split(',')[0]
+      userLocale = (
+        process.browser
+          ? navigator.language || navigator.userLanguage
+          : req.headers['accept-language'].split(',')[0]
+      ).substr(0, 2)
     } catch (err) {}
-
-    if (userLocale && !isEmpty(userLocale.language)) {
-      userLocale = userLocale.language.substr(0, 2)
-    }
   }
 
   const availableLocales = locales.filter((lang) => !!lang.enabled)
   const locale = find(availableLocales, ['code', userLocale])
     ? userLocale
-    : app.$env.LANGUAGE_FALLBACK
+    : app.$env.LANGUAGE_DEFAULT
 
-  // register the fallback locales
+  // register locales
   registerTranslation({ Vue, locale: app.$env.LANGUAGE_FALLBACK })
   if (locale !== app.$env.LANGUAGE_FALLBACK) {
     registerTranslation({ Vue, locale })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

default language configurable.

This also Applies to the backend for the emails.

This also fixes browser detection.

### How2Test
Configure docker
```
service:
  webapp:
    environment:
   - LANGUAGE_DEFAULT=de
   - LANGUAGE_FALLBACK=de
    
  backend:
    environment:
    - LANGUAGE_DEFAULT=de
```

`LANGUAGE_DEFAULT=de` in the webapp is very hard to test since it requires the browser not to send any valid language

`LANGUAGE_FALLBACK=de` - go to http://localhost:3000/registration?method=invite-code&inviteCode=ABCDEF and set to `ES` -> see German  default text

![image](https://github.com/user-attachments/assets/3346f63d-a55b-41da-98be-22161fcf0a81)
![image](https://github.com/user-attachments/assets/39145f8b-9839-407a-8ced-4ea19d5c6b20)

With `LANGUAGE_FALLBACK=en` or nothing configures (as it is the default):

![image](https://github.com/user-attachments/assets/5c543816-0faf-4748-addd-70bbca0f7a86)

For the backend `LANGUAGE_DEFAULT=de` register with `locale=fr` selected in the frontend and you should receive a German mail. When repeating the step with `locale=en` set in the frontend you should receive an English mail.

![image](https://github.com/user-attachments/assets/a56837c6-2300-4799-8d32-5988a6e7bfcc)

Note: You need to restart the docker if you configure new env varibales.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
