### PR TITLE
fix(webapp): fix ws to end on login - ensure it reconnects

### DIFF
--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -111,6 +111,10 @@ export const actions = {
       // returns the viewer-scoped keys (e.g. apiKeysEnabled) that were null
       // while anonymous — no full page reload needed.
       await dispatch('policy/init', null, { root: true })
+      // onLogin() restarted the websocket (restartWebsockets), which drops the
+      // policyChanged subscription's handler. Re-open it so live updates keep
+      // arriving without a full page reload.
+      await dispatch('policy/resubscribe', null, { root: true })
       if (cookies.get(metadata.COOKIE_NAME) === undefined) {
         throw new Error('no-cookie')
       }
@@ -128,5 +132,8 @@ export const actions = {
     // Refetch as anonymous so authenticated-only keys (e.g. apiKeysEnabled)
     // reset to their defaults instead of lingering from the logged-in session.
     await dispatch('policy/init', null, { root: true })
+    // onLogout() restarted the websocket too; re-open the subscription on the
+    // now-anonymous connection so public-key changes still arrive live.
+    await dispatch('policy/resubscribe', null, { root: true })
   },
 }

--- a/webapp/store/auth.test.js
+++ b/webapp/store/auth.test.js
@@ -259,12 +259,15 @@ describe('actions', () => {
       expect(onLogout).toHaveBeenCalled()
     })
 
-    it('refetches the policy as anonymous so authenticated-only keys reset', () => {
-      expect(dispatch).toHaveBeenCalledWith('policy/init', null, { root: true })
-    })
-
-    it('re-subscribes the policy on the now-anonymous websocket', () => {
-      expect(dispatch).toHaveBeenCalledWith('policy/resubscribe', null, { root: true })
+    it('refetches the policy as anonymous, then re-subscribes — in that order', () => {
+      // Order matters: resubscribe re-opens the websocket subscription the
+      // logout restarted, and it must run after the anonymous policy/init has
+      // reset the snapshot. An exact ordered match guards against a regression
+      // that swaps the two.
+      expect(dispatch.mock.calls).toEqual([
+        ['policy/init', null, { root: true }],
+        ['policy/resubscribe', null, { root: true }],
+      ])
     })
   })
 })

--- a/webapp/store/auth.test.js
+++ b/webapp/store/auth.test.js
@@ -175,11 +175,12 @@ describe('actions', () => {
         expect(commit.mock.calls).toEqual(expect.arrayContaining([['SET_TOKEN', token]]))
       })
 
-      it('fetches the user, initializes categories, and refetches the policy', () => {
+      it('fetches the user, initializes categories, refetches and re-subscribes the policy', () => {
         expect(dispatch.mock.calls).toEqual([
           ['fetchCurrentUser'],
           ['categories/init', null, { root: true }],
           ['policy/init', null, { root: true }],
+          ['policy/resubscribe', null, { root: true }],
         ])
       })
 
@@ -260,6 +261,10 @@ describe('actions', () => {
 
     it('refetches the policy as anonymous so authenticated-only keys reset', () => {
       expect(dispatch).toHaveBeenCalledWith('policy/init', null, { root: true })
+    })
+
+    it('re-subscribes the policy on the now-anonymous websocket', () => {
+      expect(dispatch).toHaveBeenCalledWith('policy/resubscribe', null, { root: true })
     })
   })
 })

