### PR TITLE
fix(workflow): disable docstring

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,9 +4,9 @@
 language: de
 
 reviews:
-  tools:
-    docstring_coverage:
-      enabled: false
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
 
   # Automatisches Review für alle PRs
   auto_review:


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Was hat das hier zu bedeuten? `Docstring Coverage    ⚠️  Warning    Docstring coverage is 53.85% which is insufficient. The required threshold is 80.00%.    Write docstrings for the functions missing them to satisfy the coverage       
  threshold.` Das macht coderabbitai? Was ist der mehrwert?                                                                                                                                                                                 

---                                                                                                                                                                                                                                            

● Ja, das ist ein automatischer CodeRabbit-Check. Er zählt, wie viele exportierte Funktionen/Klassen einen JSDoc-Kommentar haben, und warnt wenn ein Schwellenwert unterschritten wird.                                                     
                                                                                                                                                                                                                                            
  Der Mehrwert ist hier gering, besonders in eurem Projekt:                                                                                                                                                                                 
   
  - TypeScript liefert bereits Typ-Dokumentation (Signaturen, Parameter, Return-Types)                                                                                                                                                      
  - Props-Dokumentation wird schon via eslint-plugin-jsdoc erzwungen                                                                                                                                                                      
  - Erzwungene Docstrings auf selbsterklärenden Funktionen wie toKebabCase(str: string): string sind reines Rauschen

  Man kann den Check in .coderabbitai.yaml abschalten oder den Schwellenwert anpassen:

```
  reviews:
    tools:
      docstring_coverage:
        enabled: false
```

  Oder selektiv den Threshold senken. Ich würde ihn abschalten — eure echte Dokumentationsstrategie (JSDoc auf Props, Storybook autodocs, TypeScript-Typen) ist deutlich sinnvoller als eine pauschale Prozent-Metrik.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Konfiguration des Review-Tools angepasst: Eine neue Option wurde hinzugefügt, die Docstring-Prüfungen bei Pre-Merge-Checks deaktiviert (Standard: deaktiviert).
  * Keine bestehenden Prüfregeln wurden entfernt oder verändert; die Änderung fügt lediglich diese Deaktivierungsoption hinzu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->