### PR TITLE
feat(docker): support private repos for kubernetes pulling with secret

### DIFF
--- a/deployment/deployment-values.md
+++ b/deployment/deployment-values.md
@@ -71,3 +71,104 @@ As example see files:
 - `neo4j/.env.template`
 - `deployment/docker-compose.yml`
 - `deployment/configurations/stage.ocelot.social/kubernetes/values.yaml.template`
+
+## Private Container Images
+
+Public images on the GitHub Container Registry are pulled anonymously and need no configuration at
+all. Only if a repository an instance pulls from is **private** does the cluster need a credential.
+
+Note that every instance pulls from at least two GitHub organizations: its own — `it4change`,
+`changemedia-at`, `yunite-net` or `ocelot-social-community` — plus `ocelot-social-community` for the
+shared neo4j image. Should more than one of them be private, they may well require different tokens.
+
+### Runtime only — the build path is separate
+
+What follows covers the **cluster** pulling images. It does not cover the **build**: a configuration
+repository builds its branded images `FROM ghcr.io/ocelot-social-community/ocelot-social/*-base`,
+and `publish.yml` authenticates that with the workflow's own `GITHUB_TOKEN`.
+
+That token is scoped to its own repository and **cannot read packages of another organization** —
+not even via *Manage Actions access* on the package, which only lists repositories of the same
+owner. The branding builds therefore depend on the ocelot base images staying **public**, which is
+deliberate: they are the published artifacts of an open source project, so making them private would
+protect nothing while breaking every branding pipeline.
+
+Should they ever have to become private, a pull secret will not help. The build would need a cross-
+organization PAT, and since Docker resolves registry credentials per *host*, a second `ghcr.io`
+login would overwrite the first — the path scoping described below has no equivalent there. The
+workflow would have to be split into a PAT-authenticated build and a `GITHUB_TOKEN`-authenticated
+push.
+
+### Creating the token
+
+Registry authentication is unrelated to git access — a deploy key cannot be used here, it only
+authenticates SSH git operations against a single repository. Use a **classic** personal access
+token of a machine user instead:
+
+1. Give the token the `read:packages` scope, and nothing else. `repo` would turn it into a git
+   credential as well, which the cluster has no business holding.
+2. If the organization enforces SAML SSO, press *Configure SSO → Authorize* on the token afterwards.
+   Without that, private packages answer with a 403 and the cause is not obvious from the pod events.
+3. Grant the machine user read access to the packages themselves under *Package → Settings → Manage
+   Access*. The scope alone does not grant it.
+4. Note the expiry date somewhere you will see it again. A token without expiry is worse.
+
+### Storing it
+
+Credentials belong in the sops-encrypted environment file of a configuration, next to the other
+secrets, under the key `ghcr`:
+
+```bash
+sops edit deployment/configurations/<domain>/helmfile/environments/default.secrets.yaml
+```
+
+```yaml
+ghcr:
+    - registry: ghcr.io/it4change
+      username: <machine user>
+      password: <classic PAT>
+    - registry: ghcr.io/ocelot-social-community
+      username: <machine user>
+      password: <classic PAT>
+```
+
+Each entry is scoped to `host/path`, not to the bare host `ghcr.io`. That is what allows two
+organizations with *different* tokens to coexist: the kubelet keyring prefix-matches an image
+reference against these keys and picks the longest match. With a single `ghcr.io` key only one token
+could ever be stored.
+
+Configurations that also have a `production` environment need the block in **both**
+`default.secrets.yaml` and `production.secrets.yaml` — helmfile reads only the files of the selected
+environment.
+
+Nothing else has to be touched. `helmfile/values/ocelot.yaml.gotmpl` already passes the key through
+to the charts, which then create a `kubernetes.io/dockerconfigjson` Secret and reference it from
+every pod. While the `ghcr` key is absent, no Secret is created and no pod references one.
+
+Each of the two releases generates its own Secret (`<release>-image-pull`), so the credential exists
+twice in the namespace. To keep a single copy instead, set `imagePullCredentials.existingSecrets` on
+the `ocelot-neo4j` release and leave its `registries` empty.
+
+### Verifying
+
+Rendering shows both the Secret and its references without touching a cluster:
+
+```bash
+helmfile -e default template | grep -A2 imagePullSecrets
+```
+
+A real pull is worth testing once, because a node that already has the image cached will happily
+start the pod with a broken credential and the problem only surfaces on the next fresh node:
+
+```bash
+kubectl -n <namespace> run pulltest --rm -it --restart=Never \
+  --image=ghcr.io/<org>/<private-image>:<tag> \
+  --overrides='{"spec":{"imagePullPolicy":"Always"}}'
+```
+
+`kubectl describe pod` distinguishes the two common failures: 401 points at the token or a missing
+SSO authorization, 403 at missing package access.
+
+One caveat worth knowing: once credentials are configured, an **expired or invalid** token makes
+pulls fail even for images that are public and would need no authentication at all, because the
+registry rejects the request rather than falling back to anonymous access.

