### PR TITLE
fix(backend): fix generated slugs to not contain apostroph or comma

### DIFF
--- a/backend/src/db/factories.ts
+++ b/backend/src/db/factories.ts
@@ -9,12 +9,11 @@
 import { faker } from '@faker-js/faker'
 import { hashSync } from 'bcryptjs'
 import { Factory } from 'rosie'
-import slugify from 'slugify'
 import { v4 as uuid } from 'uuid'
 
 import { generateInviteCode } from '@graphql/resolvers/inviteCodes'
 import { isUniqueFor } from '@middleware/sluggifyMiddleware'
-import uniqueSlug from '@middleware/slugify/uniqueSlug'
+import uniqueSlug, { toSlug } from '@middleware/slugify/uniqueSlug'
 
 import { getDriver, getNeode } from './neo4j'
 
@@ -200,7 +199,10 @@ Factory.define('post')
     return pinned || null
   })
   .attr('slug', ['slug', 'title'], (slug, title) => {
-    return slug || slugify(title, { lower: true })
+    // Production slug builder: guarantees the models' slug regex /^[a-z0-9_-]+$/
+    // for faker titles (apostrophes/commas would otherwise flake the CI with an
+    // opaque neode ERROR_VALIDATION).
+    return slug || toSlug(title)
   })
   .attr('language', ['language'], (language) => {
     return language || 'en'
@@ -244,7 +246,11 @@ Factory.define('group')
     disabled: false,
   })
   .attr('slug', ['slug', 'name'], (slug, name) => {
-    return slug || slugify(name, { lower: true })
+    // Production slug builder: guarantees the Group model's slug regex
+    // /^[a-z0-9_-]+$/ for faker company names like "O'Conner Group" or
+    // "Erdman, Gutmann and Hand" (which otherwise flake the CI with an opaque
+    // neode ERROR_VALIDATION).
+    return slug || toSlug(name)
   })
   .attr(
     'descriptionExcerpt',

--- a/backend/src/graphql/resolvers/groups.spec.ts
+++ b/backend/src/graphql/resolvers/groups.spec.ts
@@ -264,6 +264,33 @@ describe('in mode', () => {
       await cleanDatabase()
     })
 
+    describe('group factory', () => {
+      // Regression guard for a CI flake: faker.company.name() occasionally
+      // produces names with apostrophes ("O'Conner Group") or commas
+      // ("Erdman, Gutmann and Hand"); the factory's slug must strip them or
+      // neode's slug regex validation rejects the create with an opaque
+      // ERROR_VALIDATION.
+      it('builds a group whose name contains an apostrophe', async () => {
+        await expect(
+          Factory.build(
+            'group',
+            { id: 'apo-1', name: "O'Conner Group" },
+            { ownerId: 'current-user' },
+          ),
+        ).resolves.toBeDefined()
+      })
+
+      it('builds a group whose name contains a comma', async () => {
+        await expect(
+          Factory.build(
+            'group',
+            { id: 'comma-1', name: 'Erdman, Gutmann and Hand' },
+            { ownerId: 'current-user' },
+          ),
+        ).resolves.toBeDefined()
+      })
+    })
+
     describe('CreateGroup', () => {
       beforeEach(() => {
         variables = {

--- a/backend/src/middleware/slugify/uniqueSlug.spec.ts
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.ts
@@ -32,4 +32,29 @@ describe('uniqueSlug', () => {
     const isUnique = jest.fn().mockResolvedValue(true)
     await expect(uniqueSlug(diacritics, isUnique)).resolves.toEqual('aaeeiioouuncaaeeiioouunc')
   })
+
+  // The User/Group/Post models validate slugs against /^[a-z0-9_-]+$/ — every
+  // character the slugify config lets through outside that alphabet ends in an
+  // opaque neode ERROR_VALIDATION on create. Guard the full alphabet contract.
+  describe('always produces a slug matching /^[a-z0-9_-]+$/', () => {
+    const isUnique = jest.fn().mockResolvedValue(true)
+
+    it('strips commas (slugify keeps them once a custom `remove` is set)', async () => {
+      await expect(uniqueSlug('Foo, Bar & Friends', isUnique)).resolves.toEqual(
+        'foo-bar-and-friends',
+      )
+    })
+
+    it('strips apostrophes', async () => {
+      await expect(uniqueSlug("O'Conner Group", isUnique)).resolves.toEqual('oconner-group')
+    })
+
+    it('keeps underscores and hyphens (both allowed by the models)', async () => {
+      await expect(uniqueSlug('foo_bar-baz', isUnique)).resolves.toEqual('foo_bar-baz')
+    })
+
+    it('falls back to "anonymous" when nothing slug-able remains', async () => {
+      await expect(uniqueSlug('!!!', isUnique)).resolves.toEqual('anonymous')
+    })
+  })
 })

--- a/backend/src/middleware/slugify/uniqueSlug.ts
+++ b/backend/src/middleware/slugify/uniqueSlug.ts
@@ -4,12 +4,23 @@ import slugify from 'slugify'
 
 slugify.extend({ Ä: 'AE', ä: 'ae', Ö: 'OE', ö: 'oe', Ü: 'UE', ü: 'ue', ß: 'ss' })
 
+// The single slug builder: the User/Group/Post models validate slugs against
+// /^[a-z0-9_-]+$/, so everything outside that alphabet must go. slugify alone
+// is not enough — passing a custom `remove` disables its default catch-all
+// (commas etc. would survive), hence the explicit post-filter. Falls back to
+// 'anonymous' when nothing slug-able remains (e.g. '!!!').
+export function toSlug(str: string): string {
+  return (
+    slugify(str || 'anonymous', {
+      lower: true,
+      remove: /[*+~.()'"!:@]/g,
+    }).replace(/[^a-z0-9_-]/g, '') || 'anonymous'
+  )
+}
+
 type IsUnique = (slug: string) => Promise<boolean>
 export default async function uniqueSlug(str: string, isUnique: IsUnique) {
-  const slug = slugify(str || 'anonymous', {
-    lower: true,
-    remove: /[*+~.()'"!:@]/g,
-  })
+  const slug = toSlug(str)
   if (await isUnique(slug)) return slug
 
   let count = 0


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix generated slugs to not contain apostroph or comma

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verbesserte Slug-Generierung für Gruppennamen und Beiträge mit präziserer Behandlung von Sonderzeichen, Umlauten, Apostrophen und Kommas
  * Erweiterte Zeichenvalidierung für konsistentere Slug-Formatierung

* **Tests**
  * Neue Testfälle für Slug-Validierung und Sonderzeichen-Handling zur Gewährleistung der Zuverlässigkeit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->