### PR TITLE
fix(webapp): fix filter button size in news feed on set filter options

### DIFF
--- a/webapp/components/FilterMenu/HeaderButton.vue
+++ b/webapp/components/FilterMenu/HeaderButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <os-button class="my-filter-button" variant="primary" appearance="filled" @click="clickButton">
+  <os-button class="my-filter-button" variant="primary" appearance="filled" size="sm" @click="clickButton">
     {{ title }}
     <template #suffix>
       <os-button

--- a/webapp/components/FilterMenu/HeaderButton.vue
+++ b/webapp/components/FilterMenu/HeaderButton.vue
@@ -1,5 +1,11 @@
 <template>
-  <os-button class="my-filter-button" variant="primary" appearance="filled" size="sm" @click="clickButton">
+  <os-button
+    class="my-filter-button"
+    variant="primary"
+    appearance="filled"
+    size="sm"
+    @click="clickButton"
+  >
     {{ title }}
     <template #suffix>
       <os-button


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Fix filter button size in news feed on set filter options if this filter buttons is active by constants in Webapp.

<img width="666" height="275" alt="Bildschirmfoto 2026-06-10 um 14 12 22" src="https://github.com/user-attachments/assets/f8f9c763-953c-4897-b6fd-22e497e18f6d" />

<img width="669" height="226" alt="Bildschirmfoto 2026-06-10 um 14 12 44" src="https://github.com/user-attachments/assets/51be6ab1-63c5-41dd-bcb5-a75ab8070501" />

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->

- [x] fix filter button size
- [x] tests not neccessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bugfixes**
  * Die primäre Header-Schaltfläche wurde auf eine standardisierte, kleinere Größe angepasst, wodurch die visuelle Konsistenz der Navigation verbessert wird und die Gesamtoptik der Benutzeroberfläche harmonischer wirkt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->