### PR TITLE
fix(webapp): keep correct file extension for audio captures (voice chat)

### DIFF
--- a/webapp/components/Chat/Chat.vue
+++ b/webapp/components/Chat/Chat.vue
@@ -376,7 +376,11 @@ export default {
 
       const filesToUpload = hasFiles
         ? files.map((file) => ({
-            upload: new File([file.blob], `${file.name}.${file.extension}`),
+            upload: new File(
+              [file.blob],
+              // Captured audio already has the right extension in the name
+              file.extension ? `${file.name}.${file.extension}` : file.name,
+            ),
             name: file.name,
             type: file.type,
           }))


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
Problem:
When audio is directly recorded to chat, it has the correct file extension in its name ("audio.mp3"). The file object we get *doesn't* have an extension property though, so the file name after our modification would be "audio.mp3.undefined". Safari doesn't accept this as audio source, and I hate to say it, but I agree.

So if there is no extension, keep the existing one. Problem solved.

