### PR TITLE
refactor(webapp): convert components A-G to plain CSS

### DIFF
--- a/webapp/components/AvatarMenu/AvatarMenu.vue
+++ b/webapp/components/AvatarMenu/AvatarMenu.vue
@@ -159,30 +159,30 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .avatar-menu {
-  margin: $space-xxx-small 0px 0px $space-xx-small;
+  margin: var(--space-xxx-small) 0px 0px var(--space-xx-small);
 }
 .avatar-menu-trigger {
   user-select: none;
   display: flex;
   align-items: center;
-  padding-left: $space-xx-small;
+  padding-left: var(--space-xx-small);
 
   > .profile-avatar {
-    margin-right: $space-xx-small;
+    margin-right: var(--space-xx-small);
   }
 }
 .avatar-menu-popover {
-  padding-top: $space-x-small;
-  padding-bottom: $space-x-small;
+  padding-top: var(--space-x-small);
+  padding-bottom: var(--space-x-small);
   hr {
-    color: $color-neutral-90;
-    background-color: $color-neutral-90;
+    color: var(--color-neutral-90);
+    background-color: var(--color-neutral-90);
   }
   .logout-link {
-    color: $text-color-danger;
-    padding-top: $space-xx-small;
+    color: var(--text-color-danger);
+    padding-top: var(--space-xx-small);
     &:hover {
       color: color-mix(in srgb, var(--color-danger), black 10%);
     }

--- a/webapp/components/BadgeSelection.vue
+++ b/webapp/components/BadgeSelection.vue
@@ -97,7 +97,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .badge-selection {
   width: 100%;
   max-width: 600px;
@@ -109,7 +109,7 @@ export default {
     background-color 0.2s ease;
 
   &.reserve-drag-over {
-    border-color: $color-success;
+    border-color: var(--color-success);
     border-style: dashed;
     background-color: color-mix(in srgb, var(--color-success) 5%, transparent);
   }

--- a/webapp/components/Badges.vue
+++ b/webapp/components/Badges.vue
@@ -114,30 +114,30 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .hc-badges {
   position: relative;
 
   transform: scale(var(--badges-scale, 1));
 
-  $badge-size-x: 30px;
-  $badge-size-y: 26px;
-  $main-badge-size-x: 60px;
-  $main-badge-size-y: 52px;
-  $gap-x: -6px;
-  $gap-y: 1px;
-  $slot-x: $badge-size-x + $gap-x;
-  $slot-y: $badge-size-y + $gap-y;
-  $offset-y: calc($badge-size-y / 2) - 2 * $gap-x;
+  --badge-size-x: 30px;
+  --badge-size-y: 26px;
+  --main-badge-size-x: 60px;
+  --main-badge-size-y: 52px;
+  --gap-x: -6px;
+  --gap-y: 1px;
+  --slot-x: calc(var(--badge-size-x) + var(--gap-x));
+  --slot-y: calc(var(--badge-size-y) + var(--gap-y));
+  --offset-y: calc(calc(var(--badge-size-y) / 2) - 2 * var(--gap-x));
 
-  width: $main-badge-size-x + 4 * $badge-size-x + 4 * $gap-x;
-  height: $offset-y + 3 * $badge-size-y + 4 * $gap-y;
+  width: calc(var(--main-badge-size-x) + 4 * var(--badge-size-x) + 4 * var(--gap-x));
+  height: calc(var(--offset-y) + 3 * var(--badge-size-y) + 4 * var(--gap-y));
   margin: auto;
 
   .hc-badge-container {
     position: absolute;
-    width: $badge-size-x;
-    height: $badge-size-y;
+    width: var(--badge-size-x);
+    height: var(--badge-size-y);
 
     clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
 
@@ -154,7 +154,7 @@ export default {
     }
 
     &.selected {
-      filter: drop-shadow(0 0 0 $color-primary);
+      filter: drop-shadow(0 0 0 var(--color-primary));
       img {
         opacity: 0.6;
       }
@@ -165,7 +165,7 @@ export default {
     }
 
     &.drag-over {
-      filter: drop-shadow(0 0 4px $color-success);
+      filter: drop-shadow(0 0 4px var(--color-success));
       transform: scale(1.15);
       transition: transform 0.15s ease;
     }
@@ -178,9 +178,9 @@ export default {
   }
 
   .hc-badge-container:nth-child(1) {
-    width: $main-badge-size-x;
-    height: $main-badge-size-y;
-    top: $offset-y + calc($gap-y / 2) - 1px;
+    width: var(--main-badge-size-x);
+    height: var(--main-badge-size-y);
+    top: calc(var(--offset-y) + calc(var(--gap-y) / 2) - 1px);
     left: 0;
   }
 
@@ -198,48 +198,50 @@ export default {
   }
 
   .hc-badge-container:nth-child(2) {
-    top: $offset-y + calc(-1 * $gap-y / 2) - 1px;
-    left: $main-badge-size-x + $gap-x;
+    top: calc(var(--offset-y) + calc(-1 * var(--gap-y) / 2) - 1px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x));
   }
 
   .hc-badge-container:nth-child(3) {
-    top: $offset-y + $slot-y + calc($gap-y / 2) - 1px;
-    left: $main-badge-size-x + $gap-x;
+    top: calc(var(--offset-y) + var(--slot-y) + calc(var(--gap-y) / 2) - 1px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x));
   }
 
   .hc-badge-container:nth-child(4) {
-    top: $offset-y + calc(-1 * $badge-size-y / 2) - (2 * $gap-y) - 0.5px;
-    left: $main-badge-size-x + $gap-x + $slot-x;
+    top: calc(var(--offset-y) + calc(-1 * var(--badge-size-y) / 2) - (2 * var(--gap-y)) - 0.5px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x) + var(--slot-x));
   }
 
   .hc-badge-container:nth-child(5) {
-    top: $offset-y + calc($badge-size-y / 2) - 0.5px;
-    left: $main-badge-size-x + $gap-x + $slot-x;
+    top: calc(var(--offset-y) + calc(var(--badge-size-y) / 2) - 0.5px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x) + var(--slot-x));
   }
 
   .hc-badge-container:nth-child(6) {
-    top: $offset-y + (1.5 * $badge-size-y) + (2 * $gap-y) - 0.5px;
-    left: $main-badge-size-x + $gap-x + $slot-x;
+    top: calc(var(--offset-y) + (1.5 * var(--badge-size-y)) + (2 * var(--gap-y)) - 0.5px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x) + var(--slot-x));
   }
 
   .hc-badge-container:nth-child(7) {
-    top: $offset-y + calc(-1 * $gap-y / 2) - 1px;
-    left: $main-badge-size-x + $gap-x + (2 * $slot-x);
+    top: calc(var(--offset-y) + calc(-1 * var(--gap-y) / 2) - 1px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x) + (2 * var(--slot-x)));
   }
 
   .hc-badge-container:nth-child(8) {
-    top: $offset-y + $slot-y + calc($gap-y / 2) - 1px;
-    left: $main-badge-size-x + $gap-x + (2 * $slot-x);
+    top: calc(var(--offset-y) + var(--slot-y) + calc(var(--gap-y) / 2) - 1px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x) + (2 * var(--slot-x)));
   }
 
   .hc-badge-container:nth-child(9) {
-    top: $offset-y + $slot-y - calc($badge-size-y / 2) - $gap-y - 0.5px;
-    left: $main-badge-size-x + $gap-x + (3 * $slot-x);
+    top: calc(
+      var(--offset-y) + var(--slot-y) - calc(var(--badge-size-y) / 2) - var(--gap-y) - 0.5px
+    );
+    left: calc(var(--main-badge-size-x) + var(--gap-x) + (3 * var(--slot-x)));
   }
 
   .hc-badge-container:nth-child(10) {
-    top: $offset-y + ($badge-size-y * 1.5) + (2 * $gap-y) - 0.5px;
-    left: $main-badge-size-x + $gap-x + (3 * $slot-x);
+    top: calc(var(--offset-y) + (var(--badge-size-y) * 1.5) + (2 * var(--gap-y)) - 0.5px);
+    left: calc(var(--main-badge-size-x) + var(--gap-x) + (3 * var(--slot-x)));
   }
 }
 </style>