--- a/webapp/store/policy.js
+++ b/webapp/store/policy.js
@@ -68,12 +68,44 @@ export const getters = {
 
 const apolloClient = (ctx) => ctx.app.apolloProvider.defaultClient
 
+// The live policyChanged subscription handle (one client per browser tab). Kept
+// at module scope so a forced websocket restart can tear it down and re-open a
+// fresh one: $apolloHelpers.onLogin/onLogout call restartWebsockets(), which
+// closes the socket and *resends the operation without its handler* — so the old
+// observable goes silent and live updates stop arriving until a full page
+// reload. Only a brand-new apolloClient.subscribe() re-registers a live handler
+// on the new connection. (A plain auto-reconnect keeps handlers, so this only
+// bites the login/logout path.)
+let policySubscription = null
+
+const openPolicySubscription = (store, commit) => {
+  const observable = apolloClient(store).subscribe({ query: PolicySubscription() })
+  policySubscription = observable.subscribe({
+    next({ data }) {
+      const event = data?.policyChanged
+      if (!event) return
+      try {
+        // Value-only notification: update the live snapshot. The last-change
+        // line is not updated live (it refreshes from policyDefaults on the
+        // next fetch) — the broadcast carries no actor/timestamp.
+        commit('PATCH_KEY', { key: event.key, value: JSON.parse(event.value) })
+      } catch (err) {
+        // Ignore malformed event payloads.
+      }
+    },
+    error() {
+      commit('SET_SUBSCRIPTION_ACTIVE', false)
+    },
+  })
+  commit('SET_SUBSCRIPTION_ACTIVE', true)
+}
+
 export const actions = {
   // Fetches the viewer-scoped snapshot. Re-dispatched whenever the auth state
   // changes (after login / logout) so authenticated keys appear / reset without
   // a full page reload — the single query returns exactly what the current
   // viewer may see.
-  async init({ commit }) {
+  async init({ commit, state }) {
     try {
       const {
         data: { policy },
@@ -84,10 +116,17 @@ export const actions = {
       commit('SET_SNAPSHOT', policy)
       commit('SET_INITIALIZED')
     } catch (err) {
-      // Non-fatal: render with everything off until the backend answers
-      // (login/register screens degrade gracefully).
-      commit('SET_SNAPSHOT', {})
-      commit('SET_INITIALIZED', false)
+      // A failed refetch must NOT wipe a known-good snapshot. Around login the
+      // websocket reconnect triggers a second init() whose in-flight query is
+      // aborted by Apollo's resetStore ("Store reset while query was in flight");
+      // wiping to {} here would drop public keys (e.g. inviteRegistration) the
+      // first init already loaded, hiding the header invite button until the next
+      // change event. Only fall back to "everything off" on the very first load
+      // (nothing to preserve); otherwise keep the last snapshot and let the next
+      // successful init / change event re-sync.
+      if (!state.isInitialized) {
+        commit('SET_SNAPSHOT', {})
+      }
     }
   },
 
@@ -149,24 +188,20 @@ export const actions = {
     if (state.subscriptionActive) {
       return
     }
-    const observable = apolloClient(this).subscribe({ query: PolicySubscription() })
-    observable.subscribe({
-      next({ data }) {
-        const event = data?.policyChanged
-        if (!event) return
-        try {
-          // Value-only notification: update the live snapshot. The last-change
-          // line is not updated live (it refreshes from policyDefaults on the
-          // next fetch) — the broadcast carries no actor/timestamp.
-          commit('PATCH_KEY', { key: event.key, value: JSON.parse(event.value) })
-        } catch (err) {
-          // Ignore malformed event payloads.
-        }
-      },
-      error() {
-        commit('SET_SUBSCRIPTION_ACTIVE', false)
-      },
-    })
-    commit('SET_SUBSCRIPTION_ACTIVE', true)
+    openPolicySubscription(this, commit)
+  },
+
+  // Re-open the subscription after a forced websocket restart (login / logout).
+  // restartWebsockets() drops the previous operation's handler, so the existing
+  // observable receives nothing — tear it down and open a fresh subscription on
+  // the new connection. Without this, live policy changes stop arriving after a
+  // client-side login until the user does a full page reload.
+  resubscribe({ commit }) {
+    if (policySubscription) {
+      policySubscription.unsubscribe?.()
+      policySubscription = null
+    }
+    commit('SET_SUBSCRIPTION_ACTIVE', false)
+    openPolicySubscription(this, commit)
   },
 }

--- a/webapp/store/policy.spec.js
+++ b/webapp/store/policy.spec.js
@@ -132,19 +132,30 @@ describe('policy store', () => {
       it('fetches the viewer-scoped policy and commits snapshot + initialized', async () => {
         const policy = { publicRegistration: true, apiKeysEnabled: null }
         const query = jest.fn().mockResolvedValue({ data: { policy } })
-        await bindAction(actions.init, { query })({ commit })
+        await bindAction(actions.init, { query })({ commit, state: { isInitialized: false } })
 
         expect(query).toHaveBeenCalled()
         expect(commit).toHaveBeenCalledWith('SET_SNAPSHOT', policy)
         expect(commit).toHaveBeenCalledWith('SET_INITIALIZED')
       })
 
-      it('falls back to an empty snapshot (everything off) and stays uninitialized on failure', async () => {
+      it('falls back to an empty snapshot on the first load (never initialized) when the query fails', async () => {
         const query = jest.fn().mockRejectedValue(new Error('network'))
-        await bindAction(actions.init, { query })({ commit })
+        await bindAction(actions.init, { query })({ commit, state: { isInitialized: false } })
 
         expect(commit).toHaveBeenCalledWith('SET_SNAPSHOT', {})
-        expect(commit).toHaveBeenCalledWith('SET_INITIALIZED', false)
+      })
+
+      it('keeps the known-good snapshot when a refetch fails after a prior init (no wipe)', async () => {
+        // Around login the websocket reconnect fires a second init() whose query
+        // is aborted by Apollo's resetStore. That failure must not blank public
+        // keys (e.g. inviteRegistration) the first init already loaded.
+        const query = jest
+          .fn()
+          .mockRejectedValue(new Error('Store reset while query was in flight'))
+        await bindAction(actions.init, { query })({ commit, state: { isInitialized: true } })
+
+        expect(commit).not.toHaveBeenCalledWith('SET_SNAPSHOT', {})
       })
     })
 
@@ -319,6 +330,31 @@ describe('policy store', () => {
         }).not.toThrow()
 
         expect(commit).not.toHaveBeenCalledWith('PATCH_KEY', expect.anything())
+      })
+    })
+
+    describe('resubscribe', () => {
+      it('tears down the stale subscription and opens a fresh one on the new socket', () => {
+        // restartWebsockets() on login/logout drops the operation handler, so the
+        // old observable goes silent — resubscribe must unsubscribe it and open a
+        // brand-new subscription that re-registers a live handler.
+        const unsubscribe = jest.fn()
+        const innerSubscribe = jest.fn(() => ({ unsubscribe }))
+        const clientSubscribe = jest.fn(() => ({ subscribe: innerSubscribe }))
+
+        // Open one first so there is a handle to tear down.
+        bindAction(actions.subscribe, { subscribe: clientSubscribe })({
+          commit,
+          state: { subscriptionActive: false },
+        })
+        expect(innerSubscribe).toHaveBeenCalledTimes(1)
+
+        bindAction(actions.resubscribe, { subscribe: clientSubscribe })({ commit })
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1)
+        expect(commit).toHaveBeenCalledWith('SET_SUBSCRIPTION_ACTIVE', false)
+        expect(innerSubscribe).toHaveBeenCalledTimes(2)
+        expect(commit).toHaveBeenCalledWith('SET_SUBSCRIPTION_ACTIVE', true)
       })
     })
   })

