### PR TITLE
fix(webapp): link to chat room in notificiation

### DIFF
--- a/backend/src/emails/sendEmail.ts
+++ b/backend/src/emails/sendEmail.ts
@@ -159,12 +159,13 @@ export interface ChatMessageEmailInput {
   senderUser: UserDbProperties
   recipientUser: UserDbProperties
   email: string
+  roomId: string
 }
 
 export const sendChatMessageMail = async (
   data: ChatMessageEmailInput,
 ): Promise<OriginalMessage> => {
-  const { senderUser, recipientUser } = data
+  const { senderUser, recipientUser, roomId } = data
   const to = data.email
   try {
     const { originalMessage } = await email.send({
@@ -178,7 +179,7 @@ export const sendChatMessageMail = async (
         name: recipientUser.name,
         chattingUser: senderUser.name,
         chattingUserUrl: new URL(`/profile/${senderUser.id}/${senderUser.slug}`, CONFIG.CLIENT_URI),
-        chatUrl: new URL('/chat', CONFIG.CLIENT_URI),
+        chatUrl: new URL(`/chat/${roomId}`, CONFIG.CLIENT_URI),
       },
     })
     return originalMessage as OriginalMessage

--- a/backend/src/middleware/notifications/notificationsMiddleware.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.ts
@@ -462,6 +462,7 @@ const handleCreateMessage = async (resolve, root, args, context, resolveInfo) =>
     })
 
     return {
+      roomId,
       senderUser: await txResponse.records.map((record) => record.get('senderUser'))[0],
       recipientUser: await txResponse.records.map((record) => record.get('recipientUser'))[0],
       email: await txResponse.records.map((record) => record.get('emailAddress'))[0]?.email,
@@ -470,7 +471,7 @@ const handleCreateMessage = async (resolve, root, args, context, resolveInfo) =>
 
   try {
     // Execute Query
-    const { senderUser, recipientUser, email } = await messageRecipient
+    const { senderUser, recipientUser, email, roomId } = await messageRecipient
 
     if (recipientUser) {
       // send subscriptions
@@ -487,7 +488,7 @@ const handleCreateMessage = async (resolve, root, args, context, resolveInfo) =>
 
       // Send EMail if we found a user(not blocked) and he is not considered online
       if (recipientUser.emailNotificationsChatMessage !== false && !isUserOnline(recipientUser)) {
-        void sendChatMessageMail({ email, senderUser, recipientUser })
+        void sendChatMessageMail({ email, senderUser, recipientUser, roomId })
       }
     }
 

--- a/webapp/pages/chat/_roomId.vue
+++ b/webapp/pages/chat/_roomId.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <add-chat-room-by-user-search
+      v-if="showUserSearch"
+      @add-chat-room="addChatRoom"
+      @close-user-search="showUserSearch = false"
+    />
+    <chat
+      :roomId="getShowChat.showChat ? getShowChat.roomID : this.$route.params.roomId"
+      ref="chat"
+      @toggle-user-search="showUserSearch = !showUserSearch"
+      :show-room="showRoom"
+    />
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapMutations } from 'vuex'
+import AddChatRoomByUserSearch from '~/components/Chat/AddChatRoomByUserSearch'
+import Chat from '~/components/Chat/Chat.vue'
+
+export default {
+  components: {
+    AddChatRoomByUserSearch,
+    Chat,
+  },
+  data() {
+    return {
+      showUserSearch: false,
+    }
+  },
+  mounted() {
+    this.showChat({ showChat: false, roomID: null })
+  },
+  computed: {
+    ...mapGetters({
+      getShowChat: 'chat/showChat',
+    }),
+  },
+  methods: {
+    ...mapMutations({
+      showChat: 'chat/SET_OPEN_CHAT',
+    }),
+    addChatRoom(userID) {
+      this.$refs.chat.newRoom(userID)
+    },
+    showRoom(roomId) {
+      this.showChat({ showChat: true, roomID: roomId })
+    },
+  },
+}
+</script>

--- a/webapp/pages/chat/index.vue
+++ b/webapp/pages/chat/index.vue
@@ -17,7 +17,7 @@
 <script>
 import { mapGetters, mapMutations } from 'vuex'
 import AddChatRoomByUserSearch from '~/components/Chat/AddChatRoomByUserSearch'
-import Chat from '../components/Chat/Chat.vue'
+import Chat from '~/components/Chat/Chat.vue'
 
 export default {
   components: {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
When a user misses a chat message, a notification is sent. So far, there is only a generic link to the chat page, not to the specific room in which the message was received.
This PR
- adds the possibility to access chat rooms via routes
- builds the route when sending the notification

### Todo
- [ ] Test if it works
- [ ] Possibly fix backend part