--- a/deployment/deployment-values.md
+++ b/deployment/deployment-values.md
@@ -163,8 +163,16 @@ start the pod with a broken credential and the problem only surfaces on the next
 ```bash
 kubectl -n <namespace> run pulltest --rm -it --restart=Never \
   --image=ghcr.io/<org>/<private-image>:<tag> \
-  --overrides='{"spec":{"imagePullPolicy":"Always"}}'
+  --image-pull-policy=Always \
+  --overrides='{"spec":{"imagePullSecrets":[{"name":"<release>-image-pull"}]}}'
 ```
+
+Both flags matter. `imagePullPolicy` lives on the container (`spec.containers[].imagePullPolicy`),
+not on the pod, so passing it through `--overrides` would be silently ignored — `kubectl run` has
+`--image-pull-policy` for it. And the pull Secret has to be named explicitly: this chart attaches it
+to the pod specs it renders, not to the namespace's ServiceAccount, so an ad-hoc `kubectl run` pod
+carries no credential at all and would fail against a private image even when the deployment itself
+is configured correctly. Substitute the release name, or the name of an `existingSecrets` entry.
 
 `kubectl describe pod` distinguishes the two common failures: 401 points at the token or a missing
 SSO authorization, 403 at missing package access.

--- a/deployment/helm/charts/ocelot-neo4j/templates/_helpers.tpl
+++ b/deployment/helm/charts/ocelot-neo4j/templates/_helpers.tpl
@@ -8,3 +8,37 @@ resources:
 {{ . | toYaml | indent 2 }}
 {{- end }}
 {{- end  }}
+
+{{- define "imagePullSecretName" -}}
+{{- .Release.Name }}-image-pull
+{{- end -}}
+
+{{/*
+Builds the `.dockerconfigjson` payload. Credentials are keyed by "host/path"
+(e.g. ghcr.io/ocelot-social-community), NOT by bare host, so that several GHCR organizations with
+different tokens can coexist in one Secret. The kubelet keyring prefix-matches an image reference
+against these keys, so the longest matching path wins.
+*/}}
+{{- define "imagePullSecretDockerConfigJson" -}}
+{{- $auths := dict -}}
+{{- range .Values.imagePullCredentials.registries -}}
+{{- $_ := set $auths .registry (dict "username" .username "password" .password "auth" (printf "%s:%s" .username .password | b64enc)) -}}
+{{- end -}}
+{{- dict "auths" $auths | toJson -}}
+{{- end -}}
+
+{{- define "imagePullSecrets"  }}
+{{- $names := list }}
+{{- if .Values.imagePullCredentials.registries }}
+{{- $names = append $names (include "imagePullSecretName" .) }}
+{{- end }}
+{{- range .Values.imagePullCredentials.existingSecrets }}
+{{- $names = append $names . }}
+{{- end }}
+{{- if $names }}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end  }}

