### PR TITLE
fix(other): fix so that pending members aren't shown on group profile 

### DIFF
--- a/backend/src/graphql/queries/groups/Group.gql
+++ b/backend/src/graphql/queries/groups/Group.gql
@@ -27,6 +27,7 @@ query Group($isMember: Boolean, $id: ID, $slug: String) {
       name
     }
     myRole
+    membersCount
     currentlyPinnedPostsCount
     inviteCodes {
       code

--- a/backend/src/graphql/queries/groups/GroupMembers.gql
+++ b/backend/src/graphql/queries/groups/GroupMembers.gql
@@ -1,5 +1,5 @@
-query GroupMembers($id: ID!) {
-  GroupMembers(id: $id) {
+query GroupMembers($id: ID!, $includePending: Boolean) {
+  GroupMembers(id: $id, includePending: $includePending) {
     user {
       id
       name

--- a/backend/src/graphql/resolvers/groups.spec.ts
+++ b/backend/src/graphql/resolvers/groups.spec.ts
@@ -2790,6 +2790,7 @@ describe('in mode', () => {
                 query: groupMembersQuery,
                 variables: {
                   id: groupId,
+                  includePending: true,
                 },
               })
               return result.data?.GroupMembers

--- a/backend/src/graphql/resolvers/groups.spec.ts
+++ b/backend/src/graphql/resolvers/groups.spec.ts
@@ -1835,6 +1835,41 @@ describe('in mode', () => {
             })
           })
         })
+
+        describe('membersCount', () => {
+          describe('public group', () => {
+            beforeEach(async () => {
+              authenticatedUser = await user.toJson()
+            })
+
+            it('counts only non-pending members', async () => {
+              const result = await query({ query: groupQuery, variables: { id: 'public-group' } })
+              expect(result.data?.Group[0]).toMatchObject({ id: 'public-group', membersCount: 3 })
+            })
+          })
+
+          describe('closed group', () => {
+            beforeEach(async () => {
+              authenticatedUser = await ownerOfClosedGroupUser.toJson()
+            })
+
+            it('counts only non-pending members', async () => {
+              const result = await query({ query: groupQuery, variables: { id: 'closed-group' } })
+              expect(result.data?.Group[0]).toMatchObject({ id: 'closed-group', membersCount: 2 })
+            })
+          })
+
+          describe('hidden group', () => {
+            beforeEach(async () => {
+              authenticatedUser = await ownerOfHiddenGroupUser.toJson()
+            })
+
+            it('counts only non-pending members', async () => {
+              const result = await query({ query: groupQuery, variables: { id: 'hidden-group' } })
+              expect(result.data?.Group[0]).toMatchObject({ id: 'hidden-group', membersCount: 3 })
+            })
+          })
+        })
       })
     })
 

--- a/backend/src/graphql/resolvers/groups.spec.ts
+++ b/backend/src/graphql/resolvers/groups.spec.ts
@@ -1429,7 +1429,7 @@ describe('in mode', () => {
                 authenticatedUser = await ownerOfClosedGroupUser.toJson()
               })
 
