### PR TITLE
fix(webapp): fix video avatar + display & navigation

### DIFF
--- a/webapp/components/ResponsiveImage/ResponsiveImage.spec.js
+++ b/webapp/components/ResponsiveImage/ResponsiveImage.spec.js
@@ -1,0 +1,72 @@
+import { mount } from '@vue/test-utils'
+import ResponsiveImage from './ResponsiveImage.vue'
+
+const localVue = global.localVue
+
+const image = {
+  url: 'https://example.org/pic.jpg',
+  w320: 'https://example.org/pic-w320.jpg',
+  w640: 'https://example.org/pic-w640.jpg',
+  w1024: 'https://example.org/pic-w1024.jpg',
+}
+
+const Wrapper = (propsData = {}) =>
+  mount(ResponsiveImage, { propsData: { image, sizes: '320px', ...propsData }, localVue })
+
+describe('ResponsiveImage', () => {
+  it('offers every variant to the browser', () => {
+    expect(Wrapper().attributes('srcset')).toBe(
+      'https://example.org/pic-w320.jpg 320w, https://example.org/pic-w640.jpg 640w, https://example.org/pic-w1024.jpg 1024w',
+    )
+  })
+
+  it('defers loading by default', () => {
+    expect(Wrapper().attributes('loading')).toBe('lazy')
+  })
+
+  it('loads eagerly on request', () => {
+    // For images that start inside a `display: none` subtree, where a deferred
+    // one is never fetched at all.
+    expect(Wrapper({ loading: 'eager' }).attributes('loading')).toBe('eager')
+  })
+
+  it('rejects a loading value the browser would not understand', () => {
+    const { validator } = ResponsiveImage.props.loading
+    expect(validator('eager')).toBe(true)
+    expect(validator('whenever')).toBe(false)
+  })
+
+  describe('load', () => {
+    it('fades in and announces itself', async () => {
+      const wrapper = Wrapper()
+      expect(wrapper.classes()).not.toContain('responsive-image--loaded')
+      await wrapper.trigger('load')
+      expect(wrapper.classes()).toContain('responsive-image--loaded')
+      expect(wrapper.emitted('loaded')).toHaveLength(1)
+    })
+
+    it('catches an image that was already complete before mount', () => {
+      // Cached images can finish before Vue attaches the listener; without the
+      // mounted() check they would stay stuck at opacity 0.
+      const wrapper = mount(ResponsiveImage, {
+        propsData: { image, sizes: '320px' },
+        localVue,
+        attachTo: document.body,
+      })
+      Object.defineProperty(wrapper.element, 'complete', { value: true })
+      Object.defineProperty(wrapper.element, 'naturalWidth', { value: 320 })
+      wrapper.vm.$options.mounted[0].call(wrapper.vm)
+      expect(wrapper.vm.loaded).toBe(true)
+      wrapper.destroy()
+    })
+  })
+
+  it('re-emits a failed load', async () => {
+    // Native error events don't bubble, so parents can only learn about a
+    // broken image through this re-emit.
+    const wrapper = Wrapper()
+    await wrapper.trigger('error')
+    expect(wrapper.emitted('error')).toHaveLength(1)
+    expect(wrapper.classes()).not.toContain('responsive-image--loaded')
+  })
+})

--- a/webapp/components/ResponsiveImage/ResponsiveImage.vue
+++ b/webapp/components/ResponsiveImage/ResponsiveImage.vue
@@ -5,16 +5,17 @@
     :srcset="srcset"
     :class="{ 'responsive-image--loaded': loaded }"
     class="responsive-image"
-    loading="lazy"
+    :loading="loading"
     fetchpriority="low"
     @load="onLoad"
