### PR TITLE
fix(backend): mask jwt token in log

### DIFF
--- a/backend/src/plugins/apolloLogger.spec.ts
+++ b/backend/src/plugins/apolloLogger.spec.ts
@@ -61,7 +61,7 @@ describe('apollo logger', () => {
   })
 
   describe('login mutation', () => {
-    it('logs the request and response', async () => {
+    it('logs the request and response, masking password and token', async () => {
       await mutate({
         mutation: loginMutation,
         variables: {
@@ -81,7 +81,7 @@ describe('apollo logger', () => {
         }),
       )
 
-      expect(loggerSpy).toBeCalledWith('Apollo Response', expect.any(String), expect.any(String))
+      expect(loggerSpy).toBeCalledWith('Apollo Response', expect.any(String), '{"login":"token"}')
 
       expect(consoleSpy).toBeCalledTimes(2)
     })

--- a/backend/src/plugins/apolloLogger.ts
+++ b/backend/src/plugins/apolloLogger.ts
@@ -30,7 +30,14 @@ export const loggerPlugin = {
             ocelotLogger.error(...logResponse, JSON.stringify(requestContext.errors))
             return
           }
-          logResponse.push(JSON.stringify(requestContext.response.data))
+          if (requestContext.response.data.login) {
+            // mask the token
+            const data = cloneDeep(requestContext.response.data)
+            data.login = 'token'
+            logResponse.push(JSON.stringify(data))
+          } else {
+            logResponse.push(JSON.stringify(requestContext.response.data))
+          }
           ocelotLogger.debug(...logResponse)
         }
       },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
This is the log of login:
```
2025-07-01 11:16:45.083 DEBUG   /src/plugins/apolloLogger.ts:22 mainLogger      Apollo Request 5ee29e84 "mutation ($email: String!, $password: String!) {\n  login(email: $email, password: $password)\n}\n" {"email":"admin@example.org","password":"***"}
2025-07-01 11:16:45.201 DEBUG   /src/plugins/apolloLogger.ts:41 mainLogger      Apollo Response 5ee29e84 {"login":"token"}
```
see unit test

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
