### PR TITLE
refactor(backend): display server errors on the logs

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -74,6 +74,8 @@ const createServer = (options?) => {
     uploads: false,
     tracing: !!CONFIG.DEBUG,
     formatError: (error) => {
+      // eslint-disable-next-line no-console
+      console.error(error.originalError)
       if (error.message === 'ERROR_VALIDATION') {
         return new Error(error.originalError.details.map((d) => d.message))
       }


### PR DESCRIPTION
So, this might clutter our CI but I found it so helpful to turn this on. Our seeds are riddled with runtime errors that we never see. It's also easier to debug the tests if you can see the actual errors thrown by the backend.

Let's see how CI log output looks like after this.

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
