### PR TITLE
fix(webapp): ensure room name does not float over the  control buttons of the small chat window

### DIFF
--- a/webapp/components/Chat/Chat.vue
+++ b/webapp/components/Chat/Chat.vue
@@ -85,7 +85,7 @@
       </component>
     </div>
 
-    <div slot="room-header-info">
+    <div slot="room-header-info" class="chat-room-header-info">
       <div class="vac-room-name vac-text-ellipsis">
         <component
           :is="roomHeaderLink ? 'nuxt-link' : 'span'"
@@ -386,6 +386,8 @@ export default {
       style.textContent = `
         .vac-player-bar { min-width: 0; }
         .vac-player-progress { width: auto; flex: 1 1 auto; min-width: 0; }
+        .vac-room-header .vac-info-wrapper { flex: 1 1 0; min-width: 0; width: auto; }
+        .vac-room-header .vac-room-name { min-width: 0; }
         ${
           this.singleRoom
             ? `
@@ -1171,6 +1173,16 @@ export default {
 
 .ds-flex-item.single-chat-bubble {
   margin-right: 1em;
+}
+
+.chat-room-options {
+  flex-shrink: 0;
+}
+
+.chat-room-header-info {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .chat-header-profile-link {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

ensure room name does not float over the  control buttons of the small chat window

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Chat-Header werden optimal in kleineren Fenstergrößen angepasst.
* Verbesserte Darstellung von Raumoptionen und Header-Informationen.
* Verhindert unerwünschten Inhaltsüberlauf im Chat-Fenster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->