--- a/webapp/components/CategoriesSelect/CategoriesSelect.vue
+++ b/webapp/components/CategoriesSelect/CategoriesSelect.vue
@@ -85,14 +85,14 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .categories-select {
   display: flex;
   flex-wrap: wrap;
 
   > button {
-    margin-right: $space-xx-small;
-    margin-bottom: $space-xx-small;
+    margin-right: var(--space-xx-small);
+    margin-bottom: var(--space-xx-small);
   }
 }
 </style>

--- a/webapp/components/Category/index.vue
+++ b/webapp/components/Category/index.vue
@@ -25,18 +25,18 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .category-tag {
   &.language {
     float: right;
   }
 
   > .os-icon {
-    font-size: $font-size-base;
+    font-size: var(--font-size-base);
   }
 }
 .filterActive {
-  color: $color-primary-inverse;
-  background-color: $color-primary-active;
+  color: var(--color-primary-inverse);
+  background-color: var(--color-primary-highlight);
 }
 </style>

--- a/webapp/components/Chat/AddChatRoomByUserSearch.vue
+++ b/webapp/components/Chat/AddChatRoomByUserSearch.vue
@@ -180,10 +180,10 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .add-chat-room-by-user-search {
   background-color: white;
-  padding: $space-base;
+  padding: var(--space-base);
   scroll-margin-top: 7rem;
 }
 .ds-flex.headline {
@@ -198,14 +198,14 @@ export default {
   width: 100%;
 }
 .chat-search-result-info {
-  margin-left: $space-x-small;
+  margin-left: var(--space-x-small);
   display: flex;
   flex-direction: column;
   flex: 1;
   min-width: 0;
 }
 .chat-search-result-name {
-  font-weight: $font-weight-bold;
+  font-weight: var(--text-weight-bold);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -215,15 +215,15 @@ export default {
   margin-right: 0;
 }
 .chat-search-result-detail {
-  font-size: $font-size-small;
-  color: $text-color-soft;
+  font-size: var(--font-size-small);
+  color: var(--text-color-soft);
 }
 .chat-search-result-badge {
   margin-left: auto;
   flex-shrink: 0;
   white-space: nowrap;
-  // Tailwind @layer utilities have lower specificity than unlayered CSS,
-  // so we need to explicitly set the badge styles here.
+  /*  Tailwind @layer utilities have lower specificity than unlayered CSS, */
+  /*  so we need to explicitly set the badge styles here. */
   font-size: 0.75rem;
   padding: 0.2em 0.8em;
   border-radius: 2em;

--- a/webapp/components/Chat/Chat.vue
+++ b/webapp/components/Chat/Chat.vue
@@ -1179,7 +1179,7 @@ export default {
   },
 }
 </script>
-<style lang="scss" scoped>
+<style scoped>
 .vac-avatar-profile {
   margin-right: 15px;
 }
@@ -1225,11 +1225,11 @@ export default {
   min-width: 0;
   overflow: hidden;
 
-  // Match the video call header — RoomTitleLink defaults to font-weight: 500
-  // for in-chat usage, but the room header is a dialog-level heading and
-  // should read bold to mirror the call modal.
+  /*  Match the video call header — RoomTitleLink defaults to font-weight: 500 */
+  /*  for in-chat usage, but the room header is a dialog-level heading and */
+  /*  should read bold to mirror the call modal. */
   ::v-deep .room-title-link {
-    font-weight: $font-weight-bold;
+    font-weight: var(--text-weight-bold);
   }
 }
 
@@ -1245,7 +1245,7 @@ export default {
   white-space: nowrap !important;
 
   &:hover {
-    color: $color-primary !important;
+    color: var(--color-primary) !important;
   }
 }
 </style>

--- a/webapp/components/CommentCard/CommentCard.vue
+++ b/webapp/components/CommentCard/CommentCard.vue
@@ -247,11 +247,11 @@ export default {
   },
 }
 </script>
-<style lang="scss">
+<style>
 .comment-card {
   display: flex;
   flex-direction: column;
-  margin-bottom: $space-small;
+  margin-bottom: var(--space-small);
 
   &.--target {
     animation: highlight 4s ease;
@@ -260,27 +260,27 @@ export default {
   > .header {
     display: flex;
     justify-content: space-between;
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
   }
 }
 
 @keyframes highlight {
   0% {
-    border: $border-size-base solid $color-primary;
+    border: var(--border-size-base) solid var(--color-primary);
   }
   100% {
-    border: $border-size-base solid transparent;
+    border: var(--border-size-base) solid transparent;
   }
 }
 </style>
 
-<style lang="scss" scoped>
+<style scoped>
 .actions {
-  margin-top: $space-x-small;
+  margin-top: var(--space-x-small);
   display: flex;
   align-items: center;
   justify-content: right;
-  gap: calc($space-base * 0.5);
+  gap: calc(var(--space-base) * 0.5);
 }
 
 .shout-button {

--- a/webapp/components/CommentForm/CommentForm.vue
+++ b/webapp/components/CommentForm/CommentForm.vue
@@ -165,10 +165,10 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .comment-form {
   .editor {
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
   }
 
   .buttons {
@@ -176,7 +176,7 @@ export default {
     justify-content: flex-end;
 
     > button {
-      margin-left: $space-x-small;
+      margin-left: var(--space-x-small);
     }
   }
 }

--- a/webapp/components/CommentList/CommentList.vue
+++ b/webapp/components/CommentList/CommentList.vue
@@ -68,13 +68,13 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .comment-list {
   > .title {
     margin-top: 0;
 
     > .os-counter-icon {
-      margin-right: $space-small;
+      margin-right: var(--space-small);
     }
   }
 }

--- a/webapp/components/ComponentSlider/ComponentSlider.vue
+++ b/webapp/components/ComponentSlider/ComponentSlider.vue
@@ -108,19 +108,20 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .Sliders {
-  &__slider-selection {
-    .selection-dot {
-      margin-right: 2px;
-      height: 18px !important;
-      width: 18px !important;
-      min-height: 18px !important;
-      min-width: 18px !important;
-    }
-    &.--unconfirmed {
-      opacity: $opacity-disabled;
-    }
+}
+
+.Sliders__slider-selection {
+  .selection-dot {
+    margin-right: 2px;
+    height: 18px !important;
+    width: 18px !important;
+    min-height: 18px !important;
+    min-width: 18px !important;
+  }
+  &.--unconfirmed {
+    opacity: var(--opacity-disabled);
   }
 }
 </style>

--- a/webapp/components/ConflictBanner.vue
+++ b/webapp/components/ConflictBanner.vue
@@ -44,27 +44,28 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-// Margin is deliberately omitted — each parent sets its own outer spacing (via a class on
-// the component root) so the tabs keep their own vertical rhythm.
+<style scoped>
+/*  Margin is deliberately omitted — each parent sets its own outer spacing (via a class on */
+/*  the component root) so the tabs keep their own vertical rhythm. */
 .conflict-banner {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: $space-x-small;
-  padding: $space-x-small $space-small;
-  border-radius: $border-radius-base;
-  border-left: 3px solid $color-warning;
+  gap: var(--space-x-small);
+  padding: var(--space-x-small) var(--space-small);
+  border-radius: var(--border-radius-base);
+  border-left: 3px solid var(--color-warning);
   background: color-mix(in srgb, var(--color-warning) 14%, transparent);
   font-size: 0.9em;
+}
 
-  &__text {
-    flex: 1 1 16rem;
-  }
-  &__actions {
-    display: inline-flex;
-    gap: $space-x-small;
-  }
+.conflict-banner__text {
+  flex: 1 1 16rem;
+}
+
+.conflict-banner__actions {
+  display: inline-flex;
+  gap: var(--space-x-small);
 }
 </style>

--- a/webapp/components/ContentMenu/ContentMenu.vue
+++ b/webapp/components/ContentMenu/ContentMenu.vue
@@ -424,8 +424,8 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .tooltip-inner.popover-inner .os-menu {
-  margin: (-$space-xx-small) (-$space-small) !important;
+  margin: calc(-1 * var(--space-xx-small)) calc(-1 * var(--space-small)) !important;
 }
 </style>

--- a/webapp/components/ContentMenu/GroupContentMenu.vue
+++ b/webapp/components/ContentMenu/GroupContentMenu.vue
@@ -176,8 +176,8 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .tooltip-inner.popover-inner .os-menu {
-  margin: (-$space-xx-small) (-$space-small) !important;
+  margin: calc(-1 * var(--space-xx-small)) calc(-1 * var(--space-small)) !important;
 }
 </style>

--- a/webapp/components/ContributionForm/ContributionForm.vue
+++ b/webapp/components/ContributionForm/ContributionForm.vue
@@ -251,7 +251,7 @@ import ImageUploader from '~/components/Uploader/ImageUploader'
 import links from '~/constants/links.js'
 import PageParamsLink from '~/components/_new/features/PageParamsLink/PageParamsLink.vue'
 import DatePicker from 'vue2-datepicker'
-import 'vue2-datepicker/scss/index.scss'
+import 'vue2-datepicker/index.css'
 import GetCategories from '~/mixins/getCategoriesMixin.js'
 import formValidation from '~/mixins/formValidation'
 import OcelotInput from '~/components/OcelotInput/OcelotInput.vue'
@@ -648,13 +648,13 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .eventData {
   .event-date-hints-zone {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: $space-small;
-    margin-bottom: $space-x-small;
+    gap: var(--space-small);
+    margin-bottom: var(--space-x-small);
   }
 
   .chipbox {
@@ -669,11 +669,11 @@ export default {
   .event-location-grid {
     grid-template-columns: repeat(2, 1fr);
     grid-auto-rows: auto;
-    gap: $space-small;
+    gap: var(--space-small);
   }
 
   .event-online-checkbox {
-    margin-top: $space-x-small;
+    margin-top: var(--space-x-small);
   }
 
   .event-grid-item {
@@ -697,7 +697,7 @@ export default {
 
   > .os-card__hero-image {
     position: relative;
-    max-height: $size-image-max-height;
+    max-height: var(--size-image-max-height);
     overflow: hidden;
 
     > .image {
@@ -707,7 +707,7 @@ export default {
   }
 
   .image.--blur-image {
-    filter: blur($blur-radius);
+    filter: blur(var(--blur-radius));
   }
 
   > .os-card__content {
@@ -720,13 +720,13 @@ export default {
 
     > .os-badge {
       align-self: flex-end;
-      margin: $space-xx-small 0 $space-base;
+      margin: var(--space-xx-small) 0 var(--space-base);
       cursor: default;
     }
 
     > .os-validation-hint {
       align-self: flex-end;
-      margin-bottom: $space-base;
+      margin-bottom: var(--space-base);
       cursor: default;
     }
 
@@ -738,7 +738,7 @@ export default {
       justify-content: flex-end;
       align-self: flex-end;
       width: 100%;
-      margin-top: $space-base;
+      margin-top: var(--space-base);
 
       > .action-buttons-group {
         margin-left: auto;
@@ -753,7 +753,7 @@ export default {
 
       > .buttons-footer-helper {
         margin-right: 16px;
-        // important needed because of component inline style
+        /*  important needed because of component inline style */
         margin-bottom: 6px !important;
       }
     }
@@ -761,7 +761,7 @@ export default {
 
   .blur-toggle {
     text-align: right;
-    margin-bottom: $space-base;
+    margin-bottom: var(--space-base);
 
     > .link {
       display: block;
@@ -800,19 +800,19 @@ export default {
     font-size: 1rem;
     height: calc(1.625rem + 18px);
     padding: 8px 8px;
-    background-color: $background-color-soft;
-    border-color: $border-color-softer;
-    color: $text-color-base;
+    background-color: var(--background-color-soft);
+    border-color: var(--border-color-softer);
+    color: var(--text-color-base);
   }
   .mx-datepicker input:hover {
-    border-color: $border-color-softer;
+    border-color: var(--border-color-softer);
   }
   .mx-datepicker input:focus {
-    border-color: $border-color-active;
-    background-color: $background-color-base;
+    border-color: var(--border-color-active);
+    background-color: var(--background-color-base);
   }
   .mx-datepicker-error input {
-    border-color: $color-danger;
+    border-color: var(--color-danger);
   }
 }
 </style>

--- a/webapp/components/CustomButton/CustomButton.vue
+++ b/webapp/components/CustomButton/CustomButton.vue
@@ -50,7 +50,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .custom-button {
   margin-left: 4px;
   margin-right: 4px;

--- a/webapp/components/DateTimeRange/DateTimeRange.vue
+++ b/webapp/components/DateTimeRange/DateTimeRange.vue
@@ -96,7 +96,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .date-time-range {
   display: flex;
   flex-direction: column;

--- a/webapp/components/DeleteData/DeleteData.vue
+++ b/webapp/components/DeleteData/DeleteData.vue
@@ -141,42 +141,42 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .delete-data {
   display: flex;
   flex-direction: column;
 
   > .title > .os-icon {
-    color: $color-danger;
+    color: var(--color-danger);
   }
 
   > .ds-form-item {
     align-self: flex-start;
-    margin-top: $space-xxx-small;
+    margin-top: var(--space-xxx-small);
   }
 
   > .notice {
-    font-weight: $font-weight-bold;
-    margin-bottom: $space-small;
+    font-weight: var(--text-weight-bold);
+    margin-bottom: var(--space-small);
   }
 
   > .checkbox {
-    margin-left: $space-base;
-    margin-bottom: $space-x-small;
+    margin-left: var(--space-base);
+    margin-bottom: var(--space-x-small);
 
     &:last-of-type {
-      margin-bottom: $space-small;
+      margin-bottom: var(--space-small);
     }
   }
 
   > .warning {
-    padding: $space-large;
-    margin-bottom: $space-small;
-    border-radius: $border-radius-base;
+    padding: var(--space-large);
+    margin-bottom: var(--space-small);
+    border-radius: var(--border-radius-base);
 
-    color: $color-danger;
-    background-color: $color-danger-inverse;
-    border-left: 4px solid $color-danger;
+    color: var(--color-danger);
+    background-color: var(--color-danger-inverse);
+    border-left: 4px solid var(--color-danger);
   }
 
   > button {

--- a/webapp/components/DonationInfo/DonationInfo.vue
+++ b/webapp/components/DonationInfo/DonationInfo.vue
@@ -49,19 +49,19 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .donation-info {
   display: flex;
   flex: 1;
-  margin-bottom: $space-x-small;
+  margin-bottom: var(--space-x-small);
   margin-top: 16px;
   cursor: pointer;
-  color: $text-color-base;
+  color: var(--text-color-base);
   text-decoration: none !important;
 
   &:hover {
     text-decoration: none !important;
-    color: $text-color-base !important;
+    color: var(--text-color-base) !important;
   }
 
   .os-button {

--- a/webapp/components/DropdownFilter/DropdownFilter.vue
+++ b/webapp/components/DropdownFilter/DropdownFilter.vue
@@ -56,17 +56,17 @@ export default {
   },
 }
 </script>
-<style lang="scss">
+<style>
 .dropdown-filter {
   user-select: none;
   display: flex;
   align-items: center;
   height: 100%;
-  padding: $space-xx-small;
-  color: $text-color-soft;
+  padding: var(--space-xx-small);
+  color: var(--text-color-soft);
 
   > .label {
-    margin: 0 $space-xx-small;
+    margin: 0 var(--space-xx-small);
   }
 }
 
@@ -75,14 +75,14 @@ export default {
   display: flex;
   align-items: center;
   height: 100%;
-  padding: $space-xx-small;
-  color: $text-color-soft;
+  padding: var(--space-xx-small);
+  color: var(--text-color-soft);
 }
 
 .dropdown-menu-popover {
   a {
-    padding: $space-x-small $space-small;
-    padding-right: $space-base;
+    padding: var(--space-x-small) var(--space-small);
+    padding-right: var(--space-base);
   }
 }
 </style>

--- a/webapp/components/Editor/ContentViewer.vue
+++ b/webapp/components/Editor/ContentViewer.vue
@@ -39,7 +39,7 @@ export default {
   },
 }
 </script>
-<style lang="scss">
+<style>
 .ProseMirror h3,
 .ProseMirror h4,
 .ProseMirror hr {

--- a/webapp/components/Editor/ContextMenu.vue
+++ b/webapp/components/Editor/ContextMenu.vue
@@ -64,32 +64,32 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .tippy-tooltip.ocelot-social-theme {
-  background-color: $color-primary;
+  background-color: var(--color-primary);
   padding: 0;
   font-size: 1rem;
   text-align: inherit;
-  color: $color-neutral-100;
+  color: var(--color-neutral-100);
 
   .tippy-backdrop {
     display: none;
   }
 
   .tippy-roundarrow {
-    fill: $color-primary;
+    fill: var(--color-primary);
   }
   .tippy-popper[x-placement^='top'] & .tippy-arrow {
-    border-top-color: $color-primary;
+    border-top-color: var(--color-primary);
   }
   .tippy-popper[x-placement^='bottom'] & .tippy-arrow {
-    border-bottom-color: $color-primary;
+    border-bottom-color: var(--color-primary);
   }
   .tippy-popper[x-placement^='left'] & .tippy-arrow {
-    border-left-color: $color-primary;
+    border-left-color: var(--color-primary);
   }
   .tippy-popper[x-placement^='right'] & .tippy-arrow {
-    border-right-color: $color-primary;
+    border-right-color: var(--color-primary);
   }
 }
 </style>

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -307,12 +307,12 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .editor p.is-empty:first-child::before {
   content: attr(data-empty-text);
   float: left;
-  color: $text-color-disabled;
-  padding-left: $space-xx-small;
+  color: var(--text-color-disabled);
+  padding-left: var(--space-xx-small);
   pointer-events: none;
   height: 0;
 }
@@ -322,8 +322,8 @@ export default {
 }
 
 li > p {
-  margin-top: $space-xx-small;
-  margin-bottom: $space-xx-small;
+  margin-top: var(--space-xx-small);
+  margin-bottom: var(--space-xx-small);
 }
 
 .editor {
@@ -331,24 +331,24 @@ li > p {
   flex-direction: column;
 
   .hashtag {
-    color: $color-primary;
+    color: var(--color-primary);
   }
   .hashtag-suggestion {
-    color: $color-primary;
+    color: var(--color-primary);
   }
   .mention-suggestion {
-    color: $color-primary;
+    color: var(--color-primary);
   }
 }
 
 .editor-content {
   flex-grow: 1;
-  margin-top: $space-small;
+  margin-top: var(--space-small);
   height: auto;
 
   &:focus-within {
-    border-color: $color-primary;
-    background-color: $color-neutral-100;
+    border-color: var(--color-primary);
+    background-color: var(--color-neutral-100);
   }
 }
 
@@ -360,46 +360,46 @@ li > p {
   }
 
   p {
-    margin: 0 0 $space-x-small;
+    margin: 0 0 var(--space-x-small);
   }
 
   ul {
-    padding-left: $space-x-large;
+    padding-left: var(--space-x-large);
 
     li {
       display: block;
-      text-indent: -$space-large;
+      text-indent: calc(-1 * var(--space-large));
 
       p:first-child:before {
         content: '•';
-        padding: $space-none $space-x-small;
-        margin-right: $space-x-small;
+        padding: var(--space-none) var(--space-x-small);
+        margin-right: var(--space-x-small);
       }
 
       p:not(:first-child) {
-        padding-left: $space-base;
+        padding-left: var(--space-base);
       }
     }
   }
 
   ol {
-    // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
+    /*  https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters */
     counter-reset: item;
-    padding-left: $space-x-large + 4px;
+    padding-left: calc(var(--space-x-large) + 4px);
 
     li {
       display: block;
-      text-indent: -$space-large - 4px;
+      text-indent: calc(-1 * var(--space-large) - 4px);
 
       p:first-child:before {
         content: counters(item, '.') '.';
         counter-increment: item;
-        padding: $space-none $space-x-small;
-        margin-right: $space-x-small;
+        padding: var(--space-none) var(--space-x-small);
+        margin-right: var(--space-x-small);
       }
 
       p:not(:first-child) {
-        padding-left: $space-base;
+        padding-left: var(--space-base);
       }
     }
   }

--- a/webapp/components/Editor/MenuBar.vue
+++ b/webapp/components/Editor/MenuBar.vue
@@ -168,7 +168,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .legend-button {
   display: inline;
   position: relative;

--- a/webapp/components/Editor/MenuLegend.vue
+++ b/webapp/components/Editor/MenuLegend.vue
@@ -78,7 +78,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .legend-question-button {
   color: #70677e !important;
   font-size: 1.2rem !important;

--- a/webapp/components/Editor/SuggestionList.vue
+++ b/webapp/components/Editor/SuggestionList.vue
@@ -63,12 +63,12 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .suggestion-list {
   list-style-type: none;
   padding: 0.2rem;
   border-radius: 5px;
-  border: 2px solid $color-primary;
+  border: 2px solid var(--color-primary);
   font-size: 0.8rem;
   font-weight: bold;
 }
@@ -85,11 +85,12 @@ export default {
 
   &.is-selected,
   &:hover {
-    background-color: rgba($color-neutral-100, 0.3);
+    /*  color-mix, not rgba(): var(--color-neutral-100) is a var() and Sass cannot decompose one. */
+    background-color: color-mix(in srgb, var(--color-neutral-100) 30%, transparent);
   }
 
   &.hint {
-    opacity: $opacity-soft;
+    opacity: var(--opacity-soft);
     pointer-events: none;
   }
 }

--- a/webapp/components/Embed/EmbedComponent.vue
+++ b/webapp/components/Embed/EmbedComponent.vue
@@ -178,44 +178,44 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .embed-component {
   position: relative;
   padding: 0;
-  margin: $space-small auto;
+  margin: var(--space-small) auto;
   overflow: hidden;
-  border-radius: $border-radius-base;
-  border: 1px solid $color-neutral-70;
-  background-color: $color-neutral-90;
+  border-radius: var(--border-radius-base);
+  border: 1px solid var(--color-neutral-70);
+  background-color: var(--color-neutral-90);
 
   > .content {
     width: 100%;
     height: 100%;
 
     h4 {
-      margin: $space-small 0 0 $space-small;
+      margin: var(--space-small) 0 0 var(--space-small);
     }
 
     p,
     a {
       display: block;
-      margin: 0 0 0 $space-small;
+      margin: 0 0 0 var(--space-small);
     }
 
     .html {
-      // width: 100%;
-      // height: 100%;
+      /*  width: 100%; */
+      /*  height: 100%; */
 
-      // see this working solution here: https://stackoverflow.com/questions/35814653/automatic-height-when-embedding-a-youtube-video
+      /*  see this working solution here: https://stackoverflow.com/questions/35814653/automatic-height-when-embedding-a-youtube-video */
       position: relative;
       padding-bottom: 56.25%; /* 16:9 */
       height: 0;
 
       iframe {
-        // width: 100%;
-        // height: auto;
+        /*  width: 100%; */
+        /*  height: auto; */
 
-        // same solution example as above
+        /*  same solution example as above */
         position: absolute;
         top: 0;
         left: 0;
@@ -242,12 +242,12 @@ export default {
     left: 0;
     right: 0;
 
-    padding: $space-large;
-    background-color: $color-neutral-100;
+    padding: var(--space-large);
+    background-color: var(--color-neutral-100);
 
     > .buttons {
       button {
-        margin-right: $space-small;
+        margin-right: var(--space-small);
       }
     }
 
@@ -255,15 +255,15 @@ export default {
       display: flex;
 
       input {
-        margin-right: $space-small;
+        margin-right: var(--space-small);
       }
     }
   }
 
   > .close-button {
     position: absolute !important;
-    top: $space-x-small !important;
-    right: $space-x-small !important;
+    top: var(--space-x-small) !important;
+    right: var(--space-x-small) !important;
   }
 }
 

--- a/webapp/components/Empty/CallToAction/CtaJoinLeaveGroup.vue
+++ b/webapp/components/Empty/CallToAction/CtaJoinLeaveGroup.vue
@@ -57,7 +57,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .join-leave-button {
   width: auto;
   margin: auto !important;

--- a/webapp/components/Empty/Empty.vue
+++ b/webapp/components/Empty/Empty.vue
@@ -57,8 +57,8 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .hc-empty-icon {
-  padding-bottom: $font-space-large;
+  padding-bottom: var(--font-space-large);
 }
 </style>

--- a/webapp/components/EnterNonce/EnterNonce.vue
+++ b/webapp/components/EnterNonce/EnterNonce.vue
@@ -77,10 +77,10 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .enter-nonce {
   display: flex;
   flex-direction: column;
-  margin: $space-large 0 $space-xxx-small 0;
+  margin: var(--space-large) 0 var(--space-xxx-small) 0;
 }
 </style>

--- a/webapp/components/FilterMenu/CategoriesFilter.vue
+++ b/webapp/components/FilterMenu/CategoriesFilter.vue
@@ -79,13 +79,13 @@ export default {
   },
 }
 </script>
-<style lang="scss">
+<style>
 .category-filter-list {
-  margin-left: $space-xx-small;
+  margin-left: var(--space-xx-small);
 
   > button {
-    margin-right: $space-xx-small;
-    margin-bottom: $space-xx-small;
+    margin-right: var(--space-xx-small);
+    margin-bottom: var(--space-xx-small);
   }
 }
 </style>

--- a/webapp/components/FilterMenu/FilterMenuComponent.vue
+++ b/webapp/components/FilterMenu/FilterMenuComponent.vue
@@ -82,7 +82,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .filter-header {
   display: flex;
   justify-content: space-between;
@@ -91,11 +91,11 @@ export default {
   }
 }
 .filter-menu-options {
-  max-width: $size-max-width-filter-menu;
-  padding: $space-small $space-x-small;
+  max-width: var(--size-max-width-filter-menu);
+  padding: var(--space-small) var(--space-x-small);
 
   > .title {
-    font-size: $font-size-large;
+    font-size: var(--font-size-large);
   }
 }
 </style>

--- a/webapp/components/FilterMenu/FilterMenuSection.vue
+++ b/webapp/components/FilterMenu/FilterMenuSection.vue
@@ -32,48 +32,48 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .filter-menu-section {
   display: flex;
   flex-wrap: wrap;
-  margin-top: $space-small;
+  margin-top: var(--space-small);
 
   > .title {
     width: 100%;
-    margin-bottom: $space-small;
-    font-size: $font-size-base;
+    margin-bottom: var(--space-small);
+    font-size: var(--font-size-base);
   }
 
-  // > .sidebar {
-  //   display: flex;
-  //   flex-wrap: wrap;
-  //   flex-basis: 80%;
-  //   flex-grow: 1;
-  //   max-width: $size-width-filter-sidebar;
-  // }
+  /*  > .sidebar { */
+  /*    display: flex; */
+  /*    flex-wrap: wrap; */
+  /*    flex-basis: 80%; */
+  /*    flex-grow: 1; */
+  /*    max-width: var(--size-width-filter-sidebar); */
+  /*  } */
 
-  // > .divider {
-  //   // border-left: $border-size-base solid $border-color-soft;
-  //   margin: $space-small;
-  //   margin-left: 0;
-  //   border-top: $border-size-base solid $border-color-soft;
-  // }
+  /*  > .divider { */
+  /*    // border-left: var(--border-size-base) solid var(--border-color-soft); */
+  /*    margin: var(--space-small); */
+  /*    margin-left: 0; */
+  /*    border-top: var(--border-size-base) solid var(--border-color-soft); */
+  /*  } */
 
   > .filter-list {
     display: flex;
     flex-wrap: wrap;
     flex-basis: 100%;
     flex-grow: 1;
-    padding-left: $space-base;
+    padding-left: var(--space-base);
 
     > .item {
-      // width: 30%;
-      padding: 0 $space-xx-small;
-      margin-bottom: $space-small;
+      /*  width: 30%; */
+      padding: 0 var(--space-xx-small);
+      margin-bottom: var(--space-small);
       text-align: center;
 
       @media only screen and (min-width: 800px) {
-        // width: 15%;
+        /*  width: 15%; */
       }
     }
   }
@@ -81,14 +81,14 @@ export default {
   @media only screen and (max-width: 630px) {
     flex-direction: column;
 
-    // > .sidebar {
-    //   max-width: none;
-    // }
+    /*  > .sidebar { */
+    /*    max-width: none; */
+    /*  } */
 
-    // > .divider {
-    //   border-top: $border-size-base solid $border-color-soft;
-    //   margin: $space-small;
-    // }
+    /*  > .divider { */
+    /*    border-top: var(--border-size-base) solid var(--border-color-soft); */
+    /*    margin: var(--space-small); */
+    /*  } */
   }
 }
 </style>

--- a/webapp/components/FilterMenu/FollowingFilter.vue
+++ b/webapp/components/FilterMenu/FollowingFilter.vue
@@ -91,14 +91,14 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .follower-filter-list {
   display: flex;
-  margin-left: $space-xx-small;
+  margin-left: var(--space-xx-small);
 
   & button {
-    margin-right: $space-xx-small;
-    margin-bottom: $space-xx-small;
+    margin-right: var(--space-xx-small);
+    margin-bottom: var(--space-xx-small);
   }
 }
 </style>

--- a/webapp/components/FilterMenu/PostTypeFilter.vue
+++ b/webapp/components/FilterMenu/PostTypeFilter.vue
@@ -66,7 +66,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .post-type-filter {
   & .item {
     min-width: 80px;

--- a/webapp/components/Group/AddGroupMember.vue
+++ b/webapp/components/Group/AddGroupMember.vue
@@ -110,9 +110,9 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .add-group-member {
   background-color: white;
-  padding: $space-base;
+  padding: var(--space-base);
 }
 </style>

--- a/webapp/components/Group/GroupForm.vue
+++ b/webapp/components/Group/GroupForm.vue
@@ -429,7 +429,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .appearance--auto {
   -webkit-appearance: auto;
   -moz-appearance: auto;
@@ -455,9 +455,9 @@ export default {
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: $space-x-small;
-    margin-top: -$space-base - $space-x-small;
-    margin-bottom: $space-x-large;
+    gap: var(--space-x-small);
+    margin-top: calc(-1 * var(--space-base) - var(--space-x-small));
+    margin-bottom: var(--space-x-large);
 
     label.is-disabled {
       opacity: 0.5;
@@ -470,7 +470,7 @@ export default {
 
   > .os-badge {
     align-self: flex-end;
-    margin: $space-xx-small 0 $space-base;
+    margin: var(--space-xx-small) 0 var(--space-base);
     cursor: default;
   }
 
@@ -480,7 +480,7 @@ export default {
 
     > .os-badge {
       align-self: flex-end;
-      margin: $space-xx-small 0 $space-base;
+      margin: var(--space-xx-small) 0 var(--space-base);
       cursor: default;
     }
   }
@@ -491,11 +491,11 @@ export default {
 
   > .buttons {
     align-self: flex-end;
-    margin-top: $space-base;
+    margin-top: var(--space-base);
   }
 
   > .location-hint {
-    margin-top: -$space-base + $space-xxx-small;
+    margin-top: calc(-1 * var(--space-base) + var(--space-xxx-small));
   }
 }
 </style>

--- a/webapp/components/Group/GroupList.vue
+++ b/webapp/components/Group/GroupList.vue
@@ -19,12 +19,12 @@ export default {
   },
 }
 </script>
-<style lang="scss" scoped>
+<style scoped>
 .group-list__item {
   flex: 0 0 98%;
   width: 98%;
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .group-list__item {
     flex: 0 0 48%;
     width: 48%;

--- a/webapp/components/Group/GroupTeaser.vue
+++ b/webapp/components/Group/GroupTeaser.vue
@@ -124,14 +124,14 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .group-teaser,
 .group-teaser:hover,
 .group-teaser:active {
   position: relative;
   display: block;
   height: 100%;
-  color: $text-color-base;
+  color: var(--text-color-base);
 
   > .ribbon {
     position: absolute;
@@ -151,16 +151,16 @@ export default {
 
   > .slug-location {
     display: flex;
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
 
     > .location-item {
-      margin-left: $space-small;
+      margin-left: var(--space-small);
     }
   }
 
   > .content {
     flex-grow: 1;
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
   }
 
   > .footer {
@@ -173,10 +173,10 @@ export default {
     }
 
     > .labeled-chip {
-      margin-top: $space-xx-small;
+      margin-top: var(--space-xx-small);
 
       > .chip {
-        margin-top: -$space-small + $space-x-small;
+        margin-top: calc(-1 * var(--space-small) + var(--space-x-small));
       }
     }
 
@@ -186,7 +186,7 @@ export default {
   }
 
   .user-teaser {
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
   }
 }
 </style>

--- a/webapp/components/GroupTeaser/GroupTeaser.vue
+++ b/webapp/components/GroupTeaser/GroupTeaser.vue
@@ -48,7 +48,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .group-teaser {
   display: flex;
   align-items: center;
@@ -65,22 +65,22 @@ export default {
     > span {
       display: flex !important;
       align-items: center;
-      gap: $space-x-small;
+      gap: var(--space-x-small);
       min-width: 0;
       overflow: hidden;
     }
   }
+}
 
-  &__avatar {
-    flex-shrink: 0;
-  }
+.group-teaser__avatar {
+  flex-shrink: 0;
+}
 
-  &__name {
-    font-size: $font-size-base;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: $text-color-soft;
-  }
+.group-teaser__name {
+  font-size: var(--font-size-base);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-color-soft);
 }
 </style>

--- a/webapp/components/features/FiledReportsTable/FiledReportsTable.vue
+++ b/webapp/components/features/FiledReportsTable/FiledReportsTable.vue
@@ -64,10 +64,10 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .nested-table {
-  padding: $space-small;
-  border-top: $border-size-base solid $color-neutral-60;
-  border-bottom: $border-size-base solid $color-neutral-60;
+  padding: var(--space-small);
+  border-top: var(--border-size-base) solid var(--color-neutral-60);
+  border-bottom: var(--border-size-base) solid var(--color-neutral-60);
 }
 </style>

--- a/webapp/components/features/ProfileList/FollowList.vue
+++ b/webapp/components/features/ProfileList/FollowList.vue
@@ -151,18 +151,18 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .connections {
   list-style: none;
   padding: 0;
   margin: 0;
+}
 
-  &__item {
-    padding: $space-xx-small;
+.connections__item {
+  padding: var(--space-xx-small);
 
-    &:hover {
-      background-color: $background-color-primary-inverse;
-    }
+  &:hover {
+    background-color: var(--background-color-primary-inverse);
   }
 }
 </style>

--- a/webapp/components/features/ProfileList/GroupMemberList.vue
+++ b/webapp/components/features/ProfileList/GroupMemberList.vue
@@ -223,15 +223,15 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .type-label {
-  font-size: $font-size-small;
-  color: $text-color-soft;
-  margin-bottom: $space-xx-small;
+  font-size: var(--font-size-small);
+  color: var(--text-color-soft);
+  margin-bottom: var(--space-xx-small);
+}
 
-  &--not-first {
-    margin-top: $space-small;
-  }
+.type-label--not-first {
+  margin-top: var(--space-small);
 }
 
 .group-list {
@@ -243,30 +243,30 @@ export default {
 .group-item {
   display: flex;
   align-items: center;
-  padding: $space-xx-small;
-  border-radius: $border-radius-base;
+  padding: var(--space-xx-small);
+  border-radius: var(--border-radius-base);
 
   &:hover {
-    background-color: $background-color-primary-inverse;
+    background-color: var(--background-color-primary-inverse);
   }
+}
 
-  &__teaser {
-    flex: 1;
-    min-width: 0;
-  }
+.group-item__teaser {
+  flex: 1;
+  min-width: 0;
+}
 
-  &__visibility-btn {
-    flex-shrink: 0;
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: $text-color-soft;
-    padding: $space-xx-small;
-    border-radius: $border-radius-base;
+.group-item__visibility-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-color-soft);
+  padding: var(--space-xx-small);
+  border-radius: var(--border-radius-base);
 
-    &:hover {
-      color: $text-color-base;
-    }
+  &:hover {
+    color: var(--text-color-base);
   }
 }
 </style>

--- a/webapp/components/features/ProfileList/GroupPageMemberList.vue
+++ b/webapp/components/features/ProfileList/GroupPageMemberList.vue
@@ -168,15 +168,15 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .role-label {
-  font-size: $font-size-small;
-  color: $text-color-soft;
-  margin-bottom: $space-xx-small;
+  font-size: var(--font-size-small);
+  color: var(--text-color-soft);
+  margin-bottom: var(--space-xx-small);
+}
 
-  &--not-first {
-    margin-top: $space-x-small;
-  }
+.role-label--not-first {
+  margin-top: var(--space-x-small);
 }
 
 .member-list {
@@ -186,15 +186,15 @@ export default {
 }
 
 .member-item {
-  padding: $space-xx-small;
-  border-radius: $border-radius-base;
+  padding: var(--space-xx-small);
+  border-radius: var(--border-radius-base);
 
   &:hover {
-    background-color: $background-color-primary-inverse;
+    background-color: var(--background-color-primary-inverse);
   }
+}
 
-  &__teaser {
-    width: 100%;
-  }
+.member-item__teaser {
+  width: 100%;
 }
 </style>

--- a/webapp/components/features/ProfileList/InfiniteScrollList.vue
+++ b/webapp/components/features/ProfileList/InfiniteScrollList.vue
@@ -125,7 +125,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .infinite-scroll-list {
   display: flex;
   flex-direction: column;
@@ -136,9 +136,9 @@ export default {
   }
 
   > .title {
-    color: $text-color-soft;
-    font-size: $font-size-base;
-    margin-bottom: $space-small;
+    color: var(--text-color-soft);
+    font-size: var(--font-size-base);
+    margin-bottom: var(--space-small);
 
     .count {
       font-weight: normal;
@@ -147,16 +147,16 @@ export default {
 }
 
 .subtitle {
-  font-size: $font-size-small;
-  color: $text-color-soft;
-  margin-top: -$space-x-small;
-  margin-bottom: $space-small;
+  font-size: var(--font-size-small);
+  color: var(--text-color-soft);
+  margin-top: calc(-1 * var(--space-x-small));
+  margin-bottom: var(--space-small);
 }
 
 .filter-wrap {
   flex-shrink: 0;
   position: relative;
-  margin-top: $space-small;
+  margin-top: var(--space-small);
 
   .filter-input {
     margin-top: 0;
@@ -165,14 +165,9 @@ export default {
 
   .filter-clear-wrap {
     position: absolute;
-    right: $space-xx-small;
+    right: var(--space-xx-small);
     top: 50%;
     transform: translateY(-50%);
-
-    &--hidden {
-      opacity: 0;
-      pointer-events: none;
-    }
 
     ::v-deep button {
       width: 20px !important;
@@ -185,6 +180,11 @@ export default {
         height: 10px !important;
       }
     }
+  }
+
+  .filter-clear-wrap--hidden {
+    opacity: 0;
+    pointer-events: none;
   }
 }
 
@@ -226,13 +226,13 @@ export default {
 
 .nobody-message {
   text-align: center;
-  color: $text-color-soft;
-  padding: $space-x-small 0;
+  color: var(--text-color-soft);
+  padding: var(--space-x-small) 0;
 }
 
 .loading-indicator {
   display: flex;
   justify-content: center;
-  padding: $space-x-small 0;
+  padding: var(--space-x-small) 0;
 }
 </style>

--- a/webapp/components/features/ProfileList/ProfileList.vue
+++ b/webapp/components/features/ProfileList/ProfileList.vue
@@ -196,7 +196,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .profile-list.os-card {
   display: flex;
   flex-direction: column;
@@ -204,13 +204,13 @@ export default {
   width: auto;
 
   > .title {
-    color: $text-color-soft;
-    font-size: $font-size-base;
+    color: var(--text-color-soft);
+    font-size: var(--font-size-base);
   }
 
   .profiles {
-    height: $size-height-connections;
-    padding: $space-none;
+    height: var(--size-height-connections);
+    padding: var(--space-none);
     list-style-type: none;
 
     &.--overflow {
@@ -218,48 +218,48 @@ export default {
     }
 
     > .connections__item {
-      padding: $space-xx-small;
+      padding: var(--space-xx-small);
 
       &.is-selected,
       &:hover {
-        background-color: $background-color-primary-inverse;
+        background-color: var(--background-color-primary-inverse);
       }
     }
   }
 
   .profiles-virtual {
-    height: $size-height-connections;
-    padding: $space-none;
+    height: var(--size-height-connections);
+    padding: var(--space-none);
 
     &.--overflow {
       overflow-y: auto;
     }
 
     .connections__item {
-      padding: $space-xx-small;
+      padding: var(--space-xx-small);
       height: 56px;
       display: flex;
       align-items: center;
 
       &:hover {
-        background-color: $background-color-primary-inverse;
+        background-color: var(--background-color-primary-inverse);
       }
     }
   }
 
   .nobody-message {
     text-align: center;
-    color: $text-color-soft;
+    color: var(--text-color-soft);
   }
 
   .loading-more {
     display: flex;
     justify-content: center;
-    padding: $space-x-small 0;
+    padding: var(--space-x-small) 0;
   }
 
   > :nth-child(n):not(:last-child) {
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
   }
 }
 

--- a/webapp/components/features/ReportList/ReportList.vue
+++ b/webapp/components/features/ReportList/ReportList.vue
@@ -171,15 +171,15 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .reports-header {
   display: flex;
   justify-content: space-between;
-  margin-bottom: $space-small;
+  margin-bottom: var(--space-small);
 
   > .title {
     margin: 0;
-    font-size: $font-size-large;
+    font-size: var(--font-size-large);
   }
 }
 </style>

--- a/webapp/components/features/ReportRow/ReportRow.vue
+++ b/webapp/components/features/ReportRow/ReportRow.vue
@@ -171,35 +171,35 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .report-row {
   &:nth-child(2n + 1) {
-    background-color: $color-neutral-95;
+    background-color: var(--color-neutral-95);
   }
 
   .title {
-    font-weight: $font-weight-bold;
+    font-weight: var(--text-weight-bold);
   }
 
   .status-line {
     display: inline-flex;
 
     > .os-icon {
-      margin-right: $space-xx-small;
+      margin-right: var(--space-xx-small);
     }
   }
 
   .user-count {
     display: block;
-    margin-bottom: $space-xx-small;
+    margin-bottom: var(--space-xx-small);
   }
 
   .--disabled {
-    color: $color-danger;
+    color: var(--color-danger);
   }
 
   .--enabled {
-    color: $color-success;
+    color: var(--color-success);
   }
 }
 </style>

--- a/webapp/components/generic/SearchGroup/SearchGroup.vue
+++ b/webapp/components/generic/SearchGroup/SearchGroup.vue
@@ -14,21 +14,21 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .search-group {
   display: flex;
 
   > .label {
     flex-grow: 1;
-    padding: 0 $space-x-small;
+    padding: 0 var(--space-x-small);
   }
 
   > .metadata {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    color: $text-color-softer;
-    font-size: $font-size-small;
+    color: var(--text-color-softer);
+    font-size: var(--font-size-small);
   }
 }
 </style>

--- a/webapp/components/generic/SearchHeading/SearchHeading.vue
+++ b/webapp/components/generic/SearchHeading/SearchHeading.vue
@@ -11,17 +11,17 @@ export default {
   },
 }
 </script>
-<style lang="scss">
+<style>
 .search-heading.ds-heading {
-  margin: -$space-x-small;
-  padding: $space-x-small;
-  background-color: $color-neutral-100;
-  font-weight: $font-weight-bold;
+  margin: calc(-1 * var(--space-x-small));
+  padding: var(--space-x-small);
+  background-color: var(--color-neutral-100);
+  font-weight: var(--text-weight-bold);
   cursor: default;
 }
 
-// override styleguide styles
+/*  override styleguide styles */
 .search-heading.ds-heading:first-child {
-  margin-top: -$space-x-small;
+  margin-top: calc(-1 * var(--space-x-small));
 }
 </style>

--- a/webapp/components/generic/SearchPost/SearchPost.vue
+++ b/webapp/components/generic/SearchPost/SearchPost.vue
@@ -30,24 +30,24 @@ export default {
   },
 }
 </script>
-<style lang="scss">
+<style>
 .search-post {
   display: flex;
 
   > .label {
     flex-grow: 1;
-    padding: 0 $space-x-small;
+    padding: 0 var(--space-x-small);
   }
 
   > .metadata {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    color: $text-color-softer;
-    font-size: $font-size-small;
+    color: var(--text-color-softer);
+    font-size: var(--font-size-small);
 
     > .counts > .os-counter-icon {
-      margin: 0 $space-x-small;
+      margin: 0 var(--space-x-small);
     }
   }
 }

--- a/webapp/components/generic/SearchableInput/SearchableInput.vue
+++ b/webapp/components/generic/SearchableInput/SearchableInput.vue
@@ -194,7 +194,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .searchable-input {
   position: relative;
   display: flex;
@@ -208,17 +208,17 @@ export default {
 
   .ds-select-dropdown {
     max-height: 70vh;
-    box-shadow: $box-shadow-x-large;
+    box-shadow: var(--box-shadow-x-large);
   }
 
   .option-with-heading {
-    margin-top: $space-x-small;
-    padding-top: $space-xx-small;
+    margin-top: var(--space-x-small);
+    padding-top: var(--space-xx-small);
   }
 
   > button {
     position: absolute !important;
-    right: $space-xx-small !important;
+    right: var(--space-xx-small) !important;
   }
 }
 </style>


### PR DESCRIPTION
Replaces lang="scss" with plain <style> and $token with var(--token). Nesting is kept — postcss-preset-env handles it natively. No visual change intended: both spellings resolve to the same values.

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

convert components A-G to plain CSS

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Die Weboberfläche verwendet durchgängig modernes CSS für zahlreiche Komponenten.
  - Abstände, Farben, Größen und weitere Designeinstellungen werden konsistent über zentrale CSS-Eigenschaften gesteuert.
  - Bestehende Layouts, responsive Darstellungen und Interaktionen bleiben unverändert.

- **Style**
  - Visuelle Anpassungen wie Badge-, Menü-, Formular-, Editor- und Listenstile bleiben funktional erhalten.
  - Die Darstellung und Bedienung der betroffenen Bereiche bleiben für Endanwender unverändert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->