### PR TITLE
refactor(other): refactor e2e test network expectations and node version 

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2
 
       - name: Copy backend env file
         run: |
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2
 
       - name: Copy backend env file
         run: |
@@ -69,7 +69,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@08f58d1471bff7f3a07d167b4ad7df25d5fcfcb6 # v4.4.0
+        with:
+          node-version-file: 'backend/.tool-versions'
+          cache: 'yarn'
 
       - name: Copy env files
         run: |
@@ -107,6 +113,15 @@ jobs:
         # run copies of the current job in parallel
         job: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@08f58d1471bff7f3a07d167b4ad7df25d5fcfcb6 # v4.4.0
+        with:
+          node-version-file: 'backend/.tool-versions'
+          cache: 'yarn'
+
       - name: Restore cypress cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.0.2
         with:
@@ -172,7 +187,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
+        uses: actions/checkout@09d2acae674a48949e3602304ab46fd20ae0c42f # v4.2.2
       
       - name: Full stack tests | cleanup cache
         run: |

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
@@ -1,14 +1,7 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see all the reported posts including the one from above', () => {
-  cy.intercept({
-    method: 'POST',
-    url: '/api',
-    hostname: 'localhost',
-  }).as('getReports')
-
-  cy.wait(['@getReports'],{ timeout: 30000 }).then((interception) => {
-    console.log('Cypress interception:', interception)
+  cy.wait('@reportsQuery', { timeout: 30000 }).then((interception) => {
     cy.wrap(interception.response.statusCode).should('eq', 200)
     cy.wrap(interception.request.body)
       .should('have.property', 'query', `query ($orderBy: ReportOrdering, $first: Int, $offset: Int, $reviewed: Boolean, $closed: Boolean) {
@@ -104,6 +97,6 @@ defineStep('I see all the reported posts including the one from above', () => {
   })
 
   cy.get('table tbody').within(() => {
-    cy.contains('tr', 'The Truth about the Holocaust')
+    cy.contains('tr', 'The Truth about the Holocaust').should('be.visible')
   })
 })

--- a/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
+++ b/cypress/support/step_definitions/Moderation.ReportContent/I_see_all_the_reported_posts_including_the_one_from_above.js
@@ -1,28 +1,109 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
 defineStep('I see all the reported posts including the one from above', () => {
-  cy.get('table tbody', { timeout: 30000 }).should('be.visible')
-  cy.get('table tbody').within(() => {
-    cy.contains('tr', 'The Truth about the Holocaust').should('be.visible')
-  })
-  
   cy.intercept({
     method: 'POST',
     url: '/api',
     hostname: 'localhost',
-  }, (req) => {
-    if (req.body && req.body.query && req.body.query.includes('reports(')) {
-      req.alias = 'getReports'
+  }).as('getReports')
+
+  cy.wait(['@getReports'],{ timeout: 30000 }).then((interception) => {
+    console.log('Cypress interception:', interception)
+    cy.wrap(interception.response.statusCode).should('eq', 200)
+    cy.wrap(interception.request.body)
+      .should('have.property', 'query', `query ($orderBy: ReportOrdering, $first: Int, $offset: Int, $reviewed: Boolean, $closed: Boolean) {
+  reports(orderBy: $orderBy, first: $first, offset: $offset, reviewed: $reviewed, closed: $closed) {
+    id
+    createdAt
+    updatedAt
+    closed
+    reviewed {
+      createdAt
+      updatedAt
+      disable
+      moderator {
+        id
+        slug
+        name
+        __typename
+      }
+      __typename
     }
+    resource {
+      __typename
+      ... on User {
+        id
+        slug
+        name
+        disabled
+        deleted
+        __typename
+      }
+      ... on Comment {
+        id
+        contentExcerpt
+        disabled
+        deleted
+        author {
+          id
+          slug
+          name
+          disabled
+          deleted
+          __typename
+        }
+        post {
+          id
+          slug
+          title
+          disabled
+          deleted
+          __typename
+        }
+        __typename
+      }
+      ... on Post {
+        id
+        slug
+        title
+        disabled
+        deleted
+        author {
+          id
+          slug
+          name
+          disabled
+          deleted
+          __typename
+        }
+        __typename
+      }
+    }
+    filed {
+      submitter {
+        id
+        slug
+        name
+        disabled
+        deleted
+        __typename
+      }
+      createdAt
+      reasonCategory
+      reasonDescription
+      __typename
+    }
+    __typename
+  }
+}
+`
+    )
+    cy.wrap(interception.response.body)
+      .should('have.nested.property', 'data.reports.0.resource.author.id')
+      .and('equal', 'annoying-user')
   })
 
-  cy.get('@getReports.all').should('have.length.at.least', 1)
-  cy.get('@getReports.all').then((interceptions) => {
-    const reportsInterception = interceptions.find(interception =>
-      interception.request.body.query.includes('reports(')
-    )
-    expect(reportsInterception).to.exist
-    expect(reportsInterception.response.statusCode).to.eq(200)
-    expect(reportsInterception.response.body).to.have.nested.property('data.reports.0.resource.author.id', 'annoying-user')
+  cy.get('table tbody').within(() => {
+    cy.contains('tr', 'The Truth about the Holocaust')
   })
 })

--- a/cypress/support/step_definitions/common/I_click_on_{string}.js
+++ b/cypress/support/step_definitions/common/I_click_on_{string}.js
@@ -14,6 +14,18 @@ defineStep('I click on {string}', element => {
     'Moderation': 'a[href="/moderation"]',
   }
 
+  if (element === 'Moderation') {
+    cy.intercept({
+      method: 'POST',
+      url: '/api',
+      hostname: 'localhost',
+    }, (req) => {
+      if (req.body && req.body.query && req.body.query.includes('query ($orderBy: ReportOrdering')) {
+        req.alias = 'reportsQuery'
+      }
+    })
+  }
+
   cy.get(elementSelectors[element])
     .click()
     .wait(750)


### PR DESCRIPTION
## Motivation
The [Nuxt config change in #8695](https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/8695) resulted in a single end-to-end test failing.
That revealed a test flakyness due to imprecise network interception expectations.

## How to test
Merge this PR's branch `refactor-e2e-test-network-interception-timing` into the #8695 branch and seethe test succeeding again.

### Issues
- relates #8695