-              it('finds all members', async () => {
+              it('finds non-pending members', async () => {
                 const result = await query({
                   query: groupMembersQuery,
                   variables,
@@ -1437,14 +1437,6 @@ describe('in mode', () => {
                 expect(result).toMatchObject({
                   data: {
                     GroupMembers: expect.arrayContaining([
-                      expect.objectContaining({
-                        user: expect.objectContaining({
-                          id: 'current-user',
-                        }),
-                        membership: expect.objectContaining({
-                          role: 'pending',
-                        }),
-                      }),
                       expect.objectContaining({
                         user: expect.objectContaining({
                           id: 'owner-of-closed-group',
@@ -1465,6 +1457,33 @@ describe('in mode', () => {
                   },
                   errors: undefined,
                 })
+                expect(result.data?.GroupMembers.length).toBe(2)
+              })
+
+              it('finds all members including pending when includePending is true', async () => {
+                const result = await query({
+                  query: groupMembersQuery,
+                  variables: { ...variables, includePending: true },
+                })
+                expect(result).toMatchObject({
+                  data: {
+                    GroupMembers: expect.arrayContaining([
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'current-user' }),
+                        membership: expect.objectContaining({ role: 'pending' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-closed-group' }),
+                        membership: expect.objectContaining({ role: 'owner' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-hidden-group' }),
+                        membership: expect.objectContaining({ role: 'usual' }),
+                      }),
+                    ]),
+                  },
+                  errors: undefined,
+                })
                 expect(result.data?.GroupMembers.length).toBe(3)
               })
             })
@@ -1474,7 +1493,7 @@ describe('in mode', () => {
                 authenticatedUser = await ownerOfHiddenGroupUser.toJson()
               })
 
-              it('finds all members', async () => {
+              it('finds non-pending members', async () => {
                 const result = await query({
                   query: groupMembersQuery,
                   variables,
@@ -1482,14 +1501,6 @@ describe('in mode', () => {
                 expect(result).toMatchObject({
                   data: {
                     GroupMembers: expect.arrayContaining([
-                      expect.objectContaining({
-                        user: expect.objectContaining({
-                          id: 'current-user',
-                        }),
-                        membership: expect.objectContaining({
-                          role: 'pending',
-                        }),
-                      }),
                       expect.objectContaining({
                         user: expect.objectContaining({
                           id: 'owner-of-closed-group',
@@ -1505,6 +1516,33 @@ describe('in mode', () => {
                         membership: expect.objectContaining({
                           role: 'usual',
                         }),
+                      }),
+                    ]),
+                  },
+                  errors: undefined,
+                })
+                expect(result.data?.GroupMembers.length).toBe(2)
+              })
+
+              it('finds all members including pending when includePending is true', async () => {
+                const result = await query({
+                  query: groupMembersQuery,
+                  variables: { ...variables, includePending: true },
+                })
+                expect(result).toMatchObject({
+                  data: {
+                    GroupMembers: expect.arrayContaining([
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'current-user' }),
+                        membership: expect.objectContaining({ role: 'pending' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-closed-group' }),
+                        membership: expect.objectContaining({ role: 'owner' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-hidden-group' }),
+                        membership: expect.objectContaining({ role: 'usual' }),
                       }),
                     ]),
                   },
@@ -1551,7 +1589,7 @@ describe('in mode', () => {
                 authenticatedUser = await ownerOfHiddenGroupUser.toJson()
               })
 
-              it('finds all members', async () => {
+              it('finds non-pending members', async () => {
                 const result = await query({
                   query: groupMembersQuery,
                   variables,
@@ -1559,14 +1597,6 @@ describe('in mode', () => {
                 expect(result).toMatchObject({
                   data: {
                     GroupMembers: expect.arrayContaining([
-                      expect.objectContaining({
-                        user: expect.objectContaining({
-                          id: 'pending-user',
-                        }),
-                        membership: expect.objectContaining({
-                          role: 'pending',
-                        }),
-                      }),
                       expect.objectContaining({
                         user: expect.objectContaining({
                           id: 'current-user',
@@ -1590,6 +1620,37 @@ describe('in mode', () => {
                         membership: expect.objectContaining({
                           role: 'owner',
                         }),
+                      }),
+                    ]),
+                  },
+                  errors: undefined,
+                })
+                expect(result.data?.GroupMembers.length).toBe(3)
+              })
+
+              it('finds all members including pending when includePending is true', async () => {
+                const result = await query({
+                  query: groupMembersQuery,
+                  variables: { ...variables, includePending: true },
+                })
+                expect(result).toMatchObject({
+                  data: {
+                    GroupMembers: expect.arrayContaining([
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'pending-user' }),
+                        membership: expect.objectContaining({ role: 'pending' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'current-user' }),
+                        membership: expect.objectContaining({ role: 'usual' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-closed-group' }),
+                        membership: expect.objectContaining({ role: 'admin' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-hidden-group' }),
+                        membership: expect.objectContaining({ role: 'owner' }),
                       }),
                     ]),
                   },
@@ -1604,7 +1665,7 @@ describe('in mode', () => {
                 authenticatedUser = await user.toJson()
               })
 
-              it('finds all members', async () => {
+              it('finds non-pending members', async () => {
                 const result = await query({
                   query: groupMembersQuery,
                   variables,
@@ -1612,14 +1673,6 @@ describe('in mode', () => {
                 expect(result).toMatchObject({
                   data: {
                     GroupMembers: expect.arrayContaining([
-                      expect.objectContaining({
-                        user: expect.objectContaining({
-                          id: 'pending-user',
-                        }),
-                        membership: expect.objectContaining({
-                          role: 'pending',
-                        }),
-                      }),
                       expect.objectContaining({
                         user: expect.objectContaining({
                           id: 'current-user',
@@ -1648,6 +1701,37 @@ describe('in mode', () => {
                   },
                   errors: undefined,
                 })
+                expect(result.data?.GroupMembers.length).toBe(3)
+              })
+
+              it('finds all members including pending when includePending is true', async () => {
+                const result = await query({
+                  query: groupMembersQuery,
+                  variables: { ...variables, includePending: true },
+                })
+                expect(result).toMatchObject({
+                  data: {
+                    GroupMembers: expect.arrayContaining([
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'pending-user' }),
+                        membership: expect.objectContaining({ role: 'pending' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'current-user' }),
+                        membership: expect.objectContaining({ role: 'usual' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-closed-group' }),
+                        membership: expect.objectContaining({ role: 'admin' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-hidden-group' }),
+                        membership: expect.objectContaining({ role: 'owner' }),
+                      }),
+                    ]),
+                  },
+                  errors: undefined,
+                })
                 expect(result.data?.GroupMembers.length).toBe(4)
               })
             })
@@ -1657,7 +1741,7 @@ describe('in mode', () => {
                 authenticatedUser = await ownerOfClosedGroupUser.toJson()
               })
 
-              it('finds all members', async () => {
+              it('finds non-pending members', async () => {
                 const result = await query({
                   query: groupMembersQuery,
                   variables,
@@ -1665,14 +1749,6 @@ describe('in mode', () => {
                 expect(result).toMatchObject({
                   data: {
                     GroupMembers: expect.arrayContaining([
-                      expect.objectContaining({
-                        user: expect.objectContaining({
-                          id: 'pending-user',
-                        }),
-                        membership: expect.objectContaining({
-                          role: 'pending',
-                        }),
-                      }),
                       expect.objectContaining({
                         user: expect.objectContaining({
                           id: 'current-user',
@@ -1696,6 +1772,37 @@ describe('in mode', () => {
                         membership: expect.objectContaining({
                           role: 'owner',
                         }),
+                      }),
+                    ]),
+                  },
+                  errors: undefined,
+                })
+                expect(result.data?.GroupMembers.length).toBe(3)
+              })
+
+              it('finds all members including pending when includePending is true', async () => {
+                const result = await query({
+                  query: groupMembersQuery,
+                  variables: { ...variables, includePending: true },
+                })
+                expect(result).toMatchObject({
+                  data: {
+                    GroupMembers: expect.arrayContaining([
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'pending-user' }),
+                        membership: expect.objectContaining({ role: 'pending' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'current-user' }),
+                        membership: expect.objectContaining({ role: 'usual' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-closed-group' }),
+                        membership: expect.objectContaining({ role: 'admin' }),
+                      }),
+                      expect.objectContaining({
+                        user: expect.objectContaining({ id: 'owner-of-hidden-group' }),
+                        membership: expect.objectContaining({ role: 'owner' }),
                       }),
                     ]),
                   },

--- a/backend/src/graphql/resolvers/groups.ts
+++ b/backend/src/graphql/resolvers/groups.ts
@@ -83,12 +83,14 @@ export default {
       }
     },
     GroupMembers: async (_object, params, context: Context, _resolveInfo) => {
-      const { id: groupId, first = 25, offset = 0 } = params
+      const { id: groupId, first = 25, offset = 0, includePending = false } = params
       const session = context.driver.session()
       try {
         return await session.readTransaction(async (txc) => {
+          const pendingFilter = includePending ? '' : "WHERE membership.role <> 'pending'"
           const groupMemberCypher = `
             MATCH (user:User)-[membership:MEMBER_OF]->(:Group {id: $groupId})
+            ${pendingFilter}
             RETURN user {.*}, membership {.*}
             SKIP toInteger($offset) LIMIT toInteger($first)
           `

--- a/backend/src/graphql/resolvers/groups.ts
+++ b/backend/src/graphql/resolvers/groups.ts
@@ -553,10 +553,25 @@ export default {
         isMutedByMe:
           'MATCH (this) RETURN EXISTS( (this)<-[:MUTED]-(:User {id: $cypherParams.currentUserId}) )',
       },
-      count: {
-        membersCount: '<-[:MEMBER_OF]-(related:User)',
-      },
     }),
+    membersCount: async (parent, _args, context: Context, _resolveInfo) => {
+      if (typeof parent.membersCount !== 'undefined') return parent.membersCount
+      const session = context.driver.session()
+      try {
+        return await session.readTransaction(async (txc) => {
+          const cypher = `
+            MATCH (:Group {id: $id})<-[membership:MEMBER_OF]-(:User)
+            WHERE membership.role <> 'pending'
+            RETURN COUNT(membership) as count
+          `
+          const result = await txc.run(cypher, { id: parent.id })
+          const [response] = result.records.map((r) => r.get('count').toNumber())
+          return response
+        })
+      } finally {
+        await session.close()
+      }
+    },
     name: async (parent, _args, context: Context, _resolveInfo) => {
       if (!context.user) {
         return parent.groupType === 'hidden' ? '' : parent.name

--- a/backend/src/graphql/resolvers/inviteCodes.spec.ts
+++ b/backend/src/graphql/resolvers/inviteCodes.spec.ts
@@ -1050,7 +1050,7 @@ describe('redeemInviteCode', () => {
       })
       authenticatedUser = await invitingUser.toJson()
       await expect(
-        query({ query: GroupMembers, variables: { id: 'hidden-group' } }),
+        query({ query: GroupMembers, variables: { id: 'hidden-group', includePending: true } }),
       ).resolves.toMatchObject({
         data: {
           GroupMembers: expect.arrayContaining([

--- a/backend/src/graphql/types/type/Group.gql
+++ b/backend/src/graphql/types/type/Group.gql
@@ -88,7 +88,7 @@ type Query {
   # orderBy: [_GroupOrdering] # not implemented yet
   # filter: _GroupFilter # not implemented yet
 
-  GroupMembers(id: ID!, first: Int, offset: Int): [GroupMember]
+  GroupMembers(id: ID!, first: Int, offset: Int, includePending: Boolean): [GroupMember]
   # orderBy: [_UserOrdering] # not implemented yet
   # filter: _UserFilter # not implemented yet
 

--- a/backend/src/graphql/types/type/Group.gql
+++ b/backend/src/graphql/types/type/Group.gql
@@ -39,7 +39,9 @@ type Group {
   categories: [Category] @relation(name: "CATEGORIZED", direction: "OUT")
 
   membersCount: Int!
-    @cypher(statement: "MATCH (this)<-[:MEMBER_OF]-(r:User) RETURN COUNT(DISTINCT r)")
+    @cypher(
+      statement: "MATCH (this)<-[membership:MEMBER_OF]-(:User) WHERE membership.role <> 'pending' RETURN COUNT(membership)"
+    )
 
   myRole: GroupMemberRole # if 'null' then the current user is no member
   posts: [Post] @relation(name: "IN", direction: "IN")

--- a/webapp/graphql/groups.js
+++ b/webapp/graphql/groups.js
@@ -246,8 +246,8 @@ export const groupMembersQuery = () => {
   return gql`
     ${imageUrls}
 
-    query ($id: ID!, $first: Int, $offset: Int) {
-      GroupMembers(id: $id, first: $first, offset: $offset) {
+    query ($id: ID!, $first: Int, $offset: Int, $includePending: Boolean) {
+      GroupMembers(id: $id, first: $first, offset: $offset, includePending: $includePending) {
         user {
           id
           name

--- a/webapp/pages/groups/edit/_id/members.spec.js
+++ b/webapp/pages/groups/edit/_id/members.spec.js
@@ -93,7 +93,7 @@ describe('pages/groups/edit/_id/members.vue', () => {
 
     it('passes the group id with a large page size', () => {
       const variables = apollo.variables.call({ group: { id: 'g1' } })
-      expect(variables).toEqual({ id: 'g1', first: 999999 })
+      expect(variables).toEqual({ id: 'g1', first: 999999, includePending: true })
     })
 
     it('clears the list and toasts on error', () => {

--- a/webapp/pages/groups/edit/_id/members.spec.js
+++ b/webapp/pages/groups/edit/_id/members.spec.js
@@ -91,7 +91,7 @@ describe('pages/groups/edit/_id/members.vue', () => {
       expect(apollo.query.call({})).toBeDefined()
     })
 
-    it('passes the group id with a large page size', () => {
+    it('passes the group id with a large page size and includes pending', () => {
       const variables = apollo.variables.call({ group: { id: 'g1' } })
       expect(variables).toEqual({ id: 'g1', first: 999999, includePending: true })
     })

--- a/webapp/pages/groups/edit/_id/members.vue
+++ b/webapp/pages/groups/edit/_id/members.vue
@@ -48,6 +48,7 @@ export default {
         return {
           id: this.group.id,
           first: 999999,
+          includePending: true,
         }
       },
       error(error) {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Fix so that pending members aren't shown on group profile but still on member administration.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->

- [x] fix so that pending members aren't shown on group profile but still on member administration
- [x] fix so that pending members aren't counted as group members on GraphQL property 'membersCount'
- [x] tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Option, ausstehende („pending“) Mitgliedschaften bei Gruppenabfragen einzuschließen (includePending).

* **Änderung**
  * Standard‑Mitgliederlisten schließen ausstehende Mitglieder aus.
  * membersCount zählt standardmäßig nur bestätigte Mitglieder.
  * Bearbeitungsansicht lädt jetzt explizit auch ausstehende Mitglieder.
  * Group‑Abfragen liefern nun das Feld membersCount mit.

* **Tests**
  * Tests erweitert, um Verhalten mit und ohne Einbeziehung ausstehender Mitglieder abzudecken.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->