--- a/deployment/helm/charts/ocelot-neo4j/templates/neo4j/image-pull-secret.yaml
+++ b/deployment/helm/charts/ocelot-neo4j/templates/neo4j/image-pull-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.imagePullCredentials.registries }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "imagePullSecretName" . }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ include "imagePullSecretDockerConfigJson" . | b64enc }}
+{{- end }}

--- a/deployment/helm/charts/ocelot-neo4j/templates/neo4j/stateful-set.yaml
+++ b/deployment/helm/charts/ocelot-neo4j/templates/neo4j/stateful-set.yaml
@@ -16,6 +16,7 @@ spec:
         app: {{ .Release.Name }}-neo4j
     spec:
       restartPolicy: Always
+      {{- include "imagePullSecrets" . | indent 6 }}
       containers:
       - name: container-{{ .Release.Name }}-neo4j
         image: "{{ .Values.neo4j.image.repository }}:{{ .Values.neo4j.image.tag | default (include "defaultTag" .)  }}"

--- a/deployment/helm/charts/ocelot-neo4j/values.yaml
+++ b/deployment/helm/charts/ocelot-neo4j/values.yaml
@@ -4,6 +4,14 @@ global:
   image:
     tag:
 
+# Credentials for pulling images from private registries — see the identically named block in the
+# ocelot-social chart. Both releases share one values file per configuration, so setting it there
+# covers this chart as well. Each chart generates its own Secret; set `existingSecrets` here and
+# leave `registries` empty to reuse the one from the ocelot-social release instead.
+imagePullCredentials:
+  registries: []
+  existingSecrets: []
+
 neo4j:
   image:
     repository: ghcr.io/ocelot-social-community/ocelot-social/neo4j

--- a/deployment/helm/charts/ocelot-social/templates/_helpers.tpl
+++ b/deployment/helm/charts/ocelot-social/templates/_helpers.tpl
@@ -8,3 +8,38 @@ resources:
 {{ . | toYaml | indent 2 }}
 {{- end }}
 {{- end  }}
+
+{{- define "imagePullSecretName" -}}
+{{- .Release.Name }}-image-pull
+{{- end -}}
+
+{{/*
+Builds the `.dockerconfigjson` payload. Credentials are keyed by "host/path"
+(e.g. ghcr.io/it4change), NOT by bare host: an instance pulls from several GHCR organizations at
+once — its own plus ocelot-social-community for the neo4j image — and those may use different
+tokens, which a single `ghcr.io` key could not hold. The kubelet keyring prefix-matches an image
+reference against these keys, so the longest matching path wins.
+*/}}
+{{- define "imagePullSecretDockerConfigJson" -}}
+{{- $auths := dict -}}
+{{- range .Values.imagePullCredentials.registries -}}
+{{- $_ := set $auths .registry (dict "username" .username "password" .password "auth" (printf "%s:%s" .username .password | b64enc)) -}}
+{{- end -}}
+{{- dict "auths" $auths | toJson -}}
+{{- end -}}
+
+{{- define "imagePullSecrets"  }}
+{{- $names := list }}
+{{- if .Values.imagePullCredentials.registries }}
+{{- $names = append $names (include "imagePullSecretName" .) }}
+{{- end }}
+{{- range .Values.imagePullCredentials.existingSecrets }}
+{{- $names = append $names . }}
+{{- end }}
+{{- if $names }}
+imagePullSecrets:
+{{- range $names }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end  }}

--- a/deployment/helm/charts/ocelot-social/templates/backend/stateful-set.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/backend/stateful-set.yaml
@@ -14,6 +14,7 @@ spec:
         app: {{ .Release.Name }}-backend
     spec:
       restartPolicy: Always
+      {{- include "imagePullSecrets" . | indent 6 }}
       initContainers:
         - name: {{ .Release.Name }}-backend-migrations
           image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default (include "defaultTag" .) }}"

