### PR TITLE
fix(backend): fix user profile counts if closed/hidden groups are involved

### DIFF
--- a/backend/src/graphql/resolvers/posts.inGroups.spec.ts
+++ b/backend/src/graphql/resolvers/posts.inGroups.spec.ts
@@ -5,6 +5,7 @@
 import Factory, { cleanDatabase } from '@db/factories'
 import SignupVerification from '@graphql/queries/auth/SignupVerification.gql'
 import CreateComment from '@graphql/queries/comments/CreateComment.gql'
+import shout from '@graphql/queries/emotions/shout.gql'
 import ChangeGroupMemberRole from '@graphql/queries/groups/ChangeGroupMemberRole.gql'
 import CreateGroup from '@graphql/queries/groups/CreateGroup.gql'
 import LeaveGroup from '@graphql/queries/groups/LeaveGroup.gql'
@@ -1116,9 +1117,17 @@ describe('Posts in Groups', () => {
             id
             contributionsCount
             commentedCount
+            shoutedCount
           }
         }
       `
+
+      beforeAll(async () => {
+        authenticatedUser = await publicUser.toJson()
+        await mutate({ mutation: shout, variables: { id: 'post-to-public-group' } })
+        await mutate({ mutation: shout, variables: { id: 'post-to-closed-group' } })
+        await mutate({ mutation: shout, variables: { id: 'post-to-hidden-group' } })
+      })
 
       describe('without membership of group', () => {
         beforeAll(async () => {
@@ -1126,13 +1135,32 @@ describe('Posts in Groups', () => {
         })
 
         it("counts only posts the viewer can see on the author's profile", async () => {
-          const result = await query({
+          const authorResult = await query({
             query: userProfileCounts,
             variables: { id: 'all-groups-user' },
           })
-          expect(result).toMatchObject({
+          expect(authorResult).toMatchObject({
             data: {
-              User: [{ id: 'all-groups-user', contributionsCount: 1, commentedCount: 1 }],
+              User: [
+                {
+                  id: 'all-groups-user',
+                  contributionsCount: 1,
+                  commentedCount: 1,
+                  shoutedCount: 0,
+                },
+              ],
+            },
+            errors: undefined,
+          })
+          const shouterResult = await query({
+            query: userProfileCounts,
+            variables: { id: 'public-user' },
+          })
+          expect(shouterResult).toMatchObject({
+            data: {
+              User: [
+                { id: 'public-user', contributionsCount: 0, commentedCount: 0, shoutedCount: 1 },
+              ],
             },
             errors: undefined,
           })
@@ -1145,13 +1173,32 @@ describe('Posts in Groups', () => {
         })
 
         it("counts only posts the viewer can see on the author's profile", async () => {
-          const result = await query({
+          const authorResult = await query({
             query: userProfileCounts,
             variables: { id: 'all-groups-user' },
           })
-          expect(result).toMatchObject({
+          expect(authorResult).toMatchObject({
             data: {
-              User: [{ id: 'all-groups-user', contributionsCount: 1, commentedCount: 1 }],
+              User: [
+                {
+                  id: 'all-groups-user',
+                  contributionsCount: 1,
+                  commentedCount: 1,
+                  shoutedCount: 0,
+                },
+              ],
+            },
+            errors: undefined,
+          })
+          const shouterResult = await query({
+            query: userProfileCounts,
+            variables: { id: 'public-user' },
+          })
+          expect(shouterResult).toMatchObject({
+            data: {
+              User: [
+                { id: 'public-user', contributionsCount: 0, commentedCount: 0, shoutedCount: 1 },
+              ],
             },
             errors: undefined,
           })
@@ -1164,13 +1211,32 @@ describe('Posts in Groups', () => {
         })
 
         it('counts all posts on the own profile', async () => {
-          const result = await query({
+          const authorResult = await query({
             query: userProfileCounts,
             variables: { id: 'all-groups-user' },
           })
-          expect(result).toMatchObject({
+          expect(authorResult).toMatchObject({
             data: {
-              User: [{ id: 'all-groups-user', contributionsCount: 3, commentedCount: 3 }],
+              User: [
+                {
+                  id: 'all-groups-user',
+                  contributionsCount: 3,
+                  commentedCount: 3,
+                  shoutedCount: 0,
+                },
+              ],
+            },
+            errors: undefined,
+          })
+          const shouterResult = await query({
+            query: userProfileCounts,
+            variables: { id: 'public-user' },
+          })
+          expect(shouterResult).toMatchObject({
+            data: {
+              User: [
+                { id: 'public-user', contributionsCount: 0, commentedCount: 0, shoutedCount: 3 },
+              ],
             },
             errors: undefined,
           })

--- a/backend/src/graphql/resolvers/posts.inGroups.spec.ts
+++ b/backend/src/graphql/resolvers/posts.inGroups.spec.ts
@@ -1109,6 +1109,75 @@ describe('Posts in Groups', () => {
       })
     })
 
+    describe('profile page counts', () => {
+      const userProfileCounts = `
+        query UserProfileCounts($id: ID) {
+          User(id: $id) {
+            id
+            contributionsCount
+            commentedCount
+          }
+        }
+      `
+
+      describe('without membership of group', () => {
+        beforeAll(async () => {
+          authenticatedUser = await anyUser.toJson()
+        })
+
+        it("counts only posts the viewer can see on the author's profile", async () => {
+          const result = await query({
+            query: userProfileCounts,
+            variables: { id: 'all-groups-user' },
+          })
+          expect(result).toMatchObject({
+            data: {
+              User: [{ id: 'all-groups-user', contributionsCount: 1, commentedCount: 1 }],
+            },
+            errors: undefined,
+          })
+        })
+      })
+
+      describe('with pending membership of group', () => {
+        beforeAll(async () => {
+          authenticatedUser = await pendingUser.toJson()
+        })
+
+        it("counts only posts the viewer can see on the author's profile", async () => {
+          const result = await query({
+            query: userProfileCounts,
+            variables: { id: 'all-groups-user' },
+          })
+          expect(result).toMatchObject({
+            data: {
+              User: [{ id: 'all-groups-user', contributionsCount: 1, commentedCount: 1 }],
+            },
+            errors: undefined,
+          })
+        })
+      })
+
+      describe('as member of group', () => {
+        beforeAll(async () => {
+          authenticatedUser = await allGroupsUser.toJson()
+        })
+
+        it('counts all posts on the own profile', async () => {
+          const result = await query({
+            query: userProfileCounts,
+            variables: { id: 'all-groups-user' },
+          })
+          expect(result).toMatchObject({
+            data: {
+              User: [{ id: 'all-groups-user', contributionsCount: 3, commentedCount: 3 }],
+            },
+            errors: undefined,
+          })
+        })
+      })
+    })
+
     describe('searchPosts', () => {
       describe('without authentication', () => {
         beforeEach(() => {

--- a/backend/src/graphql/resolvers/users.ts
+++ b/backend/src/graphql/resolvers/users.ts
@@ -618,14 +618,14 @@ export default {
       },
       count: {
         contributionsCount:
-          '-[:WROTE]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true',
+          '-[:WROTE]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true AND NOT (related)<-[:CANNOT_SEE]-(:User {id: $cypherParams.currentUserId})',
         friendsCount: '<-[:FRIENDS]->(related:User)',
         followingCount: '-[:FOLLOWS]->(related:User)',
         followedByCount: '<-[:FOLLOWS]-(related:User)',
         commentedCount:
-          '-[:WROTE]->(c:Comment)-[:COMMENTS]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true',
+          '-[:WROTE]->(c:Comment)-[:COMMENTS]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true AND NOT (related)<-[:CANNOT_SEE]-(:User {id: $cypherParams.currentUserId})',
         shoutedCount:
-          '-[:SHOUTED]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true',
+          '-[:SHOUTED]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true AND NOT (related)<-[:CANNOT_SEE]-(:User {id: $cypherParams.currentUserId})',
         badgeTrophiesCount: '<-[:REWARDED]-(related:Badge)',
       },
       hasOne: {

--- a/backend/src/graphql/resolvers/users.ts
+++ b/backend/src/graphql/resolvers/users.ts
@@ -22,6 +22,9 @@ import type { Context } from '@src/context'
 
 const neode = getNeode()
 
+const visiblePostFilter =
+  'WHERE NOT related.disabled = true AND NOT related.deleted = true AND NOT (related)<-[:CANNOT_SEE]-(:User {id: $cypherParams.currentUserId})'
+
 export const getMutedUsers = async (context) => {
   const { neode } = context
   const userModel = neode.model('User')
@@ -617,15 +620,12 @@ export default {
           'MATCH (this)<-[:MUTED]-(u:User {id: $cypherParams.currentUserId}) RETURN COUNT(u) >= 1',
       },
       count: {
-        contributionsCount:
-          '-[:WROTE]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true AND NOT (related)<-[:CANNOT_SEE]-(:User {id: $cypherParams.currentUserId})',
+        contributionsCount: `-[:WROTE]->(related:Post) ${visiblePostFilter}`,
         friendsCount: '<-[:FRIENDS]->(related:User)',
         followingCount: '-[:FOLLOWS]->(related:User)',
         followedByCount: '<-[:FOLLOWS]-(related:User)',
-        commentedCount:
-          '-[:WROTE]->(c:Comment)-[:COMMENTS]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true AND NOT (related)<-[:CANNOT_SEE]-(:User {id: $cypherParams.currentUserId})',
-        shoutedCount:
-          '-[:SHOUTED]->(related:Post) WHERE NOT related.disabled = true AND NOT related.deleted = true AND NOT (related)<-[:CANNOT_SEE]-(:User {id: $cypherParams.currentUserId})',
+        commentedCount: `-[:WROTE]->(c:Comment)-[:COMMENTS]->(related:Post) ${visiblePostFilter}`,
+        shoutedCount: `-[:SHOUTED]->(related:Post) ${visiblePostFilter}`,
         badgeTrophiesCount: '<-[:REWARDED]-(related:Badge)',
       },
       hasOne: {

--- a/backend/src/graphql/types/type/User.gql
+++ b/backend/src/graphql/types/type/User.gql
@@ -112,26 +112,13 @@ type User {
   # )
 
   contributions: [Post]! @relation(name: "WROTE", direction: "OUT")
-  contributionsCount: Int!
-    @cypher(
-      statement: """
-      MATCH (this)-[:WROTE]->(r:Post)
-      WHERE NOT r.deleted = true AND NOT r.disabled = true
-      RETURN COUNT(r)
-      """
-    )
+  contributionsCount: Int! @neo4j_ignore
 
   comments: [Comment]! @relation(name: "WROTE", direction: "OUT")
-  commentedCount: Int!
-    @cypher(
-      statement: "MATCH (this)-[:WROTE]->(:Comment)-[:COMMENTS]->(p:Post) WHERE NOT p.deleted = true AND NOT p.disabled = true RETURN COUNT(DISTINCT(p))"
-    )
+  commentedCount: Int! @neo4j_ignore
 
   shouted: [Post]! @relation(name: "SHOUTED", direction: "OUT")
-  shoutedCount: Int!
-    @cypher(
-      statement: "MATCH (this)-[:SHOUTED]->(r:Post) WHERE NOT r.deleted = true AND NOT r.disabled = true RETURN COUNT(DISTINCT r)"
-    )
+  shoutedCount: Int! @neo4j_ignore
 
   categories: [Category] @relation(name: "CATEGORIZED", direction: "OUT")
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix user profile counts if closed/hidden groups are involved

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Beitrag- und Kommentarzählungen in Benutzerprofilen werden korrekt nach Sichtbarkeitsregeln gefiltert und zeigen nur Inhalte an, auf die der anfragende Benutzer Zugriff hat.
  * Zählungen berücksichtigen nun zusätzlich blockierte Inhalte und unterscheiden zwischen fehlender, anhängiger und bestätigter Gruppenmitgliedschaft.

* **Tests**
  * Neue Tests validieren Zählungs- und Sichtbarkeitsverhalten in verschiedenen Gruppen- und Viewer-Kontexten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->