+    @error="onError"
   />
 </template>
 
 <script>
 export default {
   name: 'ResponsiveImage',
-  emits: ['loaded'],
+  emits: ['loaded', 'error'],
   props: {
     image: {
       type: Object,
@@ -23,6 +24,15 @@ export default {
     sizes: {
       type: String,
       required: true,
+    },
+    loading: {
+      // Native <img> lazy loading. Deferring is right for images far down a
+      // feed, but wrong wherever the image starts inside a `display: none`
+      // subtree (it never gets fetched, and the opacity transition below then
+      // leaves an invisible box behind) — those callers pass 'eager'.
+      type: String,
+      default: 'lazy',
+      validator: (value) => /^(lazy|eager)$/.test(value),
     },
   },
   data() {
@@ -43,6 +53,11 @@ export default {
     onLoad() {
       this.loaded = true
       this.$emit('loaded')
+    },
+    onError() {
+      // Native error events don't bubble, so a parent listening with @error
+      // would never hear about a broken image without this re-emit.
+      this.$emit('error')
     },
   },
 }

--- a/webapp/components/VideoCall/VideoCall.spec.js
+++ b/webapp/components/VideoCall/VideoCall.spec.js
@@ -785,6 +785,34 @@ describe('VideoCall', () => {
       await wrapper.vm.connect()
       expect(wrapper.vm.phase).toBe('error')
     })
+
+    it('stringifies a rejection that carries no message', async () => {
+      const { wrapper } = factory({ show: false, groupId: 'g1' })
+      wrapper.vm.$apollo = { mutate: jest.fn().mockRejectedValue('websocket closed') }
+      await wrapper.vm.connect()
+      expect(wrapper.vm.error).toBe('websocket closed')
+      expect(wrapper.vm.phase).toBe('error')
+    })
+
+    it('toasts and closes instead of erroring full screen when parked mid-handshake', async () => {
+      // The user navigated away while the handshake was still running, so the
+      // window is minimized. The error phase would blow it back up to full
+      // screen over the page they moved to.
+      const { wrapper, close } = factory({ show: true, minimized: true, groupId: null })
+      const $toast = { error: jest.fn() }
+      wrapper.vm.$toast = $toast
+      await wrapper.vm.connect()
+      expect($toast.error).toHaveBeenCalledWith('Missing group id')
+      expect(wrapper.vm.phase).toBe('idle')
+      expect(close).toHaveBeenCalled()
+    })
+
+    it('still closes when parked mid-handshake without a $toast plugin', async () => {
+      const { wrapper, close } = factory({ show: true, minimized: true, groupId: null })
+      await wrapper.vm.connect()
+      expect(wrapper.vm.phase).toBe('idle')
+      expect(close).toHaveBeenCalled()
+    })
   })
 
   describe('refreshTiles (full tile build)', () => {
@@ -978,6 +1006,28 @@ describe('VideoCall', () => {
       const { wrapper, setMinimized } = factory({ show: false })
       wrapper.vm.$options.watch.$route.call(wrapper.vm, { name: 'call-id-slug' })
       expect(setMinimized).not.toHaveBeenCalled()
+    })
+
+    it('$route watcher closes a failed call when navigating away', async () => {
+      const { wrapper, close, setMinimized } = factory({ show: true, groupId: 'g1' })
+      wrapper.setData({ phase: 'error', error: 'invalid api key' })
+      const replace = jest.fn()
+      wrapper.vm.$router.replace = replace
+      await wrapper.vm.$options.watch.$route.call(wrapper.vm, { name: 'groups-id-slug' })
+      expect(close).toHaveBeenCalled()
+      expect(wrapper.vm.phase).toBe('idle')
+      // Parking the error card would leave litter in the corner…
+      expect(setMinimized).not.toHaveBeenCalled()
+      // …and redirecting would hijack the navigation already in flight.
+      expect(replace).not.toHaveBeenCalled()
+    })
+
+    it('$route watcher keeps a failed call on the call route', async () => {
+      const { wrapper, close } = factory({ show: true, groupId: 'g1' })
+      wrapper.setData({ phase: 'error', error: 'invalid api key' })
+      await wrapper.vm.$options.watch.$route.call(wrapper.vm, { name: 'call-id-slug' })
+      expect(close).not.toHaveBeenCalled()
+      expect(wrapper.vm.phase).toBe('error')
     })
   })
 

--- a/webapp/components/VideoCall/VideoCall.spec.js
+++ b/webapp/components/VideoCall/VideoCall.spec.js
@@ -1,4 +1,5 @@
 import Vuex from 'vuex'
+import VTooltip from 'v-tooltip'
 import { mount, createLocalVue } from '@vue/test-utils'
 import VideoCall from './VideoCall.vue'
 
@@ -10,6 +11,7 @@ jest.mock('livekit-client', () => {
     ParticipantDisconnected: 'ParticipantDisconnected',
     TrackSubscribed: 'TrackSubscribed',
     TrackUnsubscribed: 'TrackUnsubscribed',
+    TrackUnpublished: 'TrackUnpublished',
     TrackMuted: 'TrackMuted',
     TrackUnmuted: 'TrackUnmuted',
     ParticipantMetadataChanged: 'ParticipantMetadataChanged',
@@ -51,6 +53,7 @@ jest.mock('livekit-client', () => {
 
 const localVue = createLocalVue()
 localVue.use(Vuex)
+localVue.use(VTooltip)
 
 const Stub = (name, opts = {}) => ({
   name,
@@ -304,19 +307,247 @@ describe('VideoCall', () => {
   })
 
   describe('tileAvatarSize', () => {
+    // A cell with room to spare for the 114px avatar plus its caption.
+    const roomy = { width: 640, height: 360 }
+
     it('returns small for non-spotlight tiles when a spotlight exists', () => {
-      const ctx = { spotlightTile: { key: 'a' } }
+      const ctx = { spotlightTile: { key: 'a' }, cellSize: roomy }
       expect(VideoCall.methods.tileAvatarSize.call(ctx, { key: 'b' })).toBe('small')
     })
 
     it('returns large for the spotlight tile itself', () => {
-      const ctx = { spotlightTile: { key: 'a' } }
+      const ctx = { spotlightTile: { key: 'a' }, cellSize: roomy }
       expect(VideoCall.methods.tileAvatarSize.call(ctx, { key: 'a' })).toBe('large')
     })
 
     it('returns large when no spotlight tile exists', () => {
-      const ctx = { spotlightTile: null }
+      const ctx = { spotlightTile: null, cellSize: roomy }
       expect(VideoCall.methods.tileAvatarSize.call(ctx, { key: 'b' })).toBe('large')
+    })
+
+    it('returns small in a cell too short for the large avatar', () => {
+      const ctx = { spotlightTile: null, cellSize: { width: 640, height: 150 } }
+      expect(VideoCall.methods.tileAvatarSize.call(ctx, { key: 'b' })).toBe('small')
+    })
+
+    it('returns small in a cell too narrow for the large avatar', () => {
+      const ctx = { spotlightTile: null, cellSize: { width: 120, height: 360 } }
+      expect(VideoCall.methods.tileAvatarSize.call(ctx, { key: 'b' })).toBe('small')
+    })
+
+    it('returns large while the stage is still unmeasured', () => {
+      // No ResizeObserver / pre-paint: zero sizes must not be read as "tiny".
+      const ctx = { spotlightTile: null, cellSize: { width: 0, height: 0 } }
+      expect(VideoCall.methods.tileAvatarSize.call(ctx, { key: 'b' })).toBe('large')
+    })
+  })
+
+  describe('gridDimensions', () => {
+    const dimensions = (tileCount, stageWidth, stageHeight) =>
+      VideoCall.computed.gridDimensions.call({
+        tiles: Array.from({ length: tileCount }, (_, i) => ({ key: `t${i}` })),
+        stageWidth,
+        stageHeight,
+      })
+
+    it('falls back to a square-ish grid while the stage is unmeasured', () => {
+      expect(dimensions(4, 0, 0)).toEqual({ columns: 2, rows: 2 })
+      expect(dimensions(3, 0, 0)).toEqual({ columns: 2, rows: 2 })
+    })
+
+    it('puts two participants side by side on a wide stage', () => {
+      expect(dimensions(2, 1600, 900)).toEqual({ columns: 2, rows: 1 })
+    })
+
+    it('stacks two participants on a tall, narrow stage', () => {
+      // Phone in portrait: side by side would leave two slivers, and cover
+      // would crop each face down to a vertical strip.
+      expect(dimensions(2, 400, 700)).toEqual({ columns: 1, rows: 2 })
+    })
+
+    it('arranges four participants two by two on a wide stage', () => {
+      expect(dimensions(4, 1600, 900)).toEqual({ columns: 2, rows: 2 })
+    })
+
+    it('gives three participants a 2x2 grid rather than one long row', () => {
+      expect(dimensions(3, 1600, 900)).toEqual({ columns: 2, rows: 2 })
+    })
+
+    it('treats an empty tile list as a single cell', () => {
+      expect(dimensions(0, 1600, 900)).toEqual({ columns: 1, rows: 1 })
+    })
+  })
+
+  describe('cellSize / gridStyle', () => {
+    it('reports nothing while the stage is unmeasured', () => {
+      const ctx = { stageWidth: 0, stageHeight: 0 }
+      expect(VideoCall.computed.cellSize.call(ctx)).toEqual({ width: 0, height: 0 })
+    })
+
+    it('gives the whole stage to the single tile of the parked window', () => {
+      const ctx = { stageWidth: 355, stageHeight: 200, isFullscreen: false, spotlightTile: null }
+      expect(VideoCall.computed.cellSize.call(ctx)).toEqual({ width: 355, height: 200 })
+    })
+
+    it('gives the whole stage to a spotlighted tile', () => {
+      const ctx = {
+        stageWidth: 1600,
+        stageHeight: 900,
+        isFullscreen: true,
+        spotlightTile: { key: 'a' },
+      }
+      expect(VideoCall.computed.cellSize.call(ctx)).toEqual({ width: 1600, height: 900 })
+    })
+
+    it('divides the stage by the grid in the regular view', () => {
+      const ctx = {
+        stageWidth: 1600,
+        stageHeight: 900,
+        isFullscreen: true,
+        spotlightTile: null,
+        gridDimensions: { columns: 2, rows: 2 },
+      }
+      expect(VideoCall.computed.cellSize.call(ctx)).toEqual({ width: 800, height: 450 })
+    })
+
+    it('spells out rows as well as columns', () => {
+      const style = VideoCall.computed.gridStyle.call({
+        gridDimensions: { columns: 3, rows: 2 },
+      })
+      expect(style).toEqual({
+        'grid-template-columns': 'repeat(3, 1fr)',
+        // Without explicit rows the implicit ones size to content and the
+        // tiles never share the stage height evenly.
+        'grid-template-rows': 'repeat(2, 1fr)',
+      })
+    })
+  })
+
+  describe('stage measurement', () => {
+    const withResizeObserver = () => {
+      const observe = jest.fn()
+      const disconnect = jest.fn()
+      let trigger = null
+      global.ResizeObserver = class {
+        constructor(cb) {
+          trigger = cb
+          this.observe = observe
+          this.disconnect = disconnect
+        }
+      }
+      return { observe, disconnect, fire: () => trigger && trigger() }
+    }
+
+    afterEach(() => {
+      delete global.ResizeObserver
+    })
+
+    it('measures the stage and re-measures on resize', () => {
+      const { observe, fire } = withResizeObserver()
+      const { wrapper } = factory({ show: true })
+      const el = { clientWidth: 1600, clientHeight: 900 }
+      wrapper.vm.$refs.stageEl = el
+      wrapper.vm.observeStage()
+      expect(observe).toHaveBeenCalledWith(el)
+      expect(wrapper.vm.stageWidth).toBe(1600)
+
+      // The chat sidebar opening narrows the stage without a window resize.
+      el.clientWidth = 1200
+      fire()
+      expect(wrapper.vm.stageWidth).toBe(1200)
+    })
+
+    it('re-observes only when the element actually changed', () => {
+      const { observe } = withResizeObserver()
+      const { wrapper } = factory({ show: true })
+      wrapper.vm.$refs.stageEl = { clientWidth: 800, clientHeight: 600 }
+      wrapper.vm.observeStage()
+      wrapper.vm.observeStage()
+      // Guards against the observer's own updates re-entering through updated().
+      expect(observe).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears the measurements when the stage goes away', () => {
+      const { disconnect } = withResizeObserver()
+      const { wrapper } = factory({ show: true })
+      wrapper.vm.$refs.stageEl = { clientWidth: 800, clientHeight: 600 }
+      wrapper.vm.observeStage()
+      wrapper.vm.$refs.stageEl = null
+      wrapper.vm.observeStage()
+      expect(disconnect).toHaveBeenCalled()
+      expect(wrapper.vm.stageWidth).toBe(0)
+      expect(wrapper.vm.stageHeight).toBe(0)
+    })
+
+    it('still measures once without ResizeObserver support', () => {
+      const { wrapper } = factory({ show: true })
+      wrapper.vm.$refs.stageEl = { clientWidth: 640, clientHeight: 480 }
+      wrapper.vm.observeStage()
+      expect(wrapper.vm.stageWidth).toBe(640)
+      expect(wrapper.vm.stageHeight).toBe(480)
+    })
+
+    it('measureStage is a no-op without an observed element', () => {
+      const { wrapper } = factory({ show: true })
+      wrapper.vm.measureStage()
+      expect(wrapper.vm.stageWidth).toBe(0)
+    })
+
+    it('treats missing client dimensions as zero', () => {
+      const { wrapper } = factory({ show: true })
+      wrapper.vm.$refs.stageEl = {}
+      wrapper.vm.observeStage()
+      expect(wrapper.vm.stageWidth).toBe(0)
+    })
+  })
+
+  describe('button labels and tooltips', () => {
+    it('names each control after its current effect', () => {
+      const { wrapper } = factory({ show: true, groupId: 'g1' })
+      wrapper.setData({ micEnabled: true, cameraEnabled: true, screenShareEnabled: false })
+      expect(wrapper.vm.micLabel).toBe('videoCall.muteMic')
+      expect(wrapper.vm.cameraLabel).toBe('videoCall.disableCamera')
+      expect(wrapper.vm.screenShareLabel).toBe('videoCall.startScreenShare')
+      expect(wrapper.vm.chatLabel).toBe('videoCall.openChat')
+      expect(wrapper.vm.leaveLabel).toBe('videoCall.leave')
+
+      wrapper.setData({ micEnabled: false, cameraEnabled: false, screenShareEnabled: true })
+      expect(wrapper.vm.micLabel).toBe('videoCall.unmuteMic')
+      expect(wrapper.vm.cameraLabel).toBe('videoCall.enableCamera')
+      expect(wrapper.vm.screenShareLabel).toBe('videoCall.stopScreenShare')
+    })
+
+    it('labels the header buttons by call state', () => {
+      const parked = factory({ show: true, minimized: true })
+      expect(parked.wrapper.vm.minimizeLabel).toBe('videoCall.maximize')
+      const open = factory({ show: true, minimized: false })
+      expect(open.wrapper.vm.minimizeLabel).toBe('videoCall.minimize')
+
+      open.wrapper.setData({ phase: 'in-call' })
+      expect(open.wrapper.vm.closeLabel).toBe('videoCall.leave')
+      open.wrapper.setData({ phase: 'prejoin' })
+      expect(open.wrapper.vm.closeLabel).toBe('videoCall.prejoin.cancel')
+    })
+
+    it('shows the chat button as closing while that chat is open', () => {
+      const { wrapper } = factory({
+        show: true,
+        groupId: 'g1',
+        chat: { showChat: true, chatUserId: null, groupId: 'g1' },
+      })
+      expect(wrapper.vm.chatLabel).toBe('videoCall.closeChat')
+    })
+
+    it('tooltips only the buttons that lost their caption', () => {
+      const { wrapper } = factory({ show: true, minimized: true })
+      wrapper.setData({ phase: 'in-call' })
+      expect(wrapper.vm.iconOnly).toBe(true)
+      expect(wrapper.vm.iconOnlyTooltip('Mute')).toBe('Mute')
+
+      const open = factory({ show: true, minimized: false })
+      open.wrapper.setData({ phase: 'in-call' })
+      // Caption is right there next to the icon — a tooltip would just repeat it.
+      expect(open.wrapper.vm.iconOnlyTooltip('Mute')).toBe('')
     })
   })
 
@@ -734,7 +965,19 @@ describe('VideoCall', () => {
       expect(wrapper.vm.screenShareEnabled).toBe(false)
     })
 
-    it('throttles active-speaker updates', () => {
+    it('rebuilds the tiles when a remote participant withdraws a track', async () => {
+      const { wrapper } = factory({ show: false, groupId: 'g1', groupSlug: 'yoga' })
+      withApollo(wrapper)
+      await wrapper.vm.connect()
+      const room = wrapper.vm.room
+      const refreshTiles = jest.spyOn(wrapper.vm, 'refreshTiles')
+      // Ending a screen share is the visible case: without this the tile can
+      // outlive its track and keep showing the last decoded frame.
+      room.handlers.TrackUnpublished()
+      expect(refreshTiles).toHaveBeenCalled()
+    })
+
+    it('holds the speaking highlight across the pauses between words', () => {
       jest.useFakeTimers()
       const { wrapper } = factory({ show: false, groupId: 'g1', groupSlug: 'yoga' })
       withApollo(wrapper)
@@ -744,12 +987,19 @@ describe('VideoCall', () => {
           .then(() => {
             const room = wrapper.vm.room
             room.handlers.ActiveSpeakersChanged([{ identity: 'a' }, { identity: 'b' }])
-            jest.advanceTimersByTime(200)
+            // Picking someone up is immediate — only letting go is delayed.
             expect(wrapper.vm.activeSpeakerIds).toEqual(['a', 'b'])
-            // Identical set within the next window is a no-op.
-            room.handlers.ActiveSpeakersChanged([{ identity: 'a' }, { identity: 'b' }])
-            jest.advanceTimersByTime(200)
+
+            // LiveKit drops 'b' mid-sentence. Reflecting that straight away is
+            // what made the chip row strobe, so the hold keeps them listed.
+            room.handlers.ActiveSpeakersChanged([{ identity: 'a' }])
+            jest.advanceTimersByTime(1000)
+            room.handlers.ActiveSpeakersChanged([{ identity: 'a' }])
             expect(wrapper.vm.activeSpeakerIds).toEqual(['a', 'b'])
+
+            // Only real silence past the hold window drops them.
+            jest.advanceTimersByTime(600)
+            expect(wrapper.vm.activeSpeakerIds).toEqual(['a'])
           })
           // Restore real timers even if an assertion above throws, so leaked fake
           // timers can't make later tests flaky.
@@ -757,6 +1007,26 @@ describe('VideoCall', () => {
             jest.useRealTimers()
           })
       )
+    })
+
+    it('leaves the speaker array untouched when nothing changed', () => {
+      jest.useFakeTimers()
+      const { wrapper } = factory({ show: false, groupId: 'g1', groupSlug: 'yoga' })
+      withApollo(wrapper)
+      return wrapper.vm
+        .connect()
+        .then(() => {
+          const room = wrapper.vm.room
+          room.handlers.ActiveSpeakersChanged([{ identity: 'a' }])
+          const first = wrapper.vm.activeSpeakerIds
+          room.handlers.ActiveSpeakersChanged([{ identity: 'a' }])
+          // Same identity, same order — reassigning would re-render every
+          // tile several times a second for nothing.
+          expect(wrapper.vm.activeSpeakerIds).toBe(first)
+        })
+        .finally(() => {
+          jest.useRealTimers()
+        })
     })
 
     it('routes a server-side disconnect through leave(), ignoring our own disconnect', async () => {
@@ -878,12 +1148,14 @@ describe('VideoCall', () => {
         videoTrackPublications: new Map([['v', { track: null }]]),
       }
       wrapper.vm.room = { localParticipant: lp, disconnect: jest.fn().mockResolvedValue() }
-      wrapper.vm._activeSpeakersTimer = 123
+      wrapper.vm.speakerHoldTimer = 123
+      wrapper.vm.speakerSeenAt.set('u1', 1)
       const clearSpy = jest.spyOn(global, 'clearTimeout')
       await wrapper.vm.cleanup()
       expect(stop).toHaveBeenCalled()
       expect(mediaStop).toHaveBeenCalled()
       expect(clearSpy).toHaveBeenCalledWith(123)
+      expect(wrapper.vm.speakerSeenAt.size).toBe(0)
       expect(wrapper.vm.room).toBeNull()
       clearSpy.mockRestore()
     })

--- a/webapp/components/VideoCall/VideoCall.vue
+++ b/webapp/components/VideoCall/VideoCall.vue
@@ -30,11 +30,12 @@
           <div class="video-call__header-actions">
             <os-button
               v-if="canMinimize && phase === 'in-call'"
+              v-tooltip="minimizeLabel"
               variant="primary"
               appearance="outline"
               size="sm"
               circle
-              :aria-label="minimized ? $t('videoCall.maximize') : $t('videoCall.minimize')"
+              :aria-label="minimizeLabel"
               @click="toggleMinimize"
             >
               <template #icon>
@@ -42,13 +43,12 @@
               </template>
             </os-button>
             <os-button
-              variant="primary"
+              v-tooltip="closeLabel"
+              variant="danger"
               appearance="outline"
               size="sm"
               circle
-              :aria-label="
-                phase === 'in-call' ? $t('videoCall.leave') : $t('videoCall.prejoin.cancel')
-              "
+              :aria-label="closeLabel"
               @click="leave"
             >
               <template #icon>
@@ -99,7 +99,11 @@
               </span>
             </span>
           </div>
-          <div :class="['video-call__stage', stageLayoutClass]" :style="gridStyleConditional">
+          <div
+            ref="stageEl"
+            :class="['video-call__stage', stageLayoutClass]"
+            :style="gridStyleConditional"
+          >
             <!--
             All tiles are always mounted so every participant's audio track stays
             attached to a DOM <audio> element. CSS Grid (in spotlight mode)
@@ -135,89 +139,95 @@
         </template>
       </div>
 
+      <!--
+        Every control collapses to an icon-only button in the parked window, so
+        each one carries a tooltip fed from the same label as its aria-label —
+        one source, no drift between what a screen reader announces and what a
+        sighted user reads. The tooltip is suppressed while the label is
+        already spelled out next to the icon.
+      -->
       <div v-if="phase === 'in-call' && !error" class="video-call__controls">
         <os-button
+          v-tooltip="iconOnlyTooltip(micLabel)"
           :variant="micEnabled ? 'default' : 'danger'"
           appearance="outline"
           :size="iconOnly ? 'sm' : 'md'"
           :circle="iconOnly"
-          :aria-label="micEnabled ? $t('videoCall.muteMic') : $t('videoCall.unmuteMic')"
+          :aria-label="micLabel"
           @click="toggleMic"
         >
           <template #icon>
             <os-icon :icon="micEnabled ? icons.microphone : icons.microphoneSlash" />
           </template>
           <template v-if="!iconOnly">
-            {{ micEnabled ? $t('videoCall.muteMic') : $t('videoCall.unmuteMic') }}
+            {{ micLabel }}
           </template>
         </os-button>
         <os-button
+          v-tooltip="iconOnlyTooltip(cameraLabel)"
           :variant="cameraEnabled ? 'default' : 'danger'"
           appearance="outline"
           :size="iconOnly ? 'sm' : 'md'"
           :circle="iconOnly"
-          :aria-label="cameraEnabled ? $t('videoCall.disableCamera') : $t('videoCall.enableCamera')"
+          :aria-label="cameraLabel"
           @click="toggleCamera"
         >
           <template #icon>
             <os-icon :icon="icons.videoCamera" />
           </template>
           <template v-if="!iconOnly">
-            {{ cameraEnabled ? $t('videoCall.disableCamera') : $t('videoCall.enableCamera') }}
+            {{ cameraLabel }}
           </template>
         </os-button>
         <os-button
           v-if="screenShareSupported"
+          v-tooltip="iconOnlyTooltip(screenShareLabel)"
           :variant="screenShareEnabled ? 'primary' : 'default'"
           appearance="outline"
           :size="iconOnly ? 'sm' : 'md'"
           :circle="iconOnly"
-          :aria-label="
-            screenShareEnabled ? $t('videoCall.stopScreenShare') : $t('videoCall.startScreenShare')
-          "
+          :aria-label="screenShareLabel"
           @click="toggleScreenShare"
         >
           <template #icon>
             <os-icon :icon="icons.desktop" />
           </template>
           <template v-if="!iconOnly">
-            {{
-              screenShareEnabled
-                ? $t('videoCall.stopScreenShare')
-                : $t('videoCall.startScreenShare')
-            }}
+            {{ screenShareLabel }}
           </template>
         </os-button>
         <os-button
           v-if="!isMobile"
+          v-tooltip="iconOnlyTooltip(chatLabel)"
           :variant="chatOpenForThisGroup ? 'primary' : 'default'"
           appearance="outline"
           :size="iconOnly ? 'sm' : 'md'"
           :circle="iconOnly"
-          :aria-label="chatOpenForThisGroup ? $t('videoCall.closeChat') : $t('videoCall.openChat')"
+          :aria-label="chatLabel"
           @click="toggleChat"
         >
           <template #icon>
             <os-icon :icon="icons.chatBubble" />
           </template>
           <template v-if="!iconOnly">
-            {{ chatOpenForThisGroup ? $t('videoCall.closeChat') : $t('videoCall.openChat') }}
+            {{ chatLabel }}
           </template>
         </os-button>
         <os-button
+          v-tooltip="iconOnlyTooltip(leaveLabel)"
           variant="danger"
           appearance="filled"
           :size="iconOnly ? 'sm' : 'md'"
           :circle="iconOnly"
           class="video-call__leave"
-          :aria-label="$t('videoCall.leave')"
+          :aria-label="leaveLabel"
           @click="leave"
         >
           <template #icon>
             <os-icon :icon="icons.phone" />
           </template>
           <template v-if="!iconOnly">
-            {{ $t('videoCall.leave') }}
+            {{ leaveLabel }}
           </template>
         </os-button>
       </div>
@@ -236,6 +246,21 @@ import ProfileAvatar from '~/components/_new/generic/ProfileAvatar/ProfileAvatar
 import RoomTitleLink from '~/components/_new/generic/RoomTitleLink/RoomTitleLink'
 import VideoTile from './VideoTile.vue'
 import PreJoin from './PreJoin.vue'
+
+// How long a participant keeps the speaking treatment after LiveKit drops them
+// from the active-speaker list. LiveKit reports raw audio activity, so it lets
+// go during the pauses between words — without a hold the chips and frames
+// strobe while someone is simply talking.
+const SPEAKER_HOLD_MS = 1500
+
+// Cameras publish 16:9, so the grid aims for cells of that shape: the closer a
+// cell matches, the less `object-fit: cover` has to crop off the sides.
+const TILE_ASPECT_RATIO = 16 / 9
+
+// Below this the 114px large avatar plus its caption no longer fits the cell
+// and the flex column starts squashing.
+const LARGE_AVATAR_MIN_CELL_HEIGHT = 200
+const LARGE_AVATAR_MIN_CELL_WIDTH = 160
 
 export default {
   name: 'VideoCall',
@@ -264,6 +289,8 @@ export default {
       Track: null,
       activeSpeakerIds: [],
       spotlightKey: null,
+      stageWidth: 0,
+      stageHeight: 0,
     }
   },
   computed: {
@@ -297,6 +324,35 @@ export default {
       return (
         this.phase === 'in-call' && this.chatOpenForThisGroup && !this.iconOnly && !this.isMobile
       )
+    },
+    micLabel() {
+      return this.micEnabled ? this.$t('videoCall.muteMic') : this.$t('videoCall.unmuteMic')
+    },
+    cameraLabel() {
+      return this.cameraEnabled
+        ? this.$t('videoCall.disableCamera')
+        : this.$t('videoCall.enableCamera')
+    },
+    screenShareLabel() {
+      return this.screenShareEnabled
+        ? this.$t('videoCall.stopScreenShare')
+        : this.$t('videoCall.startScreenShare')
+    },
+    chatLabel() {
+      return this.chatOpenForThisGroup
+        ? this.$t('videoCall.closeChat')
+        : this.$t('videoCall.openChat')
+    },
+    leaveLabel() {
+      return this.$t('videoCall.leave')
+    },
+    minimizeLabel() {
+      return this.minimized ? this.$t('videoCall.maximize') : this.$t('videoCall.minimize')
+    },
+    closeLabel() {
+      return this.phase === 'in-call'
+        ? this.$t('videoCall.leave')
+        : this.$t('videoCall.prejoin.cancel')
     },
     titleLabel() {
       const name = this.groupName || this.$t('videoCall.title')
@@ -389,10 +445,54 @@ export default {
       const anyRemote = this.tiles.find((t) => !t.isLocal)
       return anyRemote || this.tiles[0]
     },
+    gridDimensions() {
+      // Pick the column count whose resulting cells waste the least space on a
+      // 16:9 video. The old `ceil(sqrt(n))` ignored the stage's own shape, so
+      // two participants on a wide monitor got two tall, narrow cells — and
+      // `object-fit: cover` then cropped everything but a vertical strip of
+      // each face, which is what reads as "stretched".
+      const count = Math.max(1, this.tiles.length)
+      if (!this.stageWidth || !this.stageHeight) {
+        // Nothing measured yet (SSR, first paint, no ResizeObserver): keep the
+        // square-ish heuristic rather than collapsing to a single column.
+        const columns = Math.ceil(Math.sqrt(count))
+        return { columns, rows: Math.ceil(count / columns) }
+      }
+      let best = { columns: 1, rows: count, area: -1 }
+      for (let columns = 1; columns <= count; columns++) {
+        const rows = Math.ceil(count / columns)
+        const cellWidth = this.stageWidth / columns
+        const cellHeight = this.stageHeight / rows
+        // Largest 16:9 rectangle that fits this cell — maximising it maximises
+        // the visible video area.
+        const fittedWidth = Math.min(cellWidth, cellHeight * TILE_ASPECT_RATIO)
+        const area = (fittedWidth * fittedWidth) / TILE_ASPECT_RATIO
+        // `>=` so a tie goes to the wider arrangement: two people on a 16:9
+        // stage fit equally well side by side or stacked, and side by side is
+        // what every other call app does.
+        if (area >= best.area) best = { columns, rows, area }
+      }
+      return { columns: best.columns, rows: best.rows }
+    },
+    cellSize() {
+      if (!this.stageWidth || !this.stageHeight) return { width: 0, height: 0 }
+      // Outside the regular grid a tile owns the whole stage: the minimized
+      // window shows exactly one, and the spotlight tile fills the wide cell
+      // (its thumbnails are sized separately in tileAvatarSize).
+      if (!this.isFullscreen || this.spotlightTile) {
+        return { width: this.stageWidth, height: this.stageHeight }
+      }
+      const { columns, rows } = this.gridDimensions
+      return { width: this.stageWidth / columns, height: this.stageHeight / rows }
+    },
     gridStyle() {
-      const n = Math.max(1, this.tiles.length)
-      const cols = Math.ceil(Math.sqrt(n))
-      return { 'grid-template-columns': `repeat(${cols}, 1fr)` }
+      const { columns, rows } = this.gridDimensions
+      return {
+        'grid-template-columns': `repeat(${columns}, 1fr)`,
+        // Explicit rows: without them the implicit rows size to content and
+        // the tiles never share the stage height evenly.
+        'grid-template-rows': `repeat(${rows}, 1fr)`,
+      }
     },
   },
   watch: {
@@ -447,8 +547,26 @@ export default {
   },
   created() {
     this.icons = iconRegistry
+    // Non-reactive bookkeeping: identity -> timestamp of the last report from
+    // LiveKit. Insertion order doubles as a stable display order, so a speaker
+    // who keeps talking never jumps around the chip row.
+    this.speakerSeenAt = new Map()
+    this.speakerHoldTimer = null
+    this.stageObserver = null
+    this.observedStage = null
+  },
+  mounted() {
+    this.observeStage()
+  },
+  updated() {
+    // The stage only exists in some phases, so re-check after every render
+    // rather than wiring this up once. observeStage() bails out when the
+    // element is unchanged, which also keeps the observer's own updates from
+    // looping.
+    this.observeStage()
   },
   beforeDestroy() {
+    this.disconnectStageObserver()
     this.cleanup()
   },
   methods: {
@@ -459,6 +577,74 @@ export default {
       setStorePhase: 'videoCall/SET_PHASE',
       setShowChat: 'chat/SET_OPEN_CHAT',
     }),
+    observeStage() {
+      const el = this.$refs.stageEl || null
+      if (el === this.observedStage) return
+      this.disconnectStageObserver()
+      this.observedStage = el
+      if (!el) {
+        this.stageWidth = 0
+        this.stageHeight = 0
+        return
+      }
+      this.measureStage()
+      if (typeof ResizeObserver === 'undefined') return
+      // Window resize alone would miss the cases that matter most here: the
+      // in-call chat sidebar opening, or minimize/maximize resizing the panel.
+      this.stageObserver = new ResizeObserver(() => this.measureStage())
+      this.stageObserver.observe(el)
+    },
+    measureStage() {
+      const el = this.observedStage
+      if (!el) return
+      const width = el.clientWidth || 0
+      const height = el.clientHeight || 0
+      if (width === this.stageWidth && height === this.stageHeight) return
+      this.stageWidth = width
+      this.stageHeight = height
+    },
+    disconnectStageObserver() {
+      if (this.stageObserver) {
+        this.stageObserver.disconnect()
+        this.stageObserver = null
+      }
+      this.observedStage = null
+    },
+    noteActiveSpeakers(identities) {
+      const now = Date.now()
+      for (const identity of identities) this.speakerSeenAt.set(identity, now)
+      this.applyActiveSpeakers()
+    },
+    applyActiveSpeakers() {
+      const now = Date.now()
+      const next = []
+      let soonestExpiry = null
+      for (const [identity, seenAt] of this.speakerSeenAt) {
+        const remaining = SPEAKER_HOLD_MS - (now - seenAt)
+        if (remaining > 0) {
+          next.push(identity)
+          if (soonestExpiry === null || remaining < soonestExpiry) soonestExpiry = remaining
+        } else {
+          this.speakerSeenAt.delete(identity)
+        }
+      }
+      const prev = this.activeSpeakerIds
+      if (prev.length !== next.length || !prev.every((id, i) => id === next[i])) {
+        this.activeSpeakerIds = next
+      }
+      if (this.speakerHoldTimer) {
+        clearTimeout(this.speakerHoldTimer)
+        this.speakerHoldTimer = null
+      }
+      // Falling out of the list is driven by the clock, not by an event —
+      // LiveKit has nothing more to report once someone stops talking.
+      if (soonestExpiry !== null) {
+        this.speakerHoldTimer = setTimeout(() => {
+          this.speakerHoldTimer = null
+          this.applyActiveSpeakers()
+        }, soonestExpiry)
+      }
+    },
     toggleChat() {
       if (this.chatOpenForThisGroup) {
         this.setShowChat({ showChat: false, chatUserId: null, groupId: null })
@@ -476,7 +662,17 @@ export default {
       // Spotlight thumbnails are too short for the large avatar — it gets
       // visually squished into an oval. Use the small avatar there instead.
       if (this.spotlightTile && tile.key !== this.spotlightTile.key) return 'small'
+      // Same reasoning for any cramped cell: a 3x3 grid on a phone, or the
+      // parked window, leaves nowhere near enough room for the 114px avatar.
+      const { width, height } = this.cellSize
+      if (height && height < LARGE_AVATAR_MIN_CELL_HEIGHT) return 'small'
+      if (width && width < LARGE_AVATAR_MIN_CELL_WIDTH) return 'small'
       return 'large'
+    },
+    iconOnlyTooltip(label) {
+      // v-tooltip renders nothing for an empty string — exactly what we want
+      // once the button spells its label out next to the icon.
+      return this.iconOnly ? label : ''
     },
     onTileSelect(tile) {
       if (!tile) return
@@ -562,6 +758,10 @@ export default {
         room.on(RoomEvent.ParticipantDisconnected, onAny)
         room.on(RoomEvent.TrackSubscribed, onAny)
         room.on(RoomEvent.TrackUnsubscribed, onAny)
+        // A remote participant withdrawing a track — most visibly, ending a
+        // screen share. Without this the tile can outlive its track and keep
+        // painting the last decoded frame.
+        room.on(RoomEvent.TrackUnpublished, onAny)
         // LiveKit's setCameraEnabled(false) mutes the track instead of
         // unpublishing it. Re-render so the avatar fallback kicks in.
         room.on(RoomEvent.TrackMuted, onAny)
@@ -570,20 +770,11 @@ export default {
         // changes so the avatar updates without a reconnect.
         room.on(RoomEvent.ParticipantMetadataChanged, onAny)
         room.on(RoomEvent.ActiveSpeakersChanged, (speakers) => {
-          // LiveKit fires this potentially many times per second; throttle so
-          // we don't re-render every tile on every micro-change. Trailing-only
-          // is fine — the latest array always wins.
-          this._pendingActiveSpeakers = (speakers || []).map((p) => p.identity)
-          if (this._activeSpeakersTimer) return
-          this._activeSpeakersTimer = setTimeout(() => {
-            this._activeSpeakersTimer = null
-            const next = this._pendingActiveSpeakers
-            if (!next) return
-            this._pendingActiveSpeakers = null
-            const prev = this.activeSpeakerIds
-            if (prev.length === next.length && prev.every((id, i) => id === next[i])) return
-            this.activeSpeakerIds = next
-          }, 200)
+          // Feed the hold window rather than mirroring LiveKit directly: it
+          // fires many times per second and drops people during the gaps
+          // between words. Highlighting is applied at once, removal waits out
+          // SPEAKER_HOLD_MS.
+          this.noteActiveSpeakers((speakers || []).map((p) => p.identity))
         })
         room.on(RoomEvent.LocalTrackPublished, () => {
           this.screenShareEnabled = !!room.localParticipant.isScreenShareEnabled
@@ -924,11 +1115,11 @@ export default {
         }
         this.room = null
       }
-      if (this._activeSpeakersTimer) {
-        clearTimeout(this._activeSpeakersTimer)
-        this._activeSpeakersTimer = null
+      if (this.speakerHoldTimer) {
+        clearTimeout(this.speakerHoldTimer)
+        this.speakerHoldTimer = null
       }
-      this._pendingActiveSpeakers = null
+      this.speakerSeenAt.clear()
       this.tiles = []
       this.activeSpeakerIds = []
       this.spotlightKey = null

--- a/webapp/components/VideoCall/VideoCall.vue
+++ b/webapp/components/VideoCall/VideoCall.vue
@@ -425,12 +425,22 @@ export default {
         this.spotlightKey = null
       }
     },
-    $route(to) {
+    async $route(to) {
       // Keep the minimized/maximized state in sync with the URL when the user
       // navigates via links, browser back/forward, or our own routing helpers.
       if (!this.show) return
-      if (this.phase !== 'connecting' && this.phase !== 'in-call') return
       const onCall = to.name === 'call-id-slug'
+      // A failed connect holds no session worth preserving — minimizing only
+      // exists so a *live* room survives navigation. Parking an error card in
+      // the corner would be litter the user still has to dismiss, and leaving
+      // it full screen blocks the page they just navigated to. Close instead.
+      // Deliberately not leave(): its router.replace would hijack the
+      // navigation that is running right now.
+      if (this.phase === 'error') {
+        if (!onCall) await this.closeAfterError()
+        return
+      }
+      if (this.phase !== 'connecting' && this.phase !== 'in-call') return
       if (onCall && this.minimized) this.setMinimized(false)
       else if (!onCall && !this.minimized) this.setMinimized(true)
     },
@@ -617,12 +627,31 @@ export default {
         this.refreshTiles()
         this.phase = 'in-call'
       } catch (err) {
-        this.error = (err && err.message) || String(err)
+        const message = (err && err.message) || String(err)
+        // The user navigated away while the handshake was still running, so
+        // the window is parked in the corner. Since isFullscreen treats every
+        // non-'in-call' phase as full screen, showing the error block here
+        // would blow the parked window back up over the page they moved to.
+        // There is no session to park either — toast the reason and close.
+        if (this.minimized) {
+          if (this.$toast && typeof this.$toast.error === 'function') {
+            this.$toast.error(message)
+          }
+          await this.closeAfterError()
+          return
+        }
+        this.error = message
         // Distinct phase so the header stops pretending there's a live room
         // (no participant counter, no minimize button, no in-call controls)
         // while the error block is shown.
         this.phase = 'error'
       }
+    },
+    async closeAfterError() {
+      // No navigation here — unlike leave(), every caller either is already
+      // navigating or was never on the call route to begin with.
+      await this.cleanup()
+      this.close()
     },
     refreshTiles() {
       const room = this.room

--- a/webapp/components/VideoCall/VideoTile.spec.js
+++ b/webapp/components/VideoCall/VideoTile.spec.js
@@ -207,6 +207,94 @@ describe('VideoTile', () => {
     })
   })
 
+  describe('ended video tracks', () => {
+    // A live MediaStreamTrack, plus the listener bookkeeping tests need.
+    const buildMediaTrack = (readyState = 'live') => {
+      const listeners = {}
+      return {
+        readyState,
+        addEventListener: jest.fn((event, cb) => {
+          listeners[event] = cb
+        }),
+        removeEventListener: jest.fn(),
+        end: () => listeners.ended && listeners.ended(),
+      }
+    }
+
+    it('replaces an ended screen share with a placeholder instead of a black box', async () => {
+      const mediaStreamTrack = buildMediaTrack()
+      const videoTrack = { ...buildTrack(), mediaStreamTrack }
+      const wrapper = factory({ tile: buildTile({ videoTrack, isScreen: true }) })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.hasVideo).toBe(true)
+
+      // The sharer hits the browser's own "Stop sharing" bar: the track ends
+      // before the unpublish message lands, and the <video> would otherwise
+      // keep painting its last decoded frame.
+      mediaStreamTrack.end()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.hasVideo).toBe(false)
+      expect(wrapper.html()).toContain('videoCall.screenShareEnded')
+    })
+
+    it('detects a track that had already ended before attaching', async () => {
+      const videoTrack = { ...buildTrack(), mediaStreamTrack: buildMediaTrack('ended') }
+      const wrapper = factory({ tile: buildTile({ videoTrack, isScreen: true }) })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.hasVideo).toBe(false)
+    })
+
+    it('gives a replacement track a clean slate', async () => {
+      const first = buildMediaTrack()
+      const wrapper = factory({
+        tile: buildTile({ videoTrack: { ...buildTrack(), mediaStreamTrack: first } }),
+      })
+      await wrapper.vm.$nextTick()
+      first.end()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.hasVideo).toBe(false)
+
+      await wrapper.setProps({
+        tile: buildTile({ videoTrack: { ...buildTrack(), mediaStreamTrack: buildMediaTrack() } }),
+      })
+      await wrapper.vm.$nextTick()
+      // The old track ending says nothing about the new one.
+      expect(wrapper.vm.hasVideo).toBe(true)
+      expect(first.removeEventListener).toHaveBeenCalledWith('ended', expect.any(Function))
+    })
+
+    it('drops the listener on unmount', async () => {
+      const mediaStreamTrack = buildMediaTrack()
+      const wrapper = factory({
+        tile: buildTile({ videoTrack: { ...buildTrack(), mediaStreamTrack } }),
+      })
+      await wrapper.vm.$nextTick()
+      wrapper.destroy()
+      expect(mediaStreamTrack.removeEventListener).toHaveBeenCalledWith(
+        'ended',
+        expect.any(Function),
+      )
+    })
+
+    it('copes with tracks that expose no MediaStreamTrack', async () => {
+      const wrapper = factory({ tile: buildTile({ videoTrack: buildTrack() }) })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.hasVideo).toBe(true)
+    })
+
+    it('swallows removeEventListener errors', async () => {
+      const mediaStreamTrack = buildMediaTrack()
+      mediaStreamTrack.removeEventListener = jest.fn(() => {
+        throw new Error('gone')
+      })
+      const wrapper = factory({
+        tile: buildTile({ videoTrack: { ...buildTrack(), mediaStreamTrack } }),
+      })
+      await wrapper.vm.$nextTick()
+      expect(() => wrapper.destroy()).not.toThrow()
+    })
+  })
+
   describe('sink id', () => {
     it('calls setSinkId on the audio element when changed', async () => {
       const wrapper = factory({ sinkId: 'speaker-1' })

--- a/webapp/components/VideoCall/VideoTile.vue
+++ b/webapp/components/VideoCall/VideoTile.vue
@@ -25,8 +25,19 @@
         {{ $t('videoCall.youAreSharingScreen') }}
       </span>
     </div>
-    <div v-else-if="!hasVideo && !tile.isScreen" class="video-tile__fallback">
-      <profile-avatar :profile="tile.profile" :size="avatarSize" />
+    <div
+      v-else-if="!hasVideo && tile.isScreen"
+      class="video-tile__fallback video-tile__fallback--own-screen"
+    >
+      <os-icon :icon="icons.desktop" class="video-tile__fallback-icon" />
+      <span class="video-tile__fallback-text">
+        {{ $t('videoCall.screenShareEnded') }}
+      </span>
+    </div>
+    <div v-else-if="!hasVideo" class="video-tile__fallback">
+      <!-- Tiles outside the minimized window's primary slot are display:none,
+           where a lazy image never gets fetched — load avatars eagerly. -->
+      <profile-avatar :profile="tile.profile" :size="avatarSize" loading="eager" />
       <span v-if="tile.isLocal && avatarSize !== 'small'" class="video-tile__fallback-text">
         {{ $t('videoCall.prejoin.cameraDisabled') }}
       </span>
@@ -87,10 +98,15 @@ export default {
     return {
       attachedVideo: null,
       attachedAudio: null,
+      videoEnded: false,
     }
   },
   created() {
     this.icons = iconRegistry
+    // Non-reactive bookkeeping for the 'ended' listener — nothing renders off
+    // these, so keeping them out of data() avoids needless reactivity.
+    this.endedTrack = null
+    this.onTrackEnded = null
   },
   computed: {
     showOwnScreenPlaceholder() {
@@ -102,13 +118,16 @@ export default {
     },
     hasVideo() {
       if (this.showOwnScreenPlaceholder) return false
-      return !!this.tile.videoTrack
+      return !!this.tile.videoTrack && !this.videoEnded
     },
   },
   watch: {
     'tile.videoTrack': {
       immediate: true,
       handler() {
+        // A new track earns a clean slate — the previous one having ended says
+        // nothing about this one.
+        this.videoEnded = false
         this.$nextTick(this.attachVideo)
       },
     },
@@ -157,17 +176,49 @@ export default {
           /* noop */
         }
       }
+      this.stopObservingTrackEnd()
       // Local screen share is never attached locally to avoid the mirror loop.
       if (this.tile.videoTrack && !this.showOwnScreenPlaceholder) {
         try {
           this.tile.videoTrack.attach(el)
           this.attachedVideo = this.tile.videoTrack
+          this.observeTrackEnd()
         } catch (_e) {
           /* noop */
         }
       } else {
         this.attachedVideo = null
       }
+    },
+    observeTrackEnd() {
+      // Stopping a screen share from the browser's own "Stop sharing" bar ends
+      // the MediaStreamTrack right away, while the unpublish message needs
+      // another round trip. In that window the <video> keeps painting its last
+      // decoded frame — for a share that just ended, a black rectangle. Watch
+      // the underlying track so the placeholder takes over immediately.
+      const track = this.attachedVideo
+      const mediaTrack = track && track.mediaStreamTrack
+      if (!mediaTrack || typeof mediaTrack.addEventListener !== 'function') return
+      if (mediaTrack.readyState === 'ended') {
+        this.videoEnded = true
+        return
+      }
+      this.onTrackEnded = () => {
+        this.videoEnded = true
+      }
+      this.endedTrack = mediaTrack
+      mediaTrack.addEventListener('ended', this.onTrackEnded)
+    },
+    stopObservingTrackEnd() {
+      if (this.endedTrack && this.onTrackEnded) {
+        try {
+          this.endedTrack.removeEventListener('ended', this.onTrackEnded)
+        } catch (_e) {
+          /* noop */
+        }
+      }
+      this.endedTrack = null
+      this.onTrackEnded = null
     },
     attachAudio() {
       const el = this.$refs.audioEl
@@ -192,6 +243,7 @@ export default {
       }
     },
     detachAll() {
+      this.stopObservingTrackEnd()
       const v = this.$refs.videoEl
       const a = this.$refs.audioEl
       if (this.attachedVideo && v) {
@@ -218,6 +270,11 @@ export default {
 <style lang="scss" scoped>
 .video-tile {
   position: relative;
+  // Confine the speaking frame and the pin badge to this tile. Without an own
+  // stacking context their z-indexes compete with the call's overlays (the
+  // active-speaker chips), where a tie is decided by DOM order — and the tiles
+  // come last, so the frame would paint over the chips.
+  isolation: isolate;
   background: $color-neutral-0;
   overflow: hidden;
   display: flex;

--- a/webapp/components/_new/generic/ProfileAvatar/ProfileAvatar.spec.js
+++ b/webapp/components/_new/generic/ProfileAvatar/ProfileAvatar.spec.js
@@ -90,6 +90,48 @@ describe('ProfileAvatar', () => {
       it('but because the avatar is so small, it will always ask the browser to render w320 size', () => {
         expect(wrapper.find('.image').attributes('sizes')).toBe('320px')
       })
+
+      it('defers loading unless told otherwise', () => {
+        expect(wrapper.find('.image').attributes('loading')).toBe('lazy')
+      })
+
+      it('loads eagerly on request', () => {
+        propsData = { ...propsData, loading: 'eager' }
+        wrapper = Wrapper()
+        expect(wrapper.find('.image').attributes('loading')).toBe('eager')
+      })
+
+      describe('when the image cannot be loaded', () => {
+        beforeEach(async () => {
+          await wrapper.find('.image').trigger('error')
+        })
+
+        it('falls back to the initials', () => {
+          expect(wrapper.find('img').exists()).toBe(false)
+          expect(wrapper.find('.initials').text()).toEqual('NA')
+        })
+
+        it('switches to the no-image styling so the initials stay legible', () => {
+          // Hiding just the <img> would leave light initials on the light
+          // default background — the avatar then reads as broken.
+          expect(wrapper.classes()).toContain('--no-image')
+        })
+
+        it('retries for a different profile', async () => {
+          await wrapper.setProps({
+            profile: {
+              name: 'Someone Else',
+              avatar: {
+                url: 'http://localhost:8000//other.jpg',
+                w320: 'http://localhost:8000//other-w320.jpg',
+                w640: 'http://localhost:8000//other-w640.jpg',
+                w1024: 'http://localhost:8000//other-w1024.jpg',
+              },
+            },
+          })
+          expect(wrapper.find('img').exists()).toBe(true)
+        })
+      })
     })
   })
 })

--- a/webapp/components/_new/generic/ProfileAvatar/ProfileAvatar.vue
+++ b/webapp/components/_new/generic/ProfileAvatar/ProfileAvatar.vue
@@ -1,15 +1,16 @@
 <template>
-  <div :class="['profile-avatar', size && `--${size}`, !isAvatar && '--no-image']">
+  <div :class="['profile-avatar', size && `--${size}`, !showImage && '--no-image']">
     <!-- '--no-image' is neccessary, because otherwise we still have a little unwanted boarder araund the image for images with white backgrounds -->
     <span class="initials">{{ profileInitials }}</span>
     <os-icon v-if="isAnonymous" :icon="icons.eyeSlash" />
     <responsive-image
-      v-if="isAvatar"
+      v-if="showImage"
       :image="profile.avatar"
       class="image"
       :alt="profile.name"
       :title="showProfileNameTitle ? profile.name : ''"
-      @error="$event.target.style.display = 'none'"
+      :loading="loading"
+      @error="imageFailed = true"
       sizes="320px"
     />
   </div>
@@ -42,14 +43,40 @@ export default {
       type: Boolean,
       default: true,
     },
+    loading: {
+      // Forwarded to ResponsiveImage — see its prop docs for when 'eager' is
+      // the right call.
+      type: String,
+      default: 'lazy',
+      validator: (value) => /^(lazy|eager)$/.test(value),
+    },
+  },
+  data() {
+    return {
+      imageFailed: false,
+    }
+  },
+  watch: {
+    'profile.avatar.url'() {
+      // A new URL deserves a fresh attempt — otherwise one broken avatar would
+      // permanently pin this instance to the initials fallback even after the
+      // component is reused for a different profile.
+      this.imageFailed = false
+    },
   },
   computed: {
     isAnonymous() {
       return !this.profile || !this.profile.name || this.profile.name.toLowerCase() === 'anonymous'
     },
     isAvatar() {
-      // TODO may we could test as well if the image is reachable? otherwise the background gets white and the initails can not be read
       return this.profile && this.profile.avatar
+    },
+    showImage() {
+      // An unreachable avatar URL must fall back to the initials treatment.
+      // Dropping only the <img> is not enough: '--no-image' also supplies the
+      // dark background the initials are legible against, so without this the
+      // avatar renders as light-on-light and reads as broken.
+      return !!this.isAvatar && !this.imageFailed
     },
     profileInitials() {
       if (this.isAnonymous) return ''

--- a/webapp/locales/de.json
+++ b/webapp/locales/de.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Dein Browser unterstützt Audio/Video nicht."
     },
     "screenShare": "Bildschirm",
+    "screenShareEnded": "Bildschirmfreigabe beendet",
     "spotlightExit": "Spotlight beenden",
     "startScreenShare": "Bildschirm teilen",
     "stopScreenShare": "Teilen beenden",

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Your browser does not support audio/video."
     },
     "screenShare": "Screen",
+    "screenShareEnded": "Screen sharing ended",
     "spotlightExit": "Exit spotlight",
     "startScreenShare": "Share screen",
     "stopScreenShare": "Stop sharing",

--- a/webapp/locales/es.json
+++ b/webapp/locales/es.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Tu navegador no admite audio/vídeo."
     },
     "screenShare": "Pantalla",
+    "screenShareEnded": "Uso compartido de pantalla finalizado",
     "spotlightExit": "Salir del foco",
     "startScreenShare": "Compartir pantalla",
     "stopScreenShare": "Detener uso compartido",

--- a/webapp/locales/fr.json
+++ b/webapp/locales/fr.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Votre navigateur ne prend pas en charge l'audio/vidéo."
     },
     "screenShare": "Écran",
+    "screenShareEnded": "Partage d'écran terminé",
     "spotlightExit": "Quitter le focus",
     "startScreenShare": "Partager l'écran",
     "stopScreenShare": "Arrêter le partage",

--- a/webapp/locales/it.json
+++ b/webapp/locales/it.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Il tuo browser non supporta audio/video."
     },
     "screenShare": "Schermo",
+    "screenShareEnded": "Condivisione schermo terminata",
     "spotlightExit": "Esci dallo spotlight",
     "startScreenShare": "Condividi schermo",
     "stopScreenShare": "Interrompi condivisione",

--- a/webapp/locales/nl.json
+++ b/webapp/locales/nl.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Je browser ondersteunt geen audio/video."
     },
     "screenShare": "Scherm",
+    "screenShareEnded": "Schermdelen beëindigd",
     "spotlightExit": "Spotlight verlaten",
     "startScreenShare": "Scherm delen",
     "stopScreenShare": "Stoppen met delen",

--- a/webapp/locales/pl.json
+++ b/webapp/locales/pl.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Twoja przeglądarka nie obsługuje audio/wideo."
     },
     "screenShare": "Ekran",
+    "screenShareEnded": "Zakończono udostępnianie ekranu",
     "spotlightExit": "Wyjdź z trybu spotlight",
     "startScreenShare": "Udostępnij ekran",
     "stopScreenShare": "Zakończ udostępnianie",

--- a/webapp/locales/pt.json
+++ b/webapp/locales/pt.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "O teu navegador não suporta áudio/vídeo."
     },
     "screenShare": "Ecrã",
+    "screenShareEnded": "Partilha de ecrã terminada",
     "spotlightExit": "Sair do destaque",
     "startScreenShare": "Partilhar ecrã",
     "stopScreenShare": "Parar partilha",

--- a/webapp/locales/ru.json
+++ b/webapp/locales/ru.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Ваш браузер не поддерживает аудио/видео."
     },
     "screenShare": "Экран",
+    "screenShareEnded": "Показ экрана завершён",
     "spotlightExit": "Выйти из режима спотлайта",
     "startScreenShare": "Показать экран",
     "stopScreenShare": "Прекратить показ",

--- a/webapp/locales/sq.json
+++ b/webapp/locales/sq.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Shfletuesi yt nuk mbështet audio/video."
     },
     "screenShare": "Ekrani",
+    "screenShareEnded": "Ndarja e ekranit përfundoi",
     "spotlightExit": "Dil nga spotlight",
     "startScreenShare": "Ndaj ekranin",
     "stopScreenShare": "Ndalo ndarjen",

--- a/webapp/locales/uk.json
+++ b/webapp/locales/uk.json
@@ -1755,6 +1755,7 @@
       "unsupportedBrowser": "Ваш браузер не підтримує аудіо/відео."
     },
     "screenShare": "Екран",
+    "screenShareEnded": "Демонстрацію екрана завершено",
     "spotlightExit": "Вийти зі спотлайту",
     "startScreenShare": "Поділитися екраном",
     "stopScreenShare": "Припинити демонстрацію",


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix video avatar + display & navigation

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * Bilder und Profilavatare unterstützen konfigurierbares verzögertes oder sofortiges Laden.
  * Ladefehler bei Bildern werden weitergereicht und zeigen bei Avataren automatisch Initialen an.
  * Videokacheln erkennen beendete Videospuren und zeigen passende Platzhalter.
  * Das Video-Call-Layout passt sich dynamisch an die verfügbare Fläche an.
  * Sprecher bleiben kurz nach ihrer Aktivität hervorgehoben.
  * Fehler bei minimierten oder fehlgeschlagenen Anrufen werden verständlicher angezeigt.

* **Verbesserungen**
  * Bildschirmfreigaben werden nach ihrem Ende eindeutig gekennzeichnet.
  * Beschriftungen und Barrierefreiheitslabels für Video-Call-Steuerelemente wurden vereinheitlicht.
  * Die Meldung zum Ende der Bildschirmfreigabe ist in mehreren Sprachen verfügbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->