### PR TITLE
fix(webapp): fix broken observe on post

### DIFF
--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -179,6 +179,7 @@ import {
 } from '~/components/utils/PostHelpers'
 import PostQuery from '~/graphql/PostQuery'
 import { groupQuery } from '~/graphql/groups'
+import PostMutations from '~/graphql/PostMutations'
 import links from '~/constants/links.js'
 import GetCategories from '~/mixins/getCategoriesMixin.js'
 import postListActions from '~/mixins/postListActions'
@@ -319,6 +320,24 @@ export default {
       this.post.comments.push(comment)
       this.post.isObservedByMe = comment.isPostObservedByMe
       this.post.observingUsersCount = comment.postObservingUsersCount
+    },
+    toggleObservePost(postId, value) {
+      this.$apollo
+        .mutate({
+          mutation: PostMutations().toggleObservePost,
+          variables: {
+            value,
+            id: postId,
+          },
+        })
+        .then(() => {
+          const message = this.$t(
+            `post.menu.${value ? 'observedSuccessfully' : 'unobservedSuccessfully'}`,
+          )
+          this.$toast.success(message)
+          this.$apollo.queries.Post.refetch()
+        })
+        .catch((error) => this.$toast.error(error.message))
     },
     toggleNewCommentForm(showNewCommentForm) {
       this.showNewCommentForm = showNewCommentForm


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix broken observe on post

Due to missing tests & problematic refactoring, posts could no longer be observed and the new observe state beeing indicated without reloading the page.

This reverts parts of https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/8598 to fix the problem

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- relates https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/8598

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
