### PR TITLE
fix(backend): return unauthorised instead of internal_server_error for shield fallback

### DIFF
--- a/backend/src/middleware/permissionsMiddleware.ts
+++ b/backend/src/middleware/permissionsMiddleware.ts
@@ -10,6 +10,7 @@ import { rule, shield, deny, allow, or, and } from 'graphql-shield'
 
 import CONFIG from '@config/index'
 import { getNeode } from '@db/neo4j'
+import { AuthenticationError } from '@graphql/errors'
 import { validateInviteCode } from '@graphql/resolvers/inviteCodes'
 
 import type SocialMedia from '@db/models/SocialMedia'
@@ -606,6 +607,6 @@ export default shield(
     debug,
     allowExternalErrors,
     fallbackRule: allow,
-    fallbackError: Error('Not Authorized!'),
+    fallbackError: new AuthenticationError('Not Authorized!'),
   },
 )

--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -78,12 +78,16 @@ export const actions = {
 
   async fetchCurrentUser({ commit, dispatch }) {
     const client = this.app.apolloProvider.defaultClient
-    const {
-      data: { currentUser },
-    } = await client.query({ query: currentUserQuery })
-    if (!currentUser) return dispatch('logout')
-    commit('SET_USER', currentUser)
-    return currentUser
+    try {
+      const {
+        data: { currentUser },
+      } = await client.query({ query: currentUserQuery })
+      if (!currentUser) return dispatch('logout')
+      commit('SET_USER', currentUser)
+      return currentUser
+    } catch {
+      return dispatch('logout')
+    }
   },
 
   async login({ commit, dispatch }, { email, password }) {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Fix: return UNAUTHENTICATED instead of INTERNAL_SERVER_ERROR for shield fallback.

graphql-shield's fallbackError used a plain Error() which causes GraphQL to report INTERNAL_SERVER_ERROR when a rule fails (e.g. currentUser called with an expired token). Replace with AuthenticationError for the correct code.

Also add try/catch in fetchCurrentUser so an expired token no longer propagates an unhandled error through the SSR init flow; instead it gracefully calls logout.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->

- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Verbesserte Fehlerbehandlung bei Autorisierungsfehlern mit spezialisierten Fehlermeldungen
  * Robustere Benutzer-Session-Verwaltung: Benutzer werden bei Authentifizierungsfehlern konsistent abgemeldet, um die Sicherheit zu gewährleisten

<!-- end of auto-generated comment: release notes by coderabbit.ai -->