### PR TITLE
fix(backend): fix api-key flaky test (time-race) & ensure stable sort by second sort field

### DIFF
--- a/backend/src/graphql/resolvers/apiKeys.spec.ts
+++ b/backend/src/graphql/resolvers/apiKeys.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { setTimeout } from 'node:timers/promises'
+
 import { cleanDatabase } from '@db/factories'
 import adminRevokeApiKey from '@graphql/queries/apiKeys/adminRevokeApiKey.gql'
 import adminRevokeUserApiKeys from '@graphql/queries/apiKeys/adminRevokeUserApiKeys.gql'
@@ -189,6 +191,10 @@ describe('myApiKeys', () => {
 
   it('returns created keys ordered by createdAt desc', async () => {
     await mutate({ mutation: createApiKey, variables: { name: 'Key A' } })
+    // Ensure Key B lands in a different millisecond than Key A; createdAt is
+    // stored via `toString(datetime())` (ms precision) and ties would let
+    // Neo4j return either key first.
+    await setTimeout(2)
     await mutate({ mutation: createApiKey, variables: { name: 'Key B' } })
     const { data, errors } = await query({ query: myApiKeys })
     expect(errors).toBeUndefined()

--- a/backend/src/graphql/resolvers/apiKeys.ts
+++ b/backend/src/graphql/resolvers/apiKeys.ts
@@ -46,7 +46,7 @@ export default {
         query: `
           MATCH (u:User { id: $userId })-[:HAS_API_KEY]->(k:ApiKey)
           RETURN k {.*}
-          ORDER BY k.createdAt DESC
+          ORDER BY k.createdAt DESC, k.id DESC
         `,
         variables: { userId: context.user?.id },
       })
@@ -91,7 +91,7 @@ export default {
         query: `
           MATCH (u:User { id: $userId })-[:HAS_API_KEY]->(k:ApiKey)
           RETURN k {.*}
-          ORDER BY k.disabled ASC, k.createdAt DESC
+          ORDER BY k.disabled ASC, k.createdAt DESC, k.id DESC
         `,
         variables: { userId: args.userId },
       })

--- a/backend/src/graphql/resolvers/apiKeys.ts
+++ b/backend/src/graphql/resolvers/apiKeys.ts
@@ -116,6 +116,14 @@ export default {
 
       const { key, hash, prefix } = generateApiKey()
       const id = uuid()
+      // Generate the ISO timestamp in Node rather than via Cypher's
+      // `toString(datetime())`: Neo4j omits the fractional-seconds part when
+      // it is zero (e.g. "2026-04-23T14:05:32Z" instead of
+      // "2026-04-23T14:05:32.000Z"). That variable width breaks lexicographic
+      // `ORDER BY k.createdAt DESC`, because "Z" > "." in ASCII. JS's
+      // `Date#toISOString()` always emits 3 fractional digits, so string sort
+      // remains in chronological order.
+      const createdAt = new Date().toISOString()
 
       const result = await context.database.write({
         query: `
@@ -129,7 +137,7 @@ export default {
             name: $name,
             keyHash: $keyHash,
             keyPrefix: $keyPrefix,
-            createdAt: toString(datetime()),
+            createdAt: $createdAt,
             disabled: false
           })
           ${expiresAt ? 'SET k.expiresAt = $expiresAt' : ''}
@@ -141,6 +149,7 @@ export default {
           name: args.name,
           keyHash: hash,
           keyPrefix: prefix,
+          createdAt,
           expiresAt,
           maxKeys: context.config.API_KEYS_MAX_PER_USER,
         },
@@ -178,10 +187,14 @@ export default {
         query: `
           MATCH (u:User { id: $userId })-[:HAS_API_KEY]->(k:ApiKey { id: $keyId })
           WHERE NOT k.disabled
-          SET k.disabled = true, k.disabledAt = toString(datetime())
+          SET k.disabled = true, k.disabledAt = $disabledAt
           RETURN k
         `,
-        variables: { userId: context.user?.id, keyId: args.id },
+        variables: {
+          userId: context.user?.id,
+          keyId: args.id,
+          disabledAt: new Date().toISOString(),
+        },
       })
       return result.records.length > 0
     },
@@ -191,10 +204,10 @@ export default {
         query: `
           MATCH (k:ApiKey { id: $keyId })
           WHERE NOT k.disabled
-          SET k.disabled = true, k.disabledAt = toString(datetime())
+          SET k.disabled = true, k.disabledAt = $disabledAt
           RETURN k
         `,
-        variables: { keyId: args.id },
+        variables: { keyId: args.id, disabledAt: new Date().toISOString() },
       })
       return result.records.length > 0
     },
@@ -204,10 +217,10 @@ export default {
         query: `
           MATCH (u:User { id: $userId })-[:HAS_API_KEY]->(k:ApiKey)
           WHERE NOT k.disabled
-          SET k.disabled = true, k.disabledAt = toString(datetime())
+          SET k.disabled = true, k.disabledAt = $disabledAt
           RETURN count(k) AS count
         `,
-        variables: { userId: args.userId },
+        variables: { userId: args.userId, disabledAt: new Date().toISOString() },
       })
       return toNumber(result.records[0].get('count') as Integer)
     },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix api-key flaky test (time-race) & ensure stable sort by second sort field

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Konsistente und vorhersehbare Sortierung von API‑Schlüsseln, auch bei nahezu gleichzeitiger Erstellung.
  * Stabilere Erzeugungs‑ und Widerrufszeitstempel für API‑Schlüssel, wodurch Anzeige- und Reihenfolgefehler reduziert werden.

* **Tests**
  * Zuverlässigere Tests für API‑Schlüsselreihenfolge, um sporadische Testflakiness zu vermeiden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->