### PR TITLE
fix(docker): kubernetes ready-probes & protect data claims

### DIFF
--- a/deployment/TODO-next-update.md
+++ b/deployment/TODO-next-update.md
@@ -89,18 +89,23 @@ backend's GraphQL subscriptions are process-local. See
 
 ## Config changes now cause a rollout — including one restart on this upgrade
 
-Every workload took its configuration through `envFrom`, which Kubernetes resolves **once**, when
-the container starts. Changing a value in `backend.env`, `webapp.env` or `neo4j.env` therefore
-updated the ConfigMap and stopped there: the pod template stayed byte-identical, Helm saw nothing to
-do, and the running pod kept serving the old value until something unrelated happened to restart it.
-Every pod template now carries a `checksum/config` (and `checksum/secret`) annotation over the
-rendered manifests, so a changed value is a changed pod template and Helm rolls it out.
+Backend, webapp and Neo4j take their configuration through `envFrom`, which Kubernetes resolves
+**once**, when the container starts. Changing a value in `backend.env`, `webapp.env` or `neo4j.env`
+therefore updated the ConfigMap and stopped there: the pod template stayed byte-identical, Helm saw
+nothing to do, and the running pod kept serving the old value until something unrelated happened to
+restart it. Those three pod templates now carry `checksum/config` and `checksum/secret` annotations
+over the rendered manifests, so a changed value is a changed pod template and Helm rolls it out.
+
+The two remaining workloads differ: imagor has no ConfigMap — it takes everything from its secret —
+so it carries `checksum/secret` alone, and maintenance carries no `checksum/*` at all because its
+env is inline in the pod template, where a change is already a template change.
 
 **Action:** none — but be aware of two consequences.
 
-- **This upgrade restarts every pod once**, because the annotations themselves are new. For the
-  Neo4j StatefulSet that is a short database restart. It happens inside the maintenance window you
-  already need for the StatefulSet-to-Deployment switch above, so plan them together.
+- **This upgrade restarts backend, webapp, imagor and Neo4j once** (maintenance is untouched),
+  because the annotations themselves are new. For the Neo4j StatefulSet that is a short database
+  restart. It happens inside the maintenance window you already need for the
+  StatefulSet-to-Deployment switch above, so plan them together.
 - **From now on, editing `neo4j.env` restarts the database.** That is the honest behaviour — the
   setting was never live before — but treat a heap-size or page-cache change as the restart it is.
 

--- a/deployment/TODO-next-update.md
+++ b/deployment/TODO-next-update.md
@@ -83,10 +83,61 @@ waited out silently, and a pod stuck in `Init` no longer has to be deleted by ha
 rollout can start — a new rollout creates a new ReplicaSet and terminates the stuck pod along with
 the old one, where the StatefulSet's `OrderedReady` waited for it to become `Ready` forever. The
 rollout it is stuck in still counts as unfinished until `progressDeadlineSeconds` runs out. It is
-**not**
-zero-downtime yet: `replicas` is pinned to `1` and `maxSurge` to `0`, because without Redis the
+**not** zero-downtime yet: `replicas` is pinned to `1` and `maxSurge` to `0`, because without Redis the
 backend's GraphQL subscriptions are process-local. See
 [backend-zero-downtime-konzept.md](../docu/backend-zero-downtime-konzept.md).
