### PR TITLE
fix(backend): fix heartbeat

### DIFF
--- a/backend/src/graphql/resolvers/users.spec.ts
+++ b/backend/src/graphql/resolvers/users.spec.ts
@@ -901,6 +901,7 @@ describe('updateOnlineStatus', () => {
         const dbUser = database.neode.hydrateFirst(result, 'u', database.neode.model('User'))
         await expect(dbUser.toJson()).resolves.toMatchObject({
           lastOnlineStatus: 'online',
+          lastActiveAt: expect.any(String),
         })
         await expect(dbUser.toJson()).resolves.not.toMatchObject({
           awaySince: expect.any(String),

--- a/backend/src/graphql/resolvers/users.ts
+++ b/backend/src/graphql/resolvers/users.ts
@@ -358,6 +358,7 @@ export default {
           MATCH (user:User {id: $user.id})
             SET user.awaySince = null
             SET user.lastOnlineStatus = $status
+            SET user.lastActiveAt = toString(datetime())
         `
 
       await context.database.write({

--- a/backend/src/jwt/decode.spec.ts
+++ b/backend/src/jwt/decode.spec.ts
@@ -292,17 +292,15 @@ describe('decode', () => {
         })
       })
 
-      it('sets `lastActiveAt`', async () => {
+      it('does not set `lastActiveAt`', async () => {
         let user = await neode.first<typeof User>('User', { id: 'u3' }, undefined)
         await expect(user.toJson()).resolves.not.toHaveProperty('lastActiveAt')
         await decode(context)(validAuthorizationHeader)
         user = await neode.first<typeof User>('User', { id: 'u3' }, undefined)
-        await expect(user.toJson()).resolves.toMatchObject({
-          lastActiveAt: expect.any(String),
-        })
+        await expect(user.toJson()).resolves.not.toHaveProperty('lastActiveAt')
       })
 
-      it('updates `lastActiveAt` for every authenticated request', async () => {
+      it('does not touch `lastActiveAt` on authenticated requests', async () => {
         let user = await neode.first('User', { id: 'u3' }, undefined)
         await user.update({
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -316,8 +314,7 @@ describe('decode', () => {
         await decode(context)(validAuthorizationHeader)
         user = await neode.first<typeof User>('User', { id: 'u3' }, undefined)
         await expect(user.toJson()).resolves.toMatchObject({
-          // should be a different time by now ;)
-          lastActiveAt: expect.not.stringContaining('2019-10-03T23:33'),
+          lastActiveAt: '2019-10-03T23:33:08.598Z',
         })
       })
 

--- a/backend/src/jwt/decode.ts
+++ b/backend/src/jwt/decode.ts
@@ -34,20 +34,19 @@ const decodeJwt = async (
   }
   const session = context.driver.session()
 
-  const writeTxResultPromise = session.writeTransaction<DecodedUser[]>(async (transaction) => {
-    const updateUserLastActiveTransactionResponse = await transaction.run(
+  const readTxResultPromise = session.readTransaction<DecodedUser[]>(async (transaction) => {
+    const fetchUserTransactionResponse = await transaction.run(
       `
       MATCH (user:User {id: $id, deleted: false, disabled: false })
-      SET user.lastActiveAt = toString(datetime())
       RETURN user {.id, .slug, .name, .role, .disabled, .actorId}
       LIMIT 1
     `,
       { id },
     )
-    return updateUserLastActiveTransactionResponse.records.map((record) => record.get('user'))
+    return fetchUserTransactionResponse.records.map((record) => record.get('user'))
   })
   try {
-    const [currentUser] = await writeTxResultPromise
+    const [currentUser] = await readTxResultPromise
     if (!currentUser) return null
     return {
       ...currentUser,


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix heartbeat

❯ Wir haben das Phänomen, dass auf einer Instanz ein Nutzer permanent als online galt. Dadurch hat er keine Benachrichtigungen via Mail ausgespielt bekommen. Online Nutzer bekommen nur socket updates und keine      
  email. Wir persistieren den User-Online zustand in die Datenbank - was wäre eine bessere Konstruktion die solche Fehler addressiert?                                                                                 

● Kurz vorab: Soll ich das im Code verifizieren (wo isOnline gesetzt/gelesen wird), oder reicht dir die konzeptionelle Antwort?

  Konzeptionell: Der eigentliche Anti-Pattern ist, ephemeren Zustand (Präsenz) in durablem Storage zu führen — jeder Crash, verlorene Socket-Disconnect oder Pod-Restart hinterlässt Karteileichen. Drei
  Stoßrichtungen, die ich empfehlen würde, in der Reihenfolge ihres Hebels:

  1. Heartbeat statt Flag — kein isOnline-Boolean, sondern lastSeenAt mit Heartbeat alle ~20s. „Online" = now - lastSeenAt < threshold. Selbstheilend, keine Cleanup-Jobs nötig. Tradeoff: jede Präsenzabfrage wird zur
   Zeitberechnung, und die Schwelle ist eine neue Stellschraube.
  2. Präsenz aus dem Socket-Layer ableiten, nicht aus der DB — Redis mit TTL oder direkt der Socket.IO-Adapter ist Source of Truth; die Postgres/Neo4j-DB sieht den Online-Zustand gar nicht. Sauberste Trennung, aber
  bedeutet eine zusätzliche Infrastrukturkomponente und Refactoring an allen Lesestellen.
  3. Defense-in-depth bei der Mail-Entscheidung — selbst wenn „online", Mail nach X Sekunden ohne Ack/Lesebestätigung nachschicken. Adressiert das Symptom (verpasste Notifications) unabhängig davon, ob die
  Präsenzlogik korrekt ist. Tradeoff: potentielle Doppel-Benachrichtigung, also brauchst du eine Dedup-Logik bzw. ein „seen within grace period"-Feld.

  Mein Favorit für euren Fall: (1) + (3) kombiniert — Heartbeat löst die Stale-State-Klasse von Bugs grundsätzlich, und der Mail-Fallback macht die Notifications robust gegen zukünftige Bugs in der Präsenzlogik. (2)
   ist sauberer, aber für eine selbstgehostete Community-Plattform vermutlich Overkill.

✻ Brewed for 27s

❯ Ist die Heartbeat methode mit lastSeen nicht bereits implementiert?                                                                                                                                                  
                                                                      
  Searched for 3 patterns, read 3 files (ctrl+o to expand)                                                                                                                                                             
                                                                                                                                                                                                                       
● Doch — und du hast Recht, es ist ein Heartbeat-System: Frontend pingt alle 30s (webapp/plugins/onlineStatus.js:24), isUserOnline() prüft Staleness mit 90s/180s-Schwellen                                            
  (backend/src/middleware/helpers/isUserOnline.ts:10-15). In der Theorie selbstheilend.
                                                                                                                                                                                                                       
  Der Bug ist, dass es zwei unabhängige Schreiber für lastActiveAt gibt:                                                                                                                                               
                                                                                                                                                                                                                       
  1. Die explizite updateOnlineStatus-Mutation aus dem Frontend-Plugin (gewollt).                                                                                                                                      
  2. backend/src/jwt/decode.ts:41 — die JWT-Middleware schreibt bei jeder authentifizierten Anfrage SET user.lastActiveAt = toString(datetime()).                                                                      
                                                                                                                                                                                                                       
  Dadurch hält jede GraphQL-Anfrage den User „online", nicht nur der Heartbeat. Ein Hintergrund-Tab mit Polling, eine offen liegende Mobil-Session, ein Cron mit gültigem Token, sogar SSR-Requests im Namen des Users 
  — alles refresht lastActiveAt. Die 90s-Staleness greift dann praktisch nie.                                                                                                                                          
                                                                                                                                                                                                                       
  Das erklärt das Symptom „permanent online → keine Mails": Solange irgendwo etwas mit dem JWT des Nutzers spricht, läuft die Heartbeat-Logik leer, weil der Heartbeat nicht mehr die einzige Wahrheitsquelle ist.     
   
  Fix-Optionen, kleinster Eingriff zuerst:                                                                                                                                                                             
                  
  1. SET user.lastActiveAt aus decode.ts entfernen. Dann ist der Heartbeat-Plugin der einzige Schreiber und das System verhält sich, wie es gedacht war. Falls lastActiveAt woanders für „when did the user last touch 
  the API"-Zwecke gebraucht wird, dafür ein separates Feld (z.B. lastRequestAt) führen — die beiden Bedeutungen nicht in einem Feld vermischen.
  2. Zusätzlich (3) aus meiner ersten Antwort: Mail-Fallback wenn keine Socket-Ack kommt — dann sind Notifications auch robust, falls die Präsenzlogik nochmal kaputtgeht.                                             
                                                                                                                                                                                                                       
  Soll ich den Fix in decode.ts umsetzen? Das ist eine Vier-Zeilen-Änderung, aber es lohnt sich, vorher kurz zu prüfen, ob lastActiveAt noch an anderer Stelle in der Bedeutung „letzter API-Kontakt" gelesen wird     
  (z.B. in Admin-Views oder für GDPR/Inaktivitäts-Cleanup).                                                                                                                                                            
                                                                                                                                                                                                                       
✻ Cogitated for 54s               
                                                                                          
❯ Setze den Fix um                                                                                                                                                                                                     
                                                                                                                                                                                                                       
● Zuerst prüfen, ob lastActiveAt woanders mit der Bedeutung „letzter API-Kontakt" gelesen wird.                                                                                                                        
                                                                                                                                                                                                                       
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                                                                            
   
● Gut — lastActiveAt wird ausschließlich für Präsenz benutzt. Einziger Leser ist isUserOnline(). Sicher zu entfernen. Ich prüfe noch, ob Tests die Schreib-Semantik prüfen.                                            
                  
  Searched for 1 pattern, read 2 files (ctrl+o to expand)                                                                                                                                                              
                                           
● Wichtige Erkenntnis: Der updateOnlineStatus-Resolver in users.ts:344-369 schreibt awaySince und lastOnlineStatus, aber nicht lastActiveAt. Wenn ich nur den Schreibvorgang aus decode.ts entferne, würde lastActiveAt
   nie wieder aktualisiert → niemand wäre je „online". Der Fix muss also zweiteilig sein: JWT-Schreibvorgang raus, dafür das explizite Heartbeat-Mutation lastActiveAt setzen.
                                                                                                                                                                                                                       
  Searched for 1 pattern, read 2 files (ctrl+o to expand)                                                                                                                                                              
                                                                                                                                                                                                                       
● Plan ist klar. Drei Änderungen:                                                                                                                                                                                      
                                                                                                                                                                                                                       
  1. backend/src/jwt/decode.ts: SET user.lastActiveAt entfernen, writeTransaction → readTransaction.                                                                                                                   
  2. backend/src/graphql/resolvers/users.ts: Im updateOnlineStatus-Resolver SET user.lastActiveAt = toString(datetime()) zur CYPHER_ONLINE-Variante hinzufügen, damit der Heartbeat zur einzigen Wahrheitsquelle wird. 
  3. Tests anpassen: Die zwei Tests in decode.spec.ts:295-322 invertieren (decode darf lastActiveAt nicht mehr setzen), und im updateOnlineStatus-Test in users.spec.ts zusätzlich asserten, dass lastActiveAt bei     
  Status online geschrieben wird.                                                                                                                                                                                      
                                                                                                                                                                                                                       
● Update(backend/src/jwt/decode.ts)                                                                                                                                                                                    
                                                                                          
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Edit file                                                                                                                                                                                                             
✻ Cogitated for 54s

❯ Setze den Fix um                                                                                                                                                                                                     

● Zuerst prüfen, ob lastActiveAt woanders mit der Bedeutung „letzter API-Kontakt" gelesen wird.

  Searched for 1 pattern (ctrl+o to expand)

● Gut — lastActiveAt wird ausschließlich für Präsenz benutzt. Einziger Leser ist isUserOnline(). Sicher zu entfernen. Ich prüfe noch, ob Tests die Schreib-Semantik prüfen.

  Searched for 1 pattern, read 2 files (ctrl+o to expand)

● Wichtige Erkenntnis: Der updateOnlineStatus-Resolver in users.ts:344-369 schreibt awaySince und lastOnlineStatus, aber nicht lastActiveAt. Wenn ich nur den Schreibvorgang aus decode.ts entferne, würde lastActiveAt
   nie wieder aktualisiert → niemand wäre je „online". Der Fix muss also zweiteilig sein: JWT-Schreibvorgang raus, dafür das explizite Heartbeat-Mutation lastActiveAt setzen.

  Searched for 1 pattern, read 2 files (ctrl+o to expand)

● Plan ist klar. Drei Änderungen:

  1. backend/src/jwt/decode.ts: SET user.lastActiveAt entfernen, writeTransaction → readTransaction.
  2. backend/src/graphql/resolvers/users.ts: Im updateOnlineStatus-Resolver SET user.lastActiveAt = toString(datetime()) zur CYPHER_ONLINE-Variante hinzufügen, damit der Heartbeat zureinzigen Wahrheitsquelle wird.
  3. Tests anpassen: Die zwei Tests in decode.spec.ts:295-322 invertieren (decode darf lastActiveAt nicht mehr setzen), und im updateOnlineStatus-Test in users.spec.ts zusätzlich asserten, dass lastActiveAt bei
  Status online geschrieben wird.

● Update(backend/src/jwt/decode.ts)
  ⎿  Added 4 lines, removed 5 lines
      34    }                            
      35    const session = context.driver.session()                                      
      36  
      37 -  const writeTxResultPromise = session.writeTransaction<DecodedUser[]>(async (transaction) => {                                                                                                              
      38 -    const updateUserLastActiveTransactionResponse = await transaction.run(                                                                                                                            
      37 +  const readTxResultPromise = session.readTransaction<DecodedUser[]>(async (transaction) => {                                                                                                                
      38 +    const fetchUserTransactionResponse = await transaction.run(                                                                                                                                            
      39        `
      40        MATCH (user:User {id: $id, deleted: false, disabled: false })
      41 -      SET user.lastActiveAt = toString(datetime())                                                                                                                                                    
      41        RETURN user {.id, .slug, .name, .role, .disabled, .actorId}
      42        LIMIT 1
      43      `,
      44        { id },
      45      )
      47 -    return updateUserLastActiveTransactionResponse.records.map((record) => record.get('user'))                                                                                                        
      46 +    return fetchUserTransactionResponse.records.map((record) => record.get('user'))                                                                                                                   
      47    })
      48    try {
      50 -    const [currentUser] = await writeTxResultPromise                                                                                                                                                  
      49 +    const [currentUser] = await readTxResultPromise                                                                                                                                                   
      50      if (!currentUser) return null
      51      return {
      52        ...currentUser,

● Update(backend/src/graphql/resolvers/users.ts)
  ⎿  Added 1 line                                                                         
      358            MATCH (user:User {id: $user.id})                                                                                                                                                                  
      359              SET user.awaySince = null                                                                                                                                                                       
      360              SET user.lastOnlineStatus = $status
      361 +            SET user.lastActiveAt = toString(datetime())                                                                                                                                                    
      362          `                                                         
      363                                                                                                                                                                                                              
      364        await context.database.write({                                          
                                                                                                                                                                                                                       
● Jetzt die Tests anpassen.                                                                                                                                                                                            
                                                                                                                                                                                                                       
● Update(backend/src/jwt/decode.spec.ts)                                                                                                                                                                               
  ⎿  Added 4 lines, removed 7 lines                                                                                                                                                                                    
      292          })                                                                                                                                                                                                  
      293        })                                                                                                                                                                                                    
      294                                                                                                                                                                                                              
      295 -      it('sets `lastActiveAt`', async () => {                                                                                                                                                               
      295 +      it('does not set `lastActiveAt`', async () => {                                                                                                                                                       
      296          let user = await neode.first<typeof User>('User', { id: 'u3' }, undefined)                                                                                                                          
      297          await expect(user.toJson()).resolves.not.toHaveProperty('lastActiveAt')
      298          await decode(context)(validAuthorizationHeader)
      299          user = await neode.first<typeof User>('User', { id: 'u3' }, undefined)
      300 -        await expect(user.toJson()).resolves.toMatchObject({                                                                                                                                         
      301 -          lastActiveAt: expect.any(String),                                                                                                                                                          
      302 -        })                                                                                                                                                                                           
      300 +        await expect(user.toJson()).resolves.not.toHaveProperty('lastActiveAt')                                                                                                                      
      301        })
      302  
      305 -      it('updates `lastActiveAt` for every authenticated request', async () => {                                                                                                                     
      303 +      it('does not touch `lastActiveAt` on authenticated requests', async () => {                                                                                                                    
      304          let user = await neode.first('User', { id: 'u3' }, undefined)
      305          await user.update({
      306            // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...
      314          await decode(context)(validAuthorizationHeader)
      315          user = await neode.first<typeof User>('User', { id: 'u3' }, undefined)
      316          await expect(user.toJson()).resolves.toMatchObject({
      319 -          // should be a different time by now ;)                                                                                                                                                    
      320 -          lastActiveAt: expect.not.stringContaining('2019-10-03T23:33'),                                                                                                                             
      317 +          lastActiveAt: '2019-10-03T23:33:08.598Z',                                                                                                                                                  
      318          })
      319        })
      320  

● Update(backend/src/graphql/resolvers/users.spec.ts)
  ⎿  Added 1 line                                                                         
      901          const dbUser = database.neode.hydrateFirst(result, 'u', database.neode.model('User'))
      902          await expect(dbUser.toJson()).resolves.toMatchObject({                                                                                                                                              
      903            lastOnlineStatus: 'online',
      904 +          lastActiveAt: expect.any(String),                                                                                                                                                                 
      905          })                                       
      906          await expect(dbUser.toJson()).resolves.not.toMatchObject({                                                                                                                                          
      907            awaySince: expect.any(String),         

● Tests laufen lassen, um den Fix zu verifizieren.
                                                                                          
  Listed 1 directory (ctrl+o to expand)  
                                                                                                                                                                                                                       
● Bash(cd backend && npx jest --runInBand --forceExit src/jwt/decode.spec.ts 2>&1 | tail -60)
  ⎿    normalizeEmail.ts                    |   66.66 |      100 |       0 |   66.66 | 6                                                                                                                               
                                                                                          
      src/graphql/resolvers/images          |   20.25 |        0 |       0 |   19.04 |                                                                                                                                 
     … +60 lines (ctrl+o to expand)                                                                                                                                                                                    
  ⎿  (timeout 5m)                                                                         
                                                                                                                                                                                                                       
● Bash(cd backend && npx jest --runInBand --forceExit src/jwt/decode.spec.ts 2>&1 | grep -E "✓|✗|✕|FAIL|PASS|Error|TypeError|●" | head -60)                                                                            
  ⎿  Error: Exit code 1                                                                                                                                                                                                
     /bin/bash: line 1: cd: backend: No such file or directory                                                                                                                                                         
                                                                                                                                                                                                                       
● Bash(pwd && ls)                                                                         
  ⎿  /home/dornhoeschen/.data/sources/Ocelot-Social-Community/Ocelot-Social/backend                                                                                                                                    
     branding                                                                                                                                                                                                          
     build                                                                                                                                                                                                             
     … +20 lines (ctrl+o to expand)                                                                                                                                                                                    
                                                                                                                                                                                                                       
● Bash(npx jest --runInBand --forceExit src/jwt/decode.spec.ts 2>&1 | grep -E "✓|✗|✕|FAIL|PASS|●|Error:|TypeError:" | head -50)                                                                                        
  ⎿  FAIL src/jwt/decode.spec.ts (186.407 s)                                              
       ● decode › given API key with oak_ prefix › and valid API key in database › returns user object with authMethod apiKey                                                                                          
       ● decode › given API key with oak_ prefix › and valid API key in database › returns user object with authMethod apiKey                                                                                          
     … +24 lines (ctrl+o to expand)                                                       
  ⎿  (timeout 5m)                                                                                                                                                                                                      
                                                                                                                                                                                                                       
● Bash(npx jest --runInBand --forceExit src/jwt/decode.spec.ts 2>&1 | grep -A 15 "Test suite failed to run" | head -50)                                                                                                
  ⎿    ● Test suite failed to run                                                                                                                                                                                      
                                                                                                                                                                                                                       
         thrown: "Exceeded timeout of 10000 ms for a hook.                                                                                                                                                             
     … +14 lines (ctrl+o to expand)                                                       
  ⎿  (timeout 5m)                                                                                                                                                                                                      
                                                                                                                                                                                                                       
● Bash(docker ps 2>/dev/null | grep -i neo4j; echo "---"; ss -tlnp 2>/dev/null | grep -E ":7687|:7474" || echo "No Neo4j ports listening")                                                                             
  ⎿  ---                                                                                                                                                                                                               
     No Neo4j ports listening                                                                                                                                                                                          
                                                                                                                                                                                                                       
● Tests sind Integrationstests, die einen laufenden Neo4j brauchen — aktuell nicht hochgefahren (Test-Suite-Timeout im cleanDatabase-Hook, alle Tests schlagen fehl, auch unveränderte). Das ist ein Umgebungsproblem,
  nicht eine Regression durch meine Änderungen. Ich verifiziere stattdessen Typen und Syntax.                                                                                                                          
                                                                                                                                                                                                                       
  Searched for 1 pattern (ctrl+o to expand)                                                                                                                                                                            
                                                                                                                                                                                                                       
● Bash(npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "src/jwt/decode|src/graphql/resolvers/users\." | head -30)                                                                                                     
  ⎿  (No output)                                                                                                                                                                                                       
  ⎿  (timeout 3m)                 
                                                                                                                                                                                                                       
● Bash(npx tsc --noEmit -p tsconfig.json 2>&1 | tail -20)                                 
  ⎿  (No output)                                                                                                                                                                                                       
  ⎿  (timeout 3m)                                                                                                                                                                                                      
                                                                                                                                                                                                                       
● Typecheck sauber. Jetzt noch ESLint auf die geänderten Dateien.                                                                                                                       
● Bash(npx jest --runInBand --forceExit src/jwt/decode.spec.ts 2>&1 | grep -A 15 "Test suite failed to run" | head -50)
  ⎿    ● Test suite failed to run

         thrown: "Exceeded timeout of 10000 ms for a hook.
     … +14 lines (ctrl+o to expand)
  ⎿  (timeout 5m)

● Bash(docker ps 2>/dev/null | grep -i neo4j; echo "---"; ss -tlnp 2>/dev/null | grep -E ":7687|:7474" || echo "No Neo4j ports listening")
  ⎿  ---
     No Neo4j ports listening

● Tests sind Integrationstests, die einen laufenden Neo4j brauchen — aktuell nicht hochgefahren (Test-Suite-Timeout im cleanDatabase-Hook, alle Tests schlagen fehl, auch unveränderte).
   Das ist ein Umgebungsproblem, nicht eine Regression durch meine Änderungen. Ich verifiziere stattdessen Typen und Syntax.

  Searched for 1 pattern (ctrl+o to expand)

● Bash(npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "src/jwt/decode|src/graphql/resolvers/users\." | head -30)
  ⎿  (No output)
  ⎿  (timeout 3m)

● Bash(npx tsc --noEmit -p tsconfig.json 2>&1 | tail -20)
  ⎿  (No output)
  ⎿  (timeout 3m)

● Typecheck sauber. Jetzt noch ESLint auf die geänderten Dateien.

● Bash(npx eslint --max-warnings 0 src/jwt/decode.ts src/jwt/decode.spec.ts src/graphql/resolvers/users.ts src/graphql/resolvers/users.spec.ts 2>&1 | tail -30)
  ⎿  (node:37263) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///home/dornhoeschen/.data/sources/Ocelot-Social-Community/Ocelot-Social/backend/prettier.config.ts i
     s not specified and it doesn't parse as CommonJS.
     Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
     … +2 lines (ctrl+o to expand)                                                        
  ⎿  (timeout 2m)                                                                         
                                                                                                                                                                                        
● Fix umgesetzt und verifiziert (TypeScript + ESLint sauber). Tests konnte ich nicht ausführen, weil keine Neo4j-Test-Instanz läuft — die Suite ist Integration und timed out im        
  cleanDatabase-Hook.                                                                                                                                                                   
                                                                                                                                                                                        
  Geänderte Dateien:                                                                                                                                                                    
  
  - backend/src/jwt/decode.ts:35-49 — SET user.lastActiveAt entfernt, writeTransaction → readTransaction. Der JWT-Decode ist nun eine reine Lese-Operation.                             
  - backend/src/graphql/resolvers/users.ts:357-362 — CYPHER_ONLINE schreibt jetzt lastActiveAt, damit der explizite Heartbeat die einzige Wahrheitsquelle ist.
  - backend/src/jwt/decode.spec.ts:295-321 — die zwei Tests, die das alte (fehlerhafte) Verhalten festschrieben, invertiert: decode() darf lastActiveAt nicht mehr setzen oder          
  verändern.                                                                                                                                                                            
  - backend/src/graphql/resolvers/users.spec.ts:902-907 — Assertion ergänzt, dass lastActiveAt gesetzt wird, wenn der Resolver mit Status online aufgerufen wird.                       

  Wirkung: Der Heartbeat des Frontends (webapp/plugins/onlineStatus.js) wird zur einzigen Quelle, die lastActiveAt aktualisiert. Hintergrundtätigkeit (Polling-Tabs, Mobile-Tokens,
  Crons mit JWT) hält den User nicht mehr künstlich „online", die 90s-Staleness in isUserOnline() greift wie ursprünglich gedacht — und Email-Benachrichtigungen erreichen Nutzer, die
  nicht aktiv eine Session offen haben.

  Empfehlung als Folge-PR: Schritt (3) aus meiner Analyse — Mail-Fallback wenn Socket-Push nicht innerhalb von z.B. 60s acked wird. Dann sind Notifications auch dann robust, falls die
  Präsenzlogik in Zukunft nochmal kaputtgeht.

  Wenn du willst, kann ich vor dem Commit lokal docker-compose up -d neo4j (bzw. eure Variante) starten und die Tests durchlaufen lassen — sag Bescheid wie ihr die Test-DB hochfahrt.

✻ Sautéed for 12m 49s

❯ Kann es sein, dass die Gültigkeit des JWTs eine Rolle spielt. Dre unzureichend implementierte Refresh hat dazu geführt, dass die meisten JWTs eine Gültigkeit von 2 Jahren haben.     
                                                                                                                                                                                    
● Ja, das hat den Bug massiv verstärkt — und es erklärt wahrscheinlich, warum gerade bei euch dieser Fall so zuverlässig auftritt.                                                      
                                         
  Vor dem Fix: Jede authentifizierte Anfrage refreshte lastActiveAt. Mit 2-Jahres-JWTs heißt das: jede Session, die der Nutzer je auf irgendeinem Gerät angelegt hat — vergessenes      
  Tablet, alter Browser, das Smartphone in der Schublade, ein Cron-Skript mit Token — hält ihn permanent online, solange dort irgendetwas gegen die API spricht (Notification-Polling,
  Subscriptions, Service-Worker, automatische Refetches). Bei kurzen JWTs (z.B. 15 Min) wären solche Geister-Sessions schon längst ausgelaufen, der Bug wäre seltener und temporärer;   
  bei 2 Jahren bleiben sie aktiv und reaktivieren sich bei jedem Gerätestart.

  Nach dem Fix: Die JWT-Gültigkeit ist für das Präsenz-Problem weitgehend entkoppelt. Der Heartbeat-Plugin (webapp/plugins/onlineStatus.js) läuft nur in einem geladenen Browser-Tab und
   stoppt beim Schließen — ab dann läuft die 90s-Staleness zwingend ab, egal wie lange der Token noch gültig wäre. Hintergrundtabs senden away, was lastActiveAt nicht mehr refresht.
  Damit sind:                                                                                                                                                                           
  - vergessene Mobile-Sessions: nicht mehr „online" (die App pingt im Hintergrund nicht den Heartbeat)
  - API-Skripte mit Token: nicht mehr „online" (sie rufen updateOnlineStatus nicht auf)                                                                                                 
  - offene Foreground-Tabs auf einem Standby-Gerät: weiterhin „online" — was korrekt ist, der Tab ist sichtbar geöffnet
                                                                                                                                                                                        
  Aber — die langen JWTs bleiben ein eigenständiges Problem, unabhängig von Präsenz:                                                                                                    
                                                                                                                                                                                        
  1. Revocation: Ein kompromittierter Token ist 2 Jahre nutzbar. Es gibt keine Sperrliste, keinen Logout-everywhere.                                                                    
  2. Datenschutz / DSGVO: Bei „Konto löschen" oder Disable wird der Token nicht ungültig (die JWT-Middleware prüft zwar deleted/disabled im DB-Match, aber Subscriptions/Cached-Sessions
   können trotzdem Resterechte haben).                                                                                                                                                  
  3. Rotation: Passwortwechsel invalidiert die alten JWTs nicht.
  4. Audit: Du kannst nicht zuverlässig sagen, welche Geräte aktuell Zugriff haben.                                                                                                     
                                                                                                                                                                                        
  Empfehlung als getrennte Initiative: Refresh-Token-Pattern korrekt einführen — kurze Access-Tokens (15-60 Min), langlebiger Refresh-Token mit serverseitiger Allowlist (in Neo4j als  
  Session-Knoten am User). Dann entscheidet die DB über Gültigkeit, nicht nur die Token-Signatur. Aber das ist ein eigenes Stück Arbeit, nicht Teil dieses Fixes.                       
                                                                                                                                                                                        
  Soll ich für die JWT-Frage einen Memory-Eintrag anlegen, damit das in einer späteren Sitzung als bekannte technische Schuld auftaucht?  
  ```

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Verfeinerte die Verfolgung des zuletzt aktiven Zeitstempels – dieser wird nun nur beim expliziten Aktualisieren des Online-Status gesetzt, nicht mehr bei jeder Authentifizierung.

* **Tests**
  * Aktualisierte Tests zur Validierung des korrekten Verhaltens bei Aktivitätsverfolgung und Online-Status-Updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->