### PR TITLE
fix(webapp): truncate notification content to 120/180 characters

### DIFF
--- a/webapp/components/NotificationsTable/NotificationsTable.spec.js
+++ b/webapp/components/NotificationsTable/NotificationsTable.spec.js
@@ -171,7 +171,11 @@ describe('NotificationsTable.vue', () => {
         const longContent = 'word '.repeat(60).trim()
 
         const descriptionTextAt = (rowIndex) =>
-          wrapper.findAll('.notification-grid-row').at(rowIndex).find('.notification-description').text()
+          wrapper
+            .findAll('.notification-grid-row')
+            .at(rowIndex)
+            .find('.notification-description')
+            .text()
 
         it('truncates long Post content to ~120 characters', () => {
           postNotification.from.content = longContent

--- a/webapp/components/NotificationsTable/NotificationsTable.spec.js
+++ b/webapp/components/NotificationsTable/NotificationsTable.spec.js
@@ -165,22 +165,31 @@ describe('NotificationsTable.vue', () => {
       })
 
       describe('description truncation', () => {
-        const longContent = 'a'.repeat(500)
+        // word-based content so trunc-html cuts at a word boundary near the
+        // configured limit (120 for posts, 180 for comments). A single long
+        // token would collapse to "…" and hide the limit difference.
+        const longContent = 'word '.repeat(60).trim()
 
-        it('truncates long Post content', () => {
+        const descriptionTextAt = (rowIndex) =>
+          wrapper.findAll('.notification-grid-row').at(rowIndex).find('.notification-description').text()
+
+        it('truncates long Post content to ~120 characters', () => {
           postNotification.from.content = longContent
           propsData.notifications = [postNotification]
           wrapper = Wrapper()
-          const description = wrapper.findAll('.notification-grid-row').at(0).find('p')
-          expect(description.text().length).toBeLessThan(longContent.length)
+          const text = descriptionTextAt(0)
+          expect(text.length).toBeLessThan(longContent.length)
+          expect(text.length).toBeLessThanOrEqual(125)
         })
 
-        it('truncates long Comment content', () => {
+        it('truncates long Comment content to ~180 characters', () => {
           commentNotification.from.content = longContent
           propsData.notifications = [commentNotification]
           wrapper = Wrapper()
-          const description = wrapper.findAll('.notification-grid-row').at(0).find('p')
-          expect(description.text().length).toBeLessThan(longContent.length)
+          const text = descriptionTextAt(0)
+          expect(text.length).toBeLessThan(longContent.length)
+          expect(text.length).toBeGreaterThan(125)
+          expect(text.length).toBeLessThanOrEqual(185)
         })
       })
 

--- a/webapp/components/NotificationsTable/NotificationsTable.spec.js
+++ b/webapp/components/NotificationsTable/NotificationsTable.spec.js
@@ -164,6 +164,26 @@ describe('NotificationsTable.vue', () => {
         })
       })
 
+      describe('description truncation', () => {
+        const longContent = 'a'.repeat(500)
+
+        it('truncates long Post content', () => {
+          postNotification.from.content = longContent
+          propsData.notifications = [postNotification]
+          wrapper = Wrapper()
+          const description = wrapper.findAll('.notification-grid-row').at(0).find('p')
+          expect(description.text().length).toBeLessThan(longContent.length)
+        })
+
+        it('truncates long Comment content', () => {
+          commentNotification.from.content = longContent
+          propsData.notifications = [commentNotification]
+          wrapper = Wrapper()
+          const description = wrapper.findAll('.notification-grid-row').at(0).find('p')
+          expect(description.text().length).toBeLessThan(longContent.length)
+        })
+      })
+
       describe('unread status', () => {
         it('does not have class `notification-status`', () => {
           expect(wrapper.find('.notification-status').exists()).toBe(false)

--- a/webapp/components/NotificationsTable/NotificationsTable.vue
+++ b/webapp/components/NotificationsTable/NotificationsTable.vue
@@ -72,8 +72,11 @@
                   :class="{ 'notification-status': notification.read }"
                 >
                   {{
-                    $filters.removeHtml(notification.from.content) ||
-                    $filters.removeHtml(notification.from.descriptionExcerpt)
+                    $filters.truncate(
+                      $filters.removeHtml(notification.from.content) ||
+                        $filters.removeHtml(notification.from.descriptionExcerpt),
+                      isComment(notification.from) ? 180 : 120,
+                    )
                   }}
                 </p>
               </div>


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

truncate notification content to 120/180 characters as before

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Verbesserungen**
  * Benachrichtigungsbeschreibungen werden jetzt automatisch bereinigt und gekürzt; unterschiedliche Längenlimits werden je nach Benachrichtigungstyp angewendet (kürzer für allgemeine, länger für Kommentare), was die Lesbarkeit verbessert.
* **Tests**
  * Zusätzliche Tests prüfen das Verhalten der Beschreibungskürzung für verschiedene Benachrichtigungstypen, um korrekte Trunkierung sicherzustellen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->