### PR TITLE
fix(backend): prevent map crash on pinned posts without location

### DIFF
--- a/backend/src/graphql/resolvers/posts.ts
+++ b/backend/src/graphql/resolvers/posts.ts
@@ -58,12 +58,16 @@ const filterEventDates = (params) => {
 export default {
   Query: {
     Post: async (object, params, context: Context, resolveInfo) => {
+      const skipPinnedFilter = !!params.filter?.skipPinnedFilter
+      if (params.filter) delete params.filter.skipPinnedFilter
       params = await filterPostsOfMyGroups(params, context)
       params = await filterInvisiblePosts(params, context)
       params = await filterForMutedUsers(params, context)
       params = filterEventDates(params)
       params = await filterPostsHasLocation(params, context)
-      params = await maintainPinnedPosts(params)
+      if (!skipPinnedFilter) {
+        params = await maintainPinnedPosts(params)
+      }
       return neo4jgraphql(object, params, context, resolveInfo)
     },
     profilePagePosts: async (object, params, context, resolveInfo) => {

--- a/backend/src/graphql/types/type/Post.gql
+++ b/backend/src/graphql/types/type/Post.gql
@@ -93,6 +93,7 @@ input _PostFilter {
   eventStart_gte: String
   eventEnd_gte: String
   hasLocation: Boolean
+  skipPinnedFilter: Boolean
 }
 
 enum _PostOrdering {

--- a/webapp/pages/map.vue
+++ b/webapp/pages/map.vue
@@ -581,6 +581,7 @@ export default {
         })
         // add markers for "posts", post type "Event" with location coordinates
         this.posts.forEach((post) => {
+          if (!post.eventLocation) return
           this.markers.geoJSON.push({
             type: 'Feature',
             properties: {
@@ -708,6 +709,7 @@ export default {
             postType_in: ['Event'],
             eventStart_gte: new Date(),
             hasLocation: true,
+            skipPinnedFilter: true,
           },
         }
       },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

do not preserve pinned posts for map query

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Neue Funktionen
* Neue optionale Filteroption hinzugefügt, die es ermöglicht, die Behandlung von gepinnten Beiträgen in bestimmten Abfrage-Kontexten zu kontrollieren.

## Fehlerbehebungen
* Kartendarstellung verbessert: Ereignismarker ohne gültige Standortinformationen werden nun automatisch übersprungen und nicht mehr in der Kartenansicht angezeigt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->