--- a/deployment/helm/charts/ocelot-social/templates/image-pull-secret.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/image-pull-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.imagePullCredentials.registries }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "imagePullSecretName" . }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ include "imagePullSecretDockerConfigJson" . | b64enc }}
+{{- end }}

--- a/deployment/helm/charts/ocelot-social/templates/imagor/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/imagor/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         app: {{ .Release.Name }}-imagor
     spec:
       restartPolicy: Always
+      {{- include "imagePullSecrets" . | indent 6 }}
       containers:
       - name: {{ .Release.Name }}-imagor
         image: "{{ .Values.imagor.image.repository }}:{{ .Values.imagor.image.tag | default (include "defaultTag" .)  }}"

--- a/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
@@ -12,6 +12,7 @@ spec:
         app: {{ .Release.Name }}-maintenance
     spec:
       restartPolicy: Always
+      {{- include "imagePullSecrets" . | indent 6 }}
       containers:
       - name: {{ .Release.Name }}-maintenance
         image: "{{ .Values.maintenance.image.repository }}:{{ .Values.maintenance.image.tag | default (include "defaultTag" .)  }}"

--- a/deployment/helm/charts/ocelot-social/templates/webapp/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/webapp/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         app: {{ .Release.Name }}-webapp
     spec:
       restartPolicy: Always
+      {{- include "imagePullSecrets" . | indent 6 }}
       containers:
       - name: {{ .Release.Name }}-webapp
         image: "{{ .Values.webapp.image.repository }}:{{ .Values.webapp.image.tag | default (include "defaultTag" .)  }}"

--- a/deployment/helm/charts/ocelot-social/values.yaml
+++ b/deployment/helm/charts/ocelot-social/values.yaml
@@ -11,6 +11,31 @@ global:
     pullPolicy: IfNotPresent
     tag:
 
+# Credentials for pulling images from private registries. Public images need none — leave this empty
+# unless a repository the instance pulls from is actually private.
+#
+# `registries` generates a `kubernetes.io/dockerconfigjson` Secret and references it from every pod.
+# Scope each entry to "host/path" rather than the bare host, so that several GHCR organizations with
+# DIFFERENT tokens can coexist (see the "imagePullSecretDockerConfigJson" helper):
+#
+#   registries:
+#     - registry: ghcr.io/it4change
+#       username: ocelot-bot
+#       password: ghp_...            # classic PAT, scope `read:packages` only
+#     - registry: ghcr.io/ocelot-social-community
+#       username: ocelot-bot
+#       password: ghp_...
+#
+# Never put these into a plaintext values file — they come from the sops-encrypted
+# `helmfile/environments/*.secrets.yaml` of a configuration, see deployment/deployment-values.md.
+#
+# `existingSecrets` references pull Secrets created outside this chart, additionally to the
+# generated one. Use it to share a single Secret between the ocelot-social and ocelot-neo4j releases
+# instead of having each chart generate its own copy.
+imagePullCredentials:
+  registries: []
+  existingSecrets: []
+
 backend:
   image:
     repository: ghcr.io/ocelot-social-community/ocelot-social/backend


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

support private repos for kubernetes pulling with secret

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Unterstützung für private Container-Registries bei Neo4j- und Social-Komponenten hinzugefügt.
  * Automatische Erstellung und Einbindung von Kubernetes-Image-Pull-Secrets ermöglicht.
  * Vorhandene Pull-Secrets können zusätzlich verwendet werden.
  * Registry-Zugangsdaten lassen sich gezielt nach Host und Pfad konfigurieren.

* **Dokumentation**
  * Anleitung zur Authentifizierung, Token-Konfiguration, Secret-Erstellung und Überprüfung ergänzt.
  * Hinweise zur Fehlerbehebung bei Zugriff, Cache und abgelaufenen Tokens hinzugefügt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->