### PR TITLE
fix(docker): fix double definition of port 9000

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,8 +15,11 @@ services:
 
   backend:
     image: ghcr.io/ocelot-social-community/ocelot-social/backend:local-development
-    ports:
-      - 9000:9000
+    # No host port for the backend's in-container S3 proxy (it binds 9000 inside
+    # the container for its own uploads): host port 9000 is owned by minio below
+    # — it serves both the browser-facing file URLs (anonymous-read bucket) and
+    # the host-run backend test suite. Publishing it here too collides
+    # ("Bind for 0.0.0.0:9000 failed: port is already allocated").
     depends_on:
       - minio
       - minio-mc


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix double definition of port 9000

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Docker-Konfiguration angepasst: Port 9000 des Backend-Services wird nicht mehr auf den Host-Port übertragen, um Konflikte mit dem Minio-Service zu vermeiden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->