+
+## Config changes now cause a rollout — including one restart on this upgrade
+
+Every workload took its configuration through `envFrom`, which Kubernetes resolves **once**, when
+the container starts. Changing a value in `backend.env`, `webapp.env` or `neo4j.env` therefore
+updated the ConfigMap and stopped there: the pod template stayed byte-identical, Helm saw nothing to
+do, and the running pod kept serving the old value until something unrelated happened to restart it.
+Every pod template now carries a `checksum/config` (and `checksum/secret`) annotation over the
+rendered manifests, so a changed value is a changed pod template and Helm rolls it out.
+
+**Action:** none — but be aware of two consequences.
+
+- **This upgrade restarts every pod once**, because the annotations themselves are new. For the
+  Neo4j StatefulSet that is a short database restart. It happens inside the maintenance window you
+  already need for the StatefulSet-to-Deployment switch above, so plan them together.
+- **From now on, editing `neo4j.env` restarts the database.** That is the honest behaviour — the
+  setting was never live before — but treat a heap-size or page-cache change as the restart it is.
+
+Neo4j's `terminationGracePeriodSeconds` is raised to `120` in the same step: the default 30 s can
+cut a flush short on a larger graph, and a SIGKILL mid-flush turns the next start into a recovery
+run.
+
+## The Neo4j volumes are protected against Helm now
+
+`<release>-neo4j-data` and `<release>-neo4j-backups` carry `helm.sh/resource-policy: keep`. They
+were ordinary templates before, which is the same setup that lets Helm delete the uploads PVC in the
+section above — only here the volume holds the entire instance database, and a `helm uninstall`, a
+rename or a dropped template would have taken it along on a `reclaimPolicy: Delete` StorageClass.
+
+**Action:** none for an upgrade. Note for a deliberate teardown: the claims now survive
+`helm uninstall` and have to be removed by hand
+(`kubectl -n <namespace> delete pvc <release>-neo4j-data <release>-neo4j-backups`).
+
+`<release>-neo4j-backups` is mounted by no workload — the backup job that used it has not been part
+of the chart for a long time. It is kept and protected rather than removed, so that any dumps an
+instance still holds survive until the backup story is decided. If you know yours is empty, you can
+delete the claim by hand to save the storage.
+
+## Readiness probes for webapp, imagor and maintenance
+
+Only the backend had probes. Without a `readinessProbe` a pod counts as Ready the moment its
+container process starts — for Nuxt that is seconds before it listens, so Traefik routed into a 502
+for the whole surge window of every webapp rollout. Webapp, imagor and Neo4j now have readiness
+probes (`tcpSocket`), maintenance an `httpGet` on `/`, and webapp and imagor a `preStop` sleep that
+covers the gap between endpoint removal and SIGTERM.
+
+Neo4j gets **no** liveness probe on purpose: a database busy with recovery or a long GC pause is not
+one that should be killed and restarted.
+
+**Action:** none. If your instance keeps its own copy of the chart, port the probes from
+`templates/webapp/deployment.yaml`, `templates/imagor/deployment.yaml`,
+`templates/maintenance/deployment.yaml` and the neo4j chart's `stateful-set.yaml`.
 
 ## ⚠️ Branding: the `public/` bucket is gone — badges move to `assets/badges/`
 

--- a/deployment/helm/charts/ocelot-neo4j/templates/neo4j/persistent-volume-claim.yaml
+++ b/deployment/helm/charts/ocelot-neo4j/templates/neo4j/persistent-volume-claim.yaml
@@ -1,15 +1,18 @@
 {{/*
-Both claims carry `helm.sh/resource-policy: keep` DELIBERATELY. Without it these are ordinary Helm
-templates, and Helm deletes a template it no longer renders — a `helm uninstall`, a rename, or
-dropping the template would take `<release>-neo4j-data` with it. On a StorageClass with
-`reclaimPolicy: Delete` (the default for hcloud-volumes, among others) the volume's contents are
-gone in the same second, and this one holds the entire instance database. Exactly that mechanism
-removed the backend's uploads PVC on the StatefulSet-to-Deployment upgrade — there it was harmless
-because the volume was empty since the S3 migration.
+Both claims carry `helm.sh/resource-policy: keep` DELIBERATELY. Without it
+these are ordinary Helm templates, and Helm deletes a template it no longer
+renders — a `helm uninstall`, a rename, or dropping the template would take
+`<release>-neo4j-data` with it. On a StorageClass with `reclaimPolicy:
+Delete` (the default for hcloud-volumes, among others) the volume's contents
+are gone in the same second, and this one holds the entire instance database.
+Exactly that mechanism removed the backend's uploads PVC on the
+StatefulSet-to-Deployment upgrade — there it was harmless because the volume
+was empty since the S3 migration.
 
-The price is that an intentional teardown now leaves the PVCs behind and they have to be deleted by
-hand (`kubectl delete pvc <release>-neo4j-data <release>-neo4j-backups`). That is the right way
-round: an orphaned volume costs storage, a deleted one costs the instance.
+The price is that an intentional teardown now leaves the PVCs behind and they
+have to be deleted by hand (`kubectl delete pvc <release>-neo4j-data
+<release>-neo4j-backups`). That is the right way round: an orphaned volume
+costs storage, a deleted one costs the instance.
 */}}
 ---
 kind: PersistentVolumeClaim
