### PR TITLE
fix(webapp): set body as boundary for user teaser popover

### DIFF
--- a/webapp/components/Dropdown.vue
+++ b/webapp/components/Dropdown.vue
@@ -6,6 +6,7 @@
     :disabled="disabled"
     trigger="manual"
     :offset="offset"
+    :boundaries-element="bodyAsBoundary ? 'body' : undefined"
   >
     <slot :toggleMenu="toggleMenu" :openMenu="openMenu" :closeMenu="closeMenu" :isOpen="isOpen" />
     <div slot="popover" @mouseover="popoverMouseEnter" @mouseleave="popoverMouseLeave">
@@ -30,6 +31,7 @@ export default {
     disabled: { type: Boolean, default: false },
     offset: { type: [String, Number], default: '16' },
     noMouseLeaveClosing: { type: Boolean, default: false },
+    bodyAsBoundary: { type: Boolean, default: false },
   },
   data() {
     return {

--- a/webapp/components/UserTeaser/UserTeaserNonAnonymous.vue
+++ b/webapp/components/UserTeaser/UserTeaserNonAnonymous.vue
@@ -1,5 +1,5 @@
 <template>
-  <dropdown class="user-teaser">
+  <dropdown class="user-teaser" body-as-boundary>
     <template #default="{ openMenu, closeMenu }">
       <user-teaser-helper
         v-if="showAvatar"

--- a/webapp/components/UserTeaser/__snapshots__/UserTeaser.spec.js.snap
+++ b/webapp/components/UserTeaser/__snapshots__/UserTeaser.spec.js.snap
@@ -9,6 +9,7 @@ exports[`UserTeaser given an user avatar is disabled does not render the avatar 
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -140,6 +141,7 @@ exports[`UserTeaser given an user user is disabled current user is a moderator r
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -260,6 +262,7 @@ exports[`UserTeaser given an user with linkToProfile, on desktop renders 1`] = `
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -348,6 +351,7 @@ exports[`UserTeaser given an user with linkToProfile, on desktop when hovering t
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -442,6 +446,7 @@ exports[`UserTeaser given an user with linkToProfile, on touch screen renders 1`
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -530,6 +535,7 @@ exports[`UserTeaser given an user with linkToProfile, on touch screen when click
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -624,6 +630,7 @@ exports[`UserTeaser given an user without linkToProfile, on desktop renders 1`] 
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -712,6 +719,7 @@ exports[`UserTeaser given an user without linkToProfile, on desktop when hoverin
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -805,6 +813,7 @@ exports[`UserTeaser given an user without linkToProfile, on desktop when hoverin
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -898,6 +907,7 @@ exports[`UserTeaser given an user without linkToProfile, on touch screen renders
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -986,6 +996,7 @@ exports[`UserTeaser given an user without linkToProfile, on touch screen when cl
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"
@@ -1079,6 +1090,7 @@ exports[`UserTeaser given an user without linkToProfile, on touch screen when cl
     <client-only-stub>
       <v-popover-stub
         autohide="true"
+        boundarieselement="body"
         class="user-teaser"
         container="body"
         delay="0"

--- a/webapp/pages/groups/_id/__snapshots__/_slug.spec.js.snap
+++ b/webapp/pages/groups/_id/__snapshots__/_slug.spec.js.snap
@@ -517,6 +517,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -602,6 +603,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -687,6 +689,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -772,6 +775,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -2408,6 +2412,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -2493,6 +2498,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -2578,6 +2584,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -2663,6 +2670,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a close
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -3402,6 +3410,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -3487,6 +3496,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -3572,6 +3582,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -3657,6 +3668,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -4241,6 +4253,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -4326,6 +4339,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -4411,6 +4425,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -4496,6 +4511,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -5078,6 +5094,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -5163,6 +5180,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -5248,6 +5266,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -5333,6 +5352,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -5984,6 +6004,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -6069,6 +6090,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -6154,6 +6176,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -6239,6 +6262,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a curre
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -7025,6 +7049,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -7110,6 +7135,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -7195,6 +7221,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -7280,6 +7307,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -8019,6 +8047,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -8104,6 +8133,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -8189,6 +8219,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"
@@ -8274,6 +8305,7 @@ exports[`GroupProfileSlug given a puplic group – "yoga-practice" given a hidde
                 <client-only-stub>
                   <v-popover-stub
                     autohide="true"
+                    boundarieselement="body"
                     class="user-teaser"
                     container="body"
                     delay="0"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Combines #8555 and #8594 by setting `body` Element as `boundarieselement` only for the user teaser.
Thereby the flickering should go away again, but menu placements are preserved.