--- a/webapp/store/policy.spec.js
+++ b/webapp/store/policy.spec.js
@@ -356,6 +356,28 @@ describe('policy store', () => {
         expect(innerSubscribe).toHaveBeenCalledTimes(2)
         expect(commit).toHaveBeenCalledWith('SET_SUBSCRIPTION_ACTIVE', true)
       })
+
+      it('opens a fresh subscription without crashing when there is no prior handle', () => {
+        // Recover flow: resubscribe may run before any subscribe (e.g. login on a
+        // client whose initial subscribe never fired). A fresh module instance
+        // guarantees the module-level handle starts null, so this exercises the
+        // "no handle to tear down" branch in isolation.
+        jest.isolateModules(() => {
+          const { actions: freshActions } = require('./policy')
+          const innerSubscribe = jest.fn(() => ({ unsubscribe: jest.fn() }))
+          const clientSubscribe = jest.fn(() => ({ subscribe: innerSubscribe }))
+
+          expect(() =>
+            freshActions.resubscribe.bind({
+              app: { apolloProvider: { defaultClient: { subscribe: clientSubscribe } } },
+            })({ commit }),
+          ).not.toThrow()
+
+          expect(innerSubscribe).toHaveBeenCalledTimes(1)
+          expect(commit).toHaveBeenCalledWith('SET_SUBSCRIPTION_ACTIVE', false)
+          expect(commit).toHaveBeenCalledWith('SET_SUBSCRIPTION_ACTIVE', true)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix ws to end on login - ensure it reconnects

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Live-Policy-Updates kommen nach Login/Logout zuverlässig wieder an, ohne Seiten-Neuladen.
  * Bei fehlgeschlagenem Policy-Refetch werden bereits geladene Policys nicht mehr ungewollt gelöscht (kein wiederholtes Zurücksetzen des Snapshots).

* **Verbesserungen**
  * Stabileres Resubscribe-Verhalten nach Verbindungs-Neustarts sorgt für konsistentere Echtzeit-Updates während Authentifizierung.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->