@@ -28,9 +31,10 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  # Currently mounted by NO workload: the only consumer is `old/job.yaml`, which lives outside
-  # `templates/` and is never rendered. Kept (and protected) until the backup story is decided, so
-  # that whatever dumps an instance may still hold survive that decision.
+  # Currently mounted by NO workload: the only consumer is `old/job.yaml`,
+  # which lives outside `templates/` and is never rendered. Kept (and
+  # protected) until the backup story is decided, so that whatever dumps an
+  # instance may still hold survive that decision.
   name: {{ .Release.Name }}-neo4j-backups
   annotations:
     helm.sh/resource-policy: keep

--- a/deployment/helm/charts/ocelot-neo4j/templates/neo4j/persistent-volume-claim.yaml
+++ b/deployment/helm/charts/ocelot-neo4j/templates/neo4j/persistent-volume-claim.yaml
@@ -1,8 +1,23 @@
+{{/*
+Both claims carry `helm.sh/resource-policy: keep` DELIBERATELY. Without it these are ordinary Helm
+templates, and Helm deletes a template it no longer renders — a `helm uninstall`, a rename, or
+dropping the template would take `<release>-neo4j-data` with it. On a StorageClass with
+`reclaimPolicy: Delete` (the default for hcloud-volumes, among others) the volume's contents are
+gone in the same second, and this one holds the entire instance database. Exactly that mechanism
+removed the backend's uploads PVC on the StatefulSet-to-Deployment upgrade — there it was harmless
+because the volume was empty since the S3 migration.
+
+The price is that an intentional teardown now leaves the PVCs behind and they have to be deleted by
+hand (`kubectl delete pvc <release>-neo4j-data <release>-neo4j-backups`). That is the right way
+round: an orphaned volume costs storage, a deleted one costs the instance.
+*/}}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-neo4j-data
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   accessModes:
     - ReadWriteOnce
@@ -13,7 +28,12 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
+  # Currently mounted by NO workload: the only consumer is `old/job.yaml`, which lives outside
+  # `templates/` and is never rendered. Kept (and protected) until the backup story is decided, so
+  # that whatever dumps an instance may still hold survive that decision.
   name: {{ .Release.Name }}-neo4j-backups
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   accessModes:
     - ReadWriteOnce

--- a/deployment/helm/charts/ocelot-neo4j/templates/neo4j/stateful-set.yaml
+++ b/deployment/helm/charts/ocelot-neo4j/templates/neo4j/stateful-set.yaml
@@ -12,10 +12,19 @@ spec:
       name: neo4j
       annotations:
         backup.velero.io/backup-volumes: neo4j-data
+        # `envFrom` is resolved once at container start, so a changed heap size or page cache would
+        # otherwise sit in the ConfigMap without ever reaching the running database. NOTE that this
+        # makes such a change a real restart of the database — which is the honest behaviour, but
+        # plan it like one.
+        checksum/config: {{ include (print $.Template.BasePath "/neo4j/configmap.yml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/neo4j/secret.yaml") . | sha256sum }}
       labels:
         app: {{ .Release.Name }}-neo4j
     spec:
       restartPolicy: Always
+      # Neo4j flushes and closes its store files on SIGTERM. The default 30 s can cut that short on
+      # a larger graph, and a SIGKILL mid-flush turns the next start into a recovery run.
+      terminationGracePeriodSeconds: 120
       {{- include "imagePullSecrets" . | indent 6 }}
       containers:
       - name: container-{{ .Release.Name }}-neo4j
@@ -25,6 +34,20 @@ spec:
         ports:
         - containerPort: 7687
         - containerPort: 7474
