### PR TITLE
fix(backend): delete follow relations for deleted users

### DIFF
--- a/backend/src/db/migrations/20250804140837-delted-user-follows.ts
+++ b/backend/src/db/migrations/20250804140837-delted-user-follows.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+import { getDriver } from '@db/neo4j'
+
+export const description = 'Delete follow relation for deleted users'
+
+export async function up(_next) {
+  const driver = getDriver()
+  const session = driver.session()
+  const transaction = session.beginTransaction()
+
+  try {
+    // Implement your migration here.
+    await transaction.run(`
+      MATCH (:User {deleted: true})-[follow:FOLLOWS]-(:User)
+      DELETE follow;
+    `)
+    await transaction.commit()
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error)
+    await transaction.rollback()
+    // eslint-disable-next-line no-console
+    console.log('rolled back')
+    throw new Error(error)
+  } finally {
+    await session.close()
+  }
+}
+
+export async function down(_next) {
+  const driver = getDriver()
+  const session = driver.session()
+  const transaction = session.beginTransaction()
+
+  try {
+    // cannot be rolled back
+    // Implement your migration here.
+    // await transaction.run(``)
+    // await transaction.commit()
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error)
+    await transaction.rollback()
+    // eslint-disable-next-line no-console
+    console.log('rolled back')
+    throw new Error(error)
+  } finally {
+    await session.close()
+  }
+}

--- a/backend/src/graphql/resolvers/users.ts
+++ b/backend/src/graphql/resolvers/users.ts
@@ -280,6 +280,9 @@ export default {
               WITH user
               OPTIONAL MATCH (user)<-[:OWNED_BY]-(socialMedia:SocialMedia)
               DETACH DELETE socialMedia
+              WITH user
+              OPTIONAL MATCH (user)-[follow:FOLLOWS]-(:User)
+              DELETE follow
               RETURN user {.*}
             `,
           { userId },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

delete follow relations for deleted users so there are no anonymous users displayed.

Before patch:
<img width="309" height="1153" alt="image" src="https://github.com/user-attachments/assets/9ebb1376-18ab-4fd2-b363-0dce89330bf5" />

---

After patch:
<img width="288" height="1156" alt="image" src="https://github.com/user-attachments/assets/8261fc3f-c757-48b6-ae16-4714b4385719" />

---

Note: https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/8765 is the better approach, but fails at library level, as the neo4jgraphqljs library generated invalid cypher.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/Ocelot-Social-Community/Ocelot-Social/issues/8764
- fixes https://github.com/Ocelot-Social-Community/Ocelot-Social/pull/8765

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