+        # Readiness only, on Bolt — deliberately NO livenessProbe. A database that is busy with
+        # recovery or a long GC pause is not a database that should be killed and restarted, which
+        # is precisely what a liveness probe would do at the worst possible moment.
+        #
+        # This is also what makes the backend's `wait-db` initContainer honest: it polls the same
+        # port, so "the service has endpoints" and "the backend can proceed" now mean the same
+        # thing. It still only proves the listener is up, not that Neo4j finished building indexes
+        # — a Cypher `RETURN 1` would, and needs credentials this probe does not have.
+        readinessProbe:
+          tcpSocket:
+            port: 7687
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-neo4j-env

--- a/deployment/helm/charts/ocelot-neo4j/values.yaml
+++ b/deployment/helm/charts/ocelot-neo4j/values.yaml
@@ -2,6 +2,11 @@ underMaintenance: false
 
 global:
   image:
+    # Same default as the ocelot-social chart. Without it the templates rendered
+    # `imagePullPolicy: ""` and left the choice to the API server's defaulting rules — which pick
+    # `Always` for a `:latest` tag and `IfNotPresent` otherwise, i.e. silently something else than
+    # the sibling chart does.
+    pullPolicy: IfNotPresent
     tag:
 
 # Credentials for pulling images from private registries — see the identically named block in the

--- a/deployment/helm/charts/ocelot-social/templates/backend/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/backend/deployment.yaml
@@ -30,6 +30,14 @@ spec:
       app: {{ .Release.Name }}-backend
   template:
     metadata:
+      annotations:
+        # Config reaches the pod through `envFrom`, which Kubernetes resolves ONCE at container
+        # start. Changing a value therefore updates the ConfigMap but leaves this pod template
+        # byte-identical, Helm sees no diff, and the running pod keeps the old value until something
+        # unrelated happens to restart it. Hashing the rendered manifests in here makes the change
+        # visible to Helm and turns it into a rollout.
+        checksum/config: {{ include (print $.Template.BasePath "/backend/configmap.yml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/backend/secret.yaml") . | sha256sum }}
       labels:
         app: {{ .Release.Name }}-backend
     spec:
@@ -122,6 +130,10 @@ spec:
           ports:
           - containerPort: 4000
             protocol: TCP
+          # No preStop sleep here, unlike webapp and imagor. Those surge: a second pod is already
+          # serving while the old one drains, so sleeping through the endpoint-removal window buys
+          # real requests. With `maxSurge: 0` there is no such pod — the sleep would only lengthen
+          # the gap it is meant to hide. Add one together with the surge, not before.
           # tcpSocket rather than httpGet because the backend has no health endpoint yet. It only
           # proves the listener is up, not that Neo4j is reachable — replace with httpGet on a real
           # /healthz once one exists.

--- a/deployment/helm/charts/ocelot-social/templates/configmap.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}
-data:
-{{ .Values.configmap | toYaml | indent 2 }}

--- a/deployment/helm/charts/ocelot-social/templates/imagor/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/imagor/deployment.yaml
@@ -9,6 +9,11 @@ spec:
       app: {{ .Release.Name }}-imagor
   template:
     metadata:
+      annotations:
+        # See the backend deployment: `envFrom` is resolved once at container start. imagor takes
+        # its S3 credentials and signing key this way, so without this a rotated key would sit in
+        # the Secret while the running pod keeps signing with the old one.
+        checksum/secret: {{ include (print $.Template.BasePath "/imagor/secret.yaml") . | sha256sum }}
       labels:
         app: {{ .Release.Name }}-imagor
     spec:
@@ -19,8 +24,26 @@ spec:
         image: "{{ .Values.imagor.image.repository }}:{{ .Values.imagor.image.tag | default (include "defaultTag" .)  }}"
         imagePullPolicy: {{ quote .Values.global.image.pullPolicy }}
         {{- include "resources" .Values.imagor.resources | indent 8 }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
         ports:
         - containerPort: 8000
+        # tcpSocket, not httpGet: imagor documents a `/healthcheck` endpoint, but this chart pins a
+        # third-party image and a probe pointing at a path that does not exist would keep every pod
+        # permanently un-Ready — i.e. break image serving outright. Switch to
+        # `httpGet: /healthcheck` once it has been confirmed against the pinned tag.
+        readinessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 20
         env:
         - name: S3_FORCE_PATH_STYLE
           value: "1"

--- a/deployment/helm/charts/ocelot-social/templates/ingress.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/ingress.yaml
@@ -1,4 +1,3 @@
----
 {{- define "joinRedirectMiddlewares" -}}
 {{- $local := dict "first" true -}}
 {{- range $k, $v := .Values.redirect_domains -}}{{- if not $local.first -}},{{- end -}}{{$.Release.Namespace}}-redirect-{{- $v | replace "." "-" -}}@kubernetescrd{{- $_ := set $local "first" false -}}{{- end -}}

--- a/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
@@ -35,3 +35,20 @@ spec:
           {{- end }}
         ports:
           - containerPort: 8080
+        # httpGet here, unlike the other workloads: this is nginx serving a static page, so a real
+        # request is cheap and proves more than an open socket — namely that the entrypoint has
+        # finished substituting SUPPORT_EMAIL into the built files. No checksum/* annotation is
+        # needed either, because this deployment's env is inline in the template rather than in a
+        # ConfigMap: changing it already changes the pod template.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20

--- a/deployment/helm/charts/ocelot-social/templates/webapp/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/webapp/deployment.yaml
@@ -9,6 +9,11 @@ spec:
       app: {{ .Release.Name }}-webapp
   template:
     metadata:
+      annotations:
+        # See the backend deployment: `envFrom` is resolved once at container start, so without
+        # these hashes a pure config change never reaches a running pod.
+        checksum/config: {{ include (print $.Template.BasePath "/webapp/configmap.yml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/webapp/secret.yaml") . | sha256sum }}
       labels:
         app: {{ .Release.Name }}-webapp
     spec:
@@ -19,8 +24,30 @@ spec:
         image: "{{ .Values.webapp.image.repository }}:{{ .Values.webapp.image.tag | default (include "defaultTag" .)  }}"
         imagePullPolicy: {{ quote .Values.global.image.pullPolicy }}
         {{- include "resources" .Values.webapp.resources | indent 8 }}
+        lifecycle:
+          # Endpoint removal and SIGTERM reach the pod at the same time, so Traefik can still route
+          # here for a moment after Nuxt has begun shutting down. Sleeping through that window is
+          # the whole job of this hook — the container keeps serving normally while it runs.
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
         ports:
         - containerPort: 3000
+        # Without a readinessProbe a pod counts as Ready the moment its container starts, which for
+        # Nuxt is seconds before it listens — Traefik then routes into a 502 for the whole surge
+        # window of every rollout. tcpSocket rather than httpGet on `/`: Nuxt opens the port only
+        # once the server is up, so it answers the question, and probing `/` would put a full SSR
+        # render into the single-threaded event loop every few seconds for no gain.
+        readinessProbe:
+          tcpSocket:
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          tcpSocket:
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 20
         env:
         - name: WEBSOCKETS_URI
           value: "wss://{{ .Values.domain }}/api/graphql"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

kubernetes ready-probes & protect data claims

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Verbesserungen**
  * Konfigurations- und Secret-Änderungen lösen automatisch Neustarts der betroffenen Pods aus.
  * Readiness- und Liveness-Prüfungen verbessern die Erkennung verfügbarer und fehlerhafter Dienste.
  * Geordnete Beendigungen und verlängerte Fristen erhöhen die Stabilität bei Aktualisierungen.
  * Neo4j-Daten- und Backup-Speicher bleiben bei Helm-Deinstallationen oder Umbenennungen erhalten.
  * Die Bildabrufrichtlinie reduziert unnötige Downloads vorhandener Container-Images.
  * Die Dokumentation beschreibt Rollout-Verhalten, Zero-Downtime-Einschränkungen und geschützte Speicherressourcen präziser.

* **Aufräumarbeiten**
  * Nicht mehr benötigte Konfigurationsausgaben und ein überflüssiger YAML-Trenner wurden entfernt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->