### PR TITLE
refactor(webapp): convert pages and layouts to plain CSS

### DIFF
--- a/webapp/layouts/basic.vue
+++ b/webapp/layouts/basic.vue
@@ -94,7 +94,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .main-navigation-right {
   display: flex;
   justify-content: flex-end;
@@ -114,18 +114,18 @@ export default {
 }
 
 .login-button {
-  color: $color-secondary;
+  color: var(--color-secondary);
 }
 
 .login-button-menu-popover {
-  padding-top: $space-x-small;
-  padding-bottom: $space-x-small;
+  padding-top: var(--space-x-small);
+  padding-bottom: var(--space-x-small);
 
   .login-link {
-    color: $text-color-link;
-    padding-top: $space-xx-small;
+    color: var(--text-color-link);
+    padding-top: var(--space-xx-small);
     &:hover {
-      color: $text-color-link-active;
+      color: var(--text-color-link-active);
     }
   }
 }

--- a/webapp/layouts/blank.vue
+++ b/webapp/layouts/blank.vue
@@ -16,7 +16,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .layout-blank > .ds-container > div {
   padding: 5rem 2rem;
 }

--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -128,9 +128,9 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .main-navigation {
-  background-color: $color-header-background;
+  background-color: var(--color-header-background);
 }
 .main-container {
   padding-top: 6rem;
@@ -140,7 +140,7 @@ export default {
 @media (max-width: 810px) {
   .main-container {
     padding-top: 4rem;
-    padding-bottom: $space-x-small;
+    padding-bottom: var(--space-x-small);
   }
 
   .desktop-footer {
@@ -148,8 +148,8 @@ export default {
   }
 
   .ds-container {
-    padding-left: $space-x-small !important;
-    padding-right: $space-x-small !important;
+    padding-left: var(--space-x-small) !important;
+    padding-right: var(--space-x-small) !important;
   }
 }
 
@@ -159,9 +159,9 @@ export default {
   position: fixed;
   bottom: 45px;
   right: 0;
-  // Below the global tooltip/popover stack ($z-index-modal - 2 = 9997) so header
-  // dropdowns (avatar menu, notifications) remain clickable on top of the chat.
-  z-index: $z-index-overlay;
+  /*  Below the global tooltip/popover stack (var(--z-index-modal) - 2 = 9997) so header */
+  /*  dropdowns (avatar menu, notifications) remain clickable on top of the chat. */
+  z-index: var(--z-index-overlay);
   .close {
     padding: 10px;
     color: blue;
@@ -169,13 +169,13 @@ export default {
   }
 }
 
-// When a minimized video call is anchored above the footer, lift the chat
-// above the video so both fit without overlap. Minimized video sits at
-// bottom: 45px (matching the chat's footer offset) and is 280px tall.
-// The inner chat content keeps its own height; whatever extends above the
-// viewport gets clipped by the browser, leaving the message input and the
-// latest messages visible — which is what the user interacts with.
+/*  When a minimized video call is anchored above the footer, lift the chat */
+/*  above the video so both fit without overlap. Minimized video sits at */
+/*  bottom: 45px (matching the chat's footer offset) and is 280px tall. */
+/*  The inner chat content keeps its own height; whatever extends above the */
+/*  viewport gets clipped by the browser, leaving the message input and the */
+/*  latest messages visible — which is what the user interacts with. */
 .chat-modul--with-video {
-  bottom: 333px; // 45 (video bottom) + 280 (video height) + 8 (gap)
+  bottom: 333px; /*  45 (video bottom) + 280 (video height) + 8 (gap) */
 }
 </style>

--- a/webapp/layouts/error.vue
+++ b/webapp/layouts/error.vue
@@ -27,16 +27,16 @@ export default {
   },
 }
 </script>
-<style lang="scss">
+<style>
 .error-container {
   text-align: center;
-  padding: $space-small;
+  padding: var(--space-small);
 }
 .error-message {
-  font-size: $font-size-x-large;
-  font-weight: $font-weight-bold;
-  color: $text-color-softer;
-  margin: $space-base;
+  font-size: var(--font-size-x-large);
+  font-weight: var(--text-weight-bold);
+  color: var(--text-color-softer);
+  margin: var(--space-base);
 }
 .error-image {
   width: 30%;

--- a/webapp/layouts/no-header.vue
+++ b/webapp/layouts/no-header.vue
@@ -29,7 +29,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .layout-blank {
   min-height: 100vh;
   display: flex;

--- a/webapp/pages/admin.vue
+++ b/webapp/pages/admin.vue
@@ -145,11 +145,11 @@ export default {
 }
 </script>
 
-<style lang="scss">
-// AreaMenu owns its own responsive width (full-width select on narrow viewports,
-// 200px sidebar from $media-query-small up). min-width: 0 lets the main column shrink
-// below its content's intrinsic width (e.g. the wide users table), so it stays beside
-// the menu instead of wrapping to a second row under it; the content can then scroll/wrap.
+<style>
+/*  AreaMenu owns its own responsive width (full-width select on narrow viewports, */
+/*  200px sidebar from 600px up). min-width: 0 lets the main column shrink */
+/*  below its content's intrinsic width (e.g. the wide users table), so it stays beside */
+/*  the menu instead of wrapping to a second row under it; the content can then scroll/wrap. */
 .admin-layout__main {
   flex: 1 1 0;
   min-width: 0;

--- a/webapp/pages/admin/api-keys.vue
+++ b/webapp/pages/admin/api-keys.vue
@@ -367,21 +367,21 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style scoped>
 .table-no-clip {
   overflow: visible;
 }
 
 .action-buttons {
   display: flex;
-  gap: $space-xx-small;
+  gap: var(--space-xx-small);
   align-items: center;
   justify-content: flex-end;
 }
 
 .detail-cell {
-  background-color: $color-neutral-90;
-  padding: $space-small;
+  background-color: var(--color-neutral-90);
+  padding: var(--space-small);
 }
 
 .revoked-table {
@@ -389,6 +389,6 @@ export default {
 }
 
 .revoked-heading {
-  color: $text-color-soft;
+  color: var(--text-color-soft);
 }
 </style>

--- a/webapp/pages/admin/config.vue
+++ b/webapp/pages/admin/config.vue
@@ -278,23 +278,31 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .title {
-  margin-bottom: $space-xx-small;
+  margin-bottom: var(--space-xx-small);
 }
 .description {
-  margin: 0 0 $space-base;
-  color: $text-color-soft;
+  margin: 0 0 var(--space-base);
+  color: var(--text-color-soft);
 }
-// Screen-reader-only text: the table caption and the accessible name of an em-dashed
-// ("not set") cell, so assistive tech never reads a bare dash.
+/*  Screen-reader-only text: the table caption and the accessible name of an em-dashed */
+/*  ("not set") cell, so assistive tech never reads a bare dash. */
 .config-caption {
-  @include visually-hidden;
+  /*  Visually hidden, but still exposed to assistive technology. */
+  position: absolute !important;
+  top: 0;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  overflow: hidden !important;
+  height: 1px !important;
+  width: 1px !important;
+  padding: 0 !important;
+  border: 0 !important;
 }
-// No horizontal scroll box (it would break the viewport-sticky header). Instead the
-// table is fixed-layout at width:100%, so it is ALWAYS exactly as wide as the card —
-// never wider (no desktop overflow past the card, no mobile page-fill). Long values are
-// clipped to their column (see .truncate), keys/headers wrap.
+/*  No horizontal scroll box (it would break the viewport-sticky header). Instead the */
+/*  table is fixed-layout at width:100%, so it is ALWAYS exactly as wide as the card — */
+/*  never wider (no desktop overflow past the card, no mobile page-fill). Long values are */
+/*  clipped to their column (see .truncate), keys/headers wrap. */
 .config-table-wrap {
   overflow: visible;
 }
@@ -304,9 +312,9 @@ export default {
   border-collapse: collapse;
   font-size: 0.9em;
 
-  // Mobile-first: show only the three most important columns (key / effective state /
-  // policy override). The env value and software default are hidden so the narrow table
-  // stays readable; the desktop media query below re-adds them.
+  /*  Mobile-first: show only the three most important columns (key / effective state / */
+  /*  policy override). The env value and software default are hidden so the narrow table */
+  /*  stays readable; the desktop media query below re-adds them. */
   .col--key {
     width: 46%;
   }
@@ -325,38 +333,38 @@ export default {
 
   th,
   td {
-    padding: $space-xx-small $space-x-small;
+    padding: var(--space-xx-small) var(--space-x-small);
     text-align: left;
     vertical-align: top;
-    border-bottom: 1px solid $border-color-softer;
-    // Keys and headers wrap within their fixed column instead of overflowing it; value
-    // cells opt out via .truncate (single line + ellipsis).
+    border-bottom: 1px solid var(--border-color-softer);
+    /*  Keys and headers wrap within their fixed column instead of overflowing it; value */
+    /*  cells opt out via .truncate (single line + ellipsis). */
     overflow-wrap: anywhere;
   }
   thead th {
-    // Dark (not soft-grey) so the bold weight actually reads as bold — matching the key
-    // column / category sub-headings. The app font (Lato) only ships 400/700, so a grey
-    // 700 header otherwise looks lighter than the dark key names. Same font size as the
-    // body cells (no shrinking) — it inherits the table's 0.9em.
-    color: $text-color-base;
+    /*  Dark (not soft-grey) so the bold weight actually reads as bold — matching the key */
+    /*  column / category sub-headings. The app font (Lato) only ships 400/700, so a grey */
+    /*  700 header otherwise looks lighter than the dark key names. Same font size as the */
+    /*  body cells (no shrinking) — it inherits the table's 0.9em. */
+    color: var(--text-color-base);
     font-weight: bold;
     text-transform: uppercase;
     letter-spacing: 0.03em;
-    // Freeze the column header just below the fixed app header (its height is exposed as
-    // --header-height) so it stays visible while the page scrolls. A SINGLE divider via an
-    // inset shadow (no border-bottom, which would double it at rest and is anyway dropped
-    // by border-collapse while scrolling); opaque background so scrolled rows don't show through.
+    /*  Freeze the column header just below the fixed app header (its height is exposed as */
+    /*  --header-height) so it stays visible while the page scrolls. A SINGLE divider via an */
+    /*  inset shadow (no border-bottom, which would double it at rest and is anyway dropped */
+    /*  by border-collapse while scrolling); opaque background so scrolled rows don't show through. */
     border-bottom: none;
     position: sticky;
     top: var(--header-height, 6rem);
-    z-index: $z-index-sticky;
-    background: $background-color-base;
-    box-shadow: inset 0 -2px 0 $border-color-softer;
+    z-index: var(--z-index-sticky);
+    background: var(--background-color-base);
+    box-shadow: inset 0 -2px 0 var(--border-color-softer);
   }
 }
 
-// Desktop: room for all five columns (env value + software default are re-added).
-@media #{$media-query-medium} {
+/*  Desktop: room for all five columns (env value + software default are re-added). */
+@media (min-width: 768px) {
   .config-table {
     .col--key {
       width: 24%;
@@ -381,31 +389,31 @@ export default {
     }
   }
 }
-// Category sub-heading spanning the whole width, introducing each row group. The
-// leading gap separates one group from the previous one, so the very first group
-// (directly under the table head) drops it.
+/*  Category sub-heading spanning the whole width, introducing each row group. The */
+/*  leading gap separates one group from the previous one, so the very first group */
+/*  (directly under the table head) drops it. */
 .config-group-head th {
-  padding-top: $space-base;
-  color: $text-color-base;
+  padding-top: var(--space-base);
+  color: var(--text-color-base);
   font-size: 0.85em;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  border-bottom: 2px solid $border-color-soft;
+  border-bottom: 2px solid var(--border-color-soft);
 }
 .config-table tbody:first-of-type .config-group-head th {
-  padding-top: calc($space-base / 2);
+  padding-top: calc(var(--space-base) / 2);
 }
 .config-row {
-  // Reserve the accent gutter on every row so the layout doesn't shift when a row
-  // becomes blocking; only a blocking row colours it.
+  /*  Reserve the accent gutter on every row so the layout doesn't shift when a row */
+  /*  becomes blocking; only a blocking row colours it. */
   th.cell--key {
     border-left: 3px solid transparent;
   }
-  // Keep the row clear of the sticky admin header when scrolled to via #key.
-  scroll-margin-top: $space-base;
-  // Animate the deep-link highlight fading back out (applyHashHighlight clears the key
-  // after a moment). Only when the user hasn't asked for reduced motion.
+  /*  Keep the row clear of the sticky admin header when scrolled to via #key. */
+  scroll-margin-top: var(--space-base);
+  /*  Animate the deep-link highlight fading back out (applyHashHighlight clears the key */
+  /*  after a moment). Only when the user hasn't asked for reduced motion. */
   @media (prefers-reduced-motion: no-preference) {
     transition: background-color 0.6s ease;
 
@@ -414,86 +422,92 @@ export default {
     }
   }
 
-  // A missing hard-requirement secret breaks its feature → flag the whole row.
-  &--blocking {
-    background: color-mix(in srgb, var(--color-danger) 7%, transparent);
+  /*  A missing hard-requirement secret breaks its feature → flag the whole row. */
 
-    th.cell--key {
-      border-left-color: $color-danger;
-    }
+  /*  Deep-linked to from the policy/roles tabs (/admin/config#<key>) → highlight the */
+  /*  anchored row so the admin sees which env var the link pointed at. Placed after */
+  /*  --blocking so a highlighted row reads as the navigation target. */
+}
+
+.config-row--blocking {
+  background: color-mix(in srgb, var(--color-danger) 7%, transparent);
+
+  th.cell--key {
+    border-left-color: var(--color-danger);
   }
+}
 
-  // Deep-linked to from the policy/roles tabs (/admin/config#<key>) → highlight the
-  // anchored row so the admin sees which env var the link pointed at. Placed after
-  // --blocking so a highlighted row reads as the navigation target.
-  &--highlight {
-    // $color-secondary is a runtime var() now; color-mix instead of Sass rgba() for the tint.
-    background: color-mix(in srgb, var(--color-secondary) 10%, transparent);
+.config-row--highlight {
+  /*  var(--color-secondary) is a runtime var() now; color-mix instead of Sass rgba() for the tint. */
+  background: color-mix(in srgb, var(--color-secondary) 10%, transparent);
 
-    th.cell--key {
-      border-left-color: $color-secondary;
-    }
+  th.cell--key {
+    border-left-color: var(--color-secondary);
   }
 }
 .cell {
-  &--key code {
-    font-weight: 600;
-  }
-  &--effective .value {
-    font-weight: 600;
-  }
-  &__blocks {
-    display: block;
-    margin-top: $space-xxx-small;
-    color: $color-danger;
-    font-size: 0.85em;
-  }
+}
+
+.cell--key code {
+  font-weight: 600;
+}
+
+.cell--effective .value {
+  font-weight: 600;
+}
+
+.cell__blocks {
+  display: block;
+  margin-top: var(--space-xxx-small);
+  color: var(--color-danger);
+  font-size: 0.85em;
 }
 .cell-empty {
-  color: $text-color-soft;
+  color: var(--text-color-soft);
 }
-// Values are clipped to their fixed column on a single line (no wrapping, no widening
-// the table). refreshTruncation() flags the CELLS whose value is actually clipped.
+/*  Values are clipped to their fixed column on a single line (no wrapping, no widening */
+/*  the table). refreshTruncation() flags the CELLS whose value is actually clipped. */
 .truncate {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-// A clipped cell reveals the full value as an overlay tooltip on hover / tap / keyboard
-// focus — an ::after on the cell (whose overflow is visible, unlike the clipped .truncate)
-// so it floats above the table WITHOUT growing the row (no layout shift). The value comes
-// from data-full; the cell is the positioning context.
+/*  A clipped cell reveals the full value as an overlay tooltip on hover / tap / keyboard */
+/*  focus — an ::after on the cell (whose overflow is visible, unlike the clipped .truncate) */
+/*  so it floats above the table WITHOUT growing the row (no layout shift). The value comes */
+/*  from data-full; the cell is the positioning context. */
 .cell.is-clipped {
   position: relative;
   cursor: help;
 }
 .cell.is-clipped:hover,
 .cell.is-clipped:focus {
-  // Lift above sibling cells so the tooltip is never covered by later rows.
+  /*  Lift above sibling cells so the tooltip is never covered by later rows. */
   z-index: 10;
 }
 .cell.is-clipped:focus {
-  outline: 2px solid $color-secondary;
+  outline: 2px solid var(--color-secondary);
   outline-offset: -2px;
 }
 .cell.is-clipped:hover::after,
 .cell.is-clipped:focus::after {
   content: attr(data-full);
   position: absolute;
-  top: calc(100% - #{$space-xxx-small});
-  // Anchored to the cell's right edge and extending left — there is always room to the
-  // left (earlier columns), so the tooltip stays on screen.
-  right: $space-x-small;
+  top: calc(100% - var(--space-xxx-small));
+  /*  Anchored to the cell's right edge and extending left — there is always room to the */
+  /*  left (earlier columns), so the tooltip stays on screen. */
+  right: var(--space-x-small);
   z-index: 20;
   width: max-content;
   max-width: min(50ch, calc(100vw - 1rem));
-  padding: $space-xx-small $space-x-small;
-  background: $background-color-inverse;
-  color: $text-color-inverse;
-  border-radius: $border-radius-base;
-  box-shadow: 0 2px 10px rgba($color-neutral-0, 0.25);
-  // Undo the header/cell text styling for a plain, readable tooltip.
+  padding: var(--space-xx-small) var(--space-x-small);
+  background: var(--background-color-inverse);
+  color: var(--text-color-inverse);
+  border-radius: var(--border-radius-base);
+  /*  color-mix, not rgba(): var(--color-neutral-0) is a var() and Sass cannot decompose one. */
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--color-neutral-0) 25%, transparent);
+  /*  Undo the header/cell text styling for a plain, readable tooltip. */
   white-space: normal;
   overflow-wrap: anywhere;
   font-weight: normal;
@@ -503,40 +517,42 @@ export default {
   line-height: 1.4;
   pointer-events: none;
 }
-// A set secret: shown as masked dots (present, value withheld) rather than a value or
-// a misleading "not set" dash.
+/*  A set secret: shown as masked dots (present, value withheld) rather than a value or */
+/*  a misleading "not set" dash. */
 .value--masked {
-  color: $text-color-soft;
+  color: var(--text-color-soft);
   letter-spacing: 0.15em;
 }
-// Link from an overridable value to its policy on the policy tab.
+/*  Link from an overridable value to its policy on the policy tab. */
 .override-link {
   .value {
     font-weight: 600;
   }
-  // No override set yet: muted, but still a clear affordance to go set one.
-  &--empty {
-    color: $text-color-soft;
-    font-size: 0.85em;
-    font-style: italic;
-  }
+  /*  No override set yet: muted, but still a clear affordance to go set one. */
+}
+
+.override-link--empty {
+  color: var(--text-color-soft);
+  font-size: 0.85em;
+  font-style: italic;
 }
 .badge {
   display: inline-block;
   padding: 0.1em 0.5em;
-  border-radius: $border-radius-base;
+  border-radius: var(--border-radius-base);
   font-size: 0.8em;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.03em;
+}
 
-  &--ok {
-    background-color: $color-success;
-    color: $color-success-inverse;
-  }
-  &--error {
-    background-color: $color-danger;
-    color: $color-danger-inverse;
-  }
+.badge--ok {
+  background-color: var(--color-success);
+  color: var(--color-success-inverse);
+}
+
+.badge--error {
+  background-color: var(--color-danger);
+  color: var(--color-danger-inverse);
 }
 </style>

--- a/webapp/pages/admin/donations.vue
+++ b/webapp/pages/admin/donations.vue
@@ -105,17 +105,17 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .show-donations-checkbox {
-  margin-top: $space-base;
-  margin-bottom: $space-small;
+  margin-top: var(--space-base);
+  margin-bottom: var(--space-small);
 }
 
 .donations-data {
-  margin-left: $space-small;
+  margin-left: var(--space-small);
 }
 
 .donations-info-button {
-  margin-top: $space-small;
+  margin-top: var(--space-small);
 }
 </style>

--- a/webapp/pages/admin/index.vue
+++ b/webapp/pages/admin/index.vue
@@ -66,7 +66,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .admin-stats__item {
   flex: 0 0 100%;
   width: 100%;
@@ -75,13 +75,13 @@ export default {
     text-transform: uppercase;
   }
 }
-@media #{$media-query-small} {
+@media (min-width: 600px) {
   .admin-stats__item {
     flex: 0 0 50%;
     width: 50%;
   }
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .admin-stats__item {
     flex: 0 0 33.333%;
     width: 33.333%;

--- a/webapp/pages/admin/policy.vue
+++ b/webapp/pages/admin/policy.vue
@@ -451,134 +451,146 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .title {
-  margin-bottom: $space-xx-small;
+  margin-bottom: var(--space-xx-small);
 }
 .description {
   margin-bottom: 0;
-  color: $text-color-soft;
+  color: var(--text-color-soft);
 }
 .last-changed {
-  margin: $space-xxx-small 0 0;
-  color: $text-color-soft;
+  margin: var(--space-xxx-small) 0 0;
+  color: var(--text-color-soft);
   font-size: 0.85em;
   font-style: italic;
 }
-// Consistent gap before the first heading, whether or not the "last changed"
-// line is present.
+/*  Consistent gap before the first heading, whether or not the "last changed" */
+/*  line is present. */
 form {
-  margin-top: $space-base;
+  margin-top: var(--space-base);
 }
 .policy-group {
   border: none;
   padding: 0;
-  margin: 0 0 $space-small 0;
+  margin: 0 0 var(--space-small) 0;
 
-  // Set the heading off with an underline only as wide as the text itself.
-  &__title {
-    padding: 0 0 $space-xxx-small 0;
-    margin-bottom: $space-xx-small;
-    border-bottom: 1px solid $border-color-softer;
-    color: $text-color-soft;
-    font-weight: bold;
-    font-size: 0.9em;
-    letter-spacing: 0.03em;
-    text-transform: uppercase;
-  }
+  /*  Set the heading off with an underline only as wide as the text itself. */
 }
-// Outer spacing for the shared conflict banner (its appearance lives in ConflictBanner.vue).
+
+.policy-group__title {
+  padding: 0 0 var(--space-xxx-small) 0;
+  margin-bottom: var(--space-xx-small);
+  border-bottom: 1px solid var(--border-color-softer);
+  color: var(--text-color-soft);
+  font-weight: bold;
+  font-size: 0.9em;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+/*  Outer spacing for the shared conflict banner (its appearance lives in ConflictBanner.vue). */
 .policy-conflict {
-  margin-top: $space-small;
+  margin-top: var(--space-small);
 }
 .policy-row {
   display: flex;
   align-items: flex-start;
-  gap: $space-x-small;
-  margin: $space-xx-small 0;
+  gap: var(--space-x-small);
+  margin: var(--space-xx-small) 0;
   line-height: 1.3;
   border-left: 3px solid transparent;
-  padding-left: $space-xx-small;
-  // Keep the row clear of the sticky header when navigated to via #key from the config tab.
-  scroll-margin-top: $space-base;
-  // Animate the deep-link highlight fading back out (applyHashHighlight clears the key
-  // after a moment). Only when the user hasn't asked for reduced motion.
+  padding-left: var(--space-xx-small);
+  /*  Keep the row clear of the sticky header when navigated to via #key from the config tab. */
+  scroll-margin-top: var(--space-base);
+  /*  Animate the deep-link highlight fading back out (applyHashHighlight clears the key */
+  /*  after a moment). Only when the user hasn't asked for reduced motion. */
   @media (prefers-reduced-motion: no-preference) {
     transition:
       background-color 0.6s ease,
       border-left-color 0.6s ease;
   }
 
-  // Navigated to from the config tab (/admin/policy#<key>) → highlight the target row so
-  // the admin sees which policy the config link pointed at. The class is driven from the
-  // route hash (see applyHashHighlight) because history-mode pushState navigations don't
-  // update :target; the :target rule stays as a fallback for a real full-page load/reload.
-  &--highlight,
-  &:target {
-    border-left-color: $color-secondary;
-    // $color-secondary is a runtime var() now; use color-mix instead of Sass rgba() for the tint.
-    background: color-mix(in srgb, var(--color-secondary) 10%, transparent);
-  }
+  /*  Navigated to from the config tab (/admin/policy#<key>) → highlight the target row so */
+  /*  the admin sees which policy the config link pointed at. The class is driven from the */
+  /*  route hash (see applyHashHighlight) because history-mode pushState navigations don't */
+  /*  update :target; the :target rule stays as a fallback for a real full-page load/reload. */
 
-  // This field was edited locally AND changed on the server → highlight it.
-  &--conflict {
-    border-left-color: $color-warning;
-    background: color-mix(in srgb, var(--color-warning) 10%, transparent);
-  }
+  /*  This field was edited locally AND changed on the server → highlight it. */
 
-  &__checkbox {
-    margin-top: 0.15em;
-    flex-shrink: 0;
-  }
-  &__number {
-    width: 4.5em;
-    margin-top: -0.1em;
-    flex-shrink: 0;
-  }
-  &__label {
-    display: flex;
-    flex-direction: column;
-    cursor: pointer;
-  }
-  &__name {
-    font-weight: 600;
-  }
-  &__current {
-    margin-left: $space-xx-small;
-    color: $text-color-soft;
-    font-family: monospace;
-    font-size: 0.8em;
-    font-weight: normal;
-  }
-  &__description {
-    color: $text-color-soft;
-    font-size: 0.85em;
-    line-height: 1.25;
-  }
-  &__conflict {
-    margin-top: 0.15em;
-    color: $color-warning-active;
-    font-size: 0.8em;
-    font-weight: 600;
-  }
-  &__env {
-    color: $color-danger;
-    font-size: 0.85em;
-    line-height: 1.25;
-  }
-  &__env-link {
-    white-space: nowrap;
-  }
+  /*  Hard env requirement unmet: the stored flag has no effect, so dim the row and */
+  /*  disable its input (the env note + config link explain why). */
+}
 
-  // Hard env requirement unmet: the stored flag has no effect, so dim the row and
-  // disable its input (the env note + config link explain why).
-  &--unavailable {
-    opacity: 0.6;
-  }
+.policy-row--highlight,
+.policy-row:target {
+  border-left-color: var(--color-secondary);
+  /*  var(--color-secondary) is a runtime var() now; use color-mix instead of Sass rgba() for the tint. */
+  background: color-mix(in srgb, var(--color-secondary) 10%, transparent);
+}
+
+.policy-row--conflict {
+  border-left-color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
+}
+
+.policy-row__checkbox {
+  margin-top: 0.15em;
+  flex-shrink: 0;
+}
+
+.policy-row__number {
+  width: 4.5em;
+  margin-top: -0.1em;
+  flex-shrink: 0;
+}
+
+.policy-row__label {
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+}
+
+.policy-row__name {
+  font-weight: 600;
+}
+
+.policy-row__current {
+  margin-left: var(--space-xx-small);
+  color: var(--text-color-soft);
+  font-family: monospace;
+  font-size: 0.8em;
+  font-weight: normal;
+}
+
+.policy-row__description {
+  color: var(--text-color-soft);
+  font-size: 0.85em;
+  line-height: 1.25;
+}
+
+.policy-row__conflict {
+  margin-top: 0.15em;
+  color: var(--color-warning-highlight);
+  font-size: 0.8em;
+  font-weight: 600;
+}
+
+.policy-row__env {
+  color: var(--color-danger);
+  font-size: 0.85em;
+  line-height: 1.25;
+}
+
+.policy-row__env-link {
+  white-space: nowrap;
+}
+
+.policy-row--unavailable {
+  opacity: 0.6;
 }
 .actions {
-  margin-top: $space-small;
+  margin-top: var(--space-small);
   display: flex;
-  gap: $space-small;
+  gap: var(--space-small);
 }
 </style>

--- a/webapp/pages/admin/roles.vue
+++ b/webapp/pages/admin/roles.vue
@@ -772,234 +772,258 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .title {
-  margin-bottom: $space-xx-small;
+  margin-bottom: var(--space-xx-small);
 }
 .description {
-  margin-bottom: $space-base;
-  color: $text-color-soft;
+  margin-bottom: var(--space-base);
+  color: var(--text-color-soft);
 }
 .role-tabs {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: $space-x-small;
-  padding-bottom: $space-small;
-  border-bottom: 1px solid $border-color-softer;
+  gap: var(--space-x-small);
+  padding-bottom: var(--space-small);
+  border-bottom: 1px solid var(--border-color-softer);
 }
 .role-tab {
   display: inline-flex;
   align-items: center;
-  gap: $space-xxx-small;
-  padding: $space-xx-small $space-small;
-  border: 1px solid $border-color-soft;
-  border-radius: $border-radius-x-large;
-  background: $background-color-base;
-  color: $text-color-base;
+  gap: var(--space-xxx-small);
+  padding: var(--space-xx-small) var(--space-small);
+  border: 1px solid var(--border-color-soft);
+  border-radius: var(--border-radius-x-large);
+  background: var(--background-color-base);
+  color: var(--text-color-base);
   font-size: 0.9em;
   line-height: 1.4;
   cursor: pointer;
 
   &:hover {
-    background: $background-color-softer;
+    background: var(--background-color-softer);
   }
-  &--active {
-    border-color: $color-primary;
-    background: $color-primary;
-    color: $color-primary-inverse;
-    font-weight: bold;
+}
 
-    &:hover {
-      background: $color-primary;
-    }
+.role-tab--active {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-primary-inverse);
+  font-weight: bold;
+
+  &:hover {
+    background: var(--color-primary);
   }
-  &--add {
-    font-weight: bold;
-    border-style: dashed;
+}
+
+.role-tab--add {
+  font-weight: bold;
+  border-style: dashed;
+}
+
+.role-tab--input {
+  padding: var(--space-xxx-small) var(--space-xx-small);
+  cursor: default;
+}
+
+.role-tab__badge {
+  font-size: 0.8em;
+}
+
+.role-tab__input {
+  border: none;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  min-width: 8rem;
+}
+
+.role-tab__confirm,
+.role-tab__cancel {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0 var(--space-xxx-small);
+  color: var(--text-color-soft);
+
+  &:hover {
+    color: var(--text-color-base);
   }
-  &--input {
-    padding: $space-xxx-small $space-xx-small;
+  &:disabled {
+    opacity: 0.4;
     cursor: default;
-  }
-  &__badge {
-    font-size: 0.8em;
-  }
-  &__input {
-    border: none;
-    outline: none;
-    background: transparent;
-    font: inherit;
-    min-width: 8rem;
-  }
-  &__confirm,
-  &__cancel {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    padding: 0 $space-xxx-small;
-    color: $text-color-soft;
-
-    &:hover {
-      color: $text-color-base;
-    }
-    &:disabled {
-      opacity: 0.4;
-      cursor: default;
-    }
   }
 }
 .role {
-  padding-top: $space-base;
-  &__header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: $space-small;
-    // Set the role identity apart from its permission groups with a clear gap, so the
-    // (possibly terse, e.g. "ra") role name reads as its own header rather than crowding
-    // the first group title.
-    margin-bottom: $space-base;
-  }
-  &__name {
-    margin: 0;
-  }
-  // "Role:" prefix before the name, so a poorly-named role (ra, rb) still reads as the
-  // role name. Softer + lighter than the name it labels.
-  &__label {
-    color: $text-color-soft;
-    font-weight: normal;
-  }
-  &__badge {
-    margin-left: $space-xx-small;
-    font-size: 0.7em;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: $text-color-soft;
-  }
-  // Pencil affordance next to the role name; reveals the inline rename input.
-  &__rename {
-    margin-left: $space-xx-small;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    font-size: 0.7em;
-    color: $text-color-soft;
+  padding-top: var(--space-base);
+  /*  "Role:" prefix before the name, so a poorly-named role (ra, rb) still reads as the */
+  /*  role name. Softer + lighter than the name it labels. */
+  /*  Pencil affordance next to the role name; reveals the inline rename input. */
+  /*  Outer spacing for the shared conflict banner (its appearance lives in ConflictBanner.vue). */
+  /*  Wrapper so the title hint shows even while the button inside is disabled. */
+}
 
-    &:hover {
-      color: $color-primary;
-    }
-  }
-  &__members {
-    color: $text-color-soft;
-    font-size: 0.85em;
-    text-decoration: none;
+.role__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-small);
+  /*  Set the role identity apart from its permission groups with a clear gap, so the */
+  /*  (possibly terse, e.g. "ra") role name reads as its own header rather than crowding */
+  /*  the first group title. */
+  margin-bottom: var(--space-base);
+}
 
-    &:hover {
-      color: $color-primary;
-      text-decoration: underline;
-    }
-  }
-  &__protected-note {
-    color: $text-color-soft;
-    font-style: italic;
-  }
-  // Outer spacing for the shared conflict banner (its appearance lives in ConflictBanner.vue).
-  &__conflict {
-    margin: $space-x-small 0;
-  }
-  &__actions {
-    margin-top: $space-x-small;
-    display: flex;
-    gap: $space-small;
-  }
-  // Wrapper so the title hint shows even while the button inside is disabled.
-  &__action {
-    display: inline-flex;
+.role__name {
+  margin: 0;
+}
+
+.role__label {
+  color: var(--text-color-soft);
+  font-weight: normal;
+}
+
+.role__badge {
+  margin-left: var(--space-xx-small);
+  font-size: 0.7em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-color-soft);
+}
+
+.role__rename {
+  margin-left: var(--space-xx-small);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.7em;
+  color: var(--text-color-soft);
+
+  &:hover {
+    color: var(--color-primary);
   }
 }
-// Desktop (>=1024px): pack the permission groups into two columns for a more
-// compact overview. Mobile/tablet stay single-column (the default). column-* is
-// used (rather than grid/flex) so unequal-height groups fill the space tightly.
+
+.role__members {
+  color: var(--text-color-soft);
+  font-size: 0.85em;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--color-primary);
+    text-decoration: underline;
+  }
+}
+
+.role__protected-note {
+  color: var(--text-color-soft);
+  font-style: italic;
+}
+
+.role__conflict {
+  margin: var(--space-x-small) 0;
+}
+
+.role__actions {
+  margin-top: var(--space-x-small);
+  display: flex;
+  gap: var(--space-small);
+}
+
+.role__action {
+  display: inline-flex;
+}
+/*  Desktop (>=1024px): pack the permission groups into two columns for a more */
+/*  compact overview. Mobile/tablet stay single-column (the default). column-* is */
+/*  used (rather than grid/flex) so unequal-height groups fill the space tightly. */
 .perm-groups {
-  @media #{$media-query-large} {
+  @media (min-width: 1024px) {
     column-count: 2;
-    column-gap: $space-large;
+    column-gap: var(--space-large);
   }
 }
 .perm-group {
   border: none;
   padding: 0;
-  margin: $space-x-small 0;
-  // Keep a group (title + its rows) from splitting across the two columns.
+  margin: var(--space-x-small) 0;
+  /*  Keep a group (title + its rows) from splitting across the two columns. */
   break-inside: avoid;
-  // The first group's top margin would otherwise misalign the two column tops.
+  /*  The first group's top margin would otherwise misalign the two column tops. */
   &:first-child {
     margin-top: 0;
   }
+}
 
-  &__title {
-    color: $text-color-soft;
-    font-weight: bold;
-    font-size: 0.85em;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-  }
+.perm-group__title {
+  color: var(--text-color-soft);
+  font-weight: bold;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 .perm-row {
   display: flex;
   align-items: flex-start;
-  gap: $space-x-small;
-  margin: $space-xxx-small 0;
-  padding: $space-xxx-small $space-xx-small;
-  border-radius: $border-radius-small;
+  gap: var(--space-x-small);
+  margin: var(--space-xxx-small) 0;
+  padding: var(--space-xxx-small) var(--space-xx-small);
+  border-radius: var(--border-radius-small);
   border-left: 3px solid transparent;
   cursor: pointer;
   transition: background-color 0.1s ease;
 
-  // Hover-diff against the active role: the hovered role would add (green) or
-  // remove (red) this permission.
-  &--added {
-    background: color-mix(in srgb, var(--color-success) 16%, transparent);
-    border-left-color: $color-success;
-  }
-  &--removed {
-    background: color-mix(in srgb, var(--color-danger) 16%, transparent);
-    border-left-color: $color-danger;
-  }
-  // The permission's feature is not configured/enabled: granting it has no effect,
-  // so the row is dimmed and the checkbox disabled (with an explanatory note).
-  &--unavailable {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
+  /*  Hover-diff against the active role: the hovered role would add (green) or */
+  /*  remove (red) this permission. */
+  /*  The permission's feature is not configured/enabled: granting it has no effect, */
+  /*  so the row is dimmed and the checkbox disabled (with an explanatory note). */
   input:disabled {
     cursor: default;
   }
 
-  &__text {
-    display: flex;
-    flex-direction: column;
-    line-height: 1.25;
-  }
-  &__key {
-    font-family: monospace;
-    font-size: 0.85em;
-  }
-  &__desc {
-    color: $text-color-soft;
-    font-size: 0.8em;
-  }
-  &__gate {
-    color: $color-danger;
-    font-size: 0.75em;
-    font-style: italic;
-  }
-  // The deep-link to the policy tab. Colour/affordance come from the global `a` reset
-  // ($color-primary, no underline — the app-wide link convention, matching the policy tab's
-  // env-link); only keep it from wrapping mid-phrase inside the italic gate note.
-  &__gate-link {
-    white-space: nowrap;
-  }
+  /*  The deep-link to the policy tab. Colour/affordance come from the global `a` reset */
+  /*  (var(--color-primary), no underline — the app-wide link convention, matching the policy tab's */
+  /*  env-link); only keep it from wrapping mid-phrase inside the italic gate note. */
+}
+
+.perm-row--added {
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+  border-left-color: var(--color-success);
+}
+
+.perm-row--removed {
+  background: color-mix(in srgb, var(--color-danger) 16%, transparent);
+  border-left-color: var(--color-danger);
+}
+
+.perm-row--unavailable {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.perm-row__text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.perm-row__key {
+  font-family: monospace;
+  font-size: 0.85em;
+}
+
+.perm-row__desc {
+  color: var(--text-color-soft);
+  font-size: 0.8em;
+}
+
+.perm-row__gate {
+  color: var(--color-danger);
+  font-size: 0.75em;
+  font-style: italic;
+}
+
+.perm-row__gate-link {
+  white-space: nowrap;
 }
 </style>

--- a/webapp/pages/call/_id/_slug.vue
+++ b/webapp/pages/call/_id/_slug.vue
@@ -110,10 +110,10 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .call-page {
-  // The video overlay covers this page entirely — the host page is just
-  // here so the call has its own URL.
+  /*  The video overlay covers this page entirely — the host page is just */
+  /*  here so the call has its own URL. */
   position: absolute;
   inset: 0;
 }

--- a/webapp/pages/chat.vue
+++ b/webapp/pages/chat.vue
@@ -100,7 +100,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .layout-default:has(.chat-page) {
   > .ds-container {
     padding-left: 0 !important;

--- a/webapp/pages/groups/_id/_slug.vue
+++ b/webapp/pages/groups/_id/_slug.vue
@@ -848,20 +848,20 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style scoped>
 ::v-deep .profile-page-avatar.profile-avatar {
   margin: auto;
   margin-top: -60px;
 }
 @media (max-width: 810px) {
   .group-profile {
-    padding-top: $space-large;
+    padding-top: var(--space-large);
   }
 }
 .group-layout__sidebar ::v-deep .group-profile-content-menu {
   position: absolute;
-  top: $space-x-small;
-  right: $space-x-small;
+  top: var(--space-x-small);
+  right: var(--space-x-small);
 }
 .group-layout__sidebar,
 .group-layout__main {
@@ -869,7 +869,7 @@ export default {
   width: 100%;
   min-width: 0;
 }
-@media #{$media-query-small} {
+@media (min-width: 600px) {
   .group-layout__sidebar {
     flex: 2 0 0;
   }
@@ -877,7 +877,7 @@ export default {
     flex: 3 0 0;
   }
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .group-layout__sidebar {
     flex: 2 0 0;
   }
@@ -885,7 +885,7 @@ export default {
     flex: 5 0 0;
   }
 }
-@media #{$media-query-large} {
+@media (min-width: 1024px) {
   .group-layout__sidebar {
     flex: 1 0 0;
   }
@@ -894,30 +894,30 @@ export default {
   }
 }
 ::v-deep .profile-post-add-button {
-  box-shadow: $box-shadow-x-large;
+  box-shadow: var(--box-shadow-x-large);
 }
 .action-buttons {
   display: flex;
   flex-direction: column;
-  gap: $space-x-small;
-  margin: $space-small 0;
+  gap: var(--space-x-small);
+  margin: var(--space-small) 0;
 }
 .centered-text {
   text-align: center;
-  margin-bottom: $space-xxx-small;
+  margin-bottom: var(--space-xxx-small);
 }
 .chip {
-  margin-bottom: $space-x-small;
+  margin-bottom: var(--space-x-small);
 }
 ::v-deep .group-description.os-card {
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding-bottom: $space-base !important;
+  padding-bottom: var(--space-base) !important;
 
   .content {
     flex-grow: 1;
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
   }
 }
 .word-break-all {
@@ -926,7 +926,7 @@ export default {
 .member-teaser {
   display: flex;
   align-items: center;
-  gap: $space-x-small;
+  gap: var(--space-x-small);
   width: 100%;
 
   .member-teaser__user {

--- a/webapp/pages/groups/create.vue
+++ b/webapp/pages/groups/create.vue
@@ -84,13 +84,13 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .group-create-layout__main,
 .group-create-layout__aside {
   flex: 0 0 100%;
   width: 100%;
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .group-create-layout__main {
     flex: 5 0 0;
   }

--- a/webapp/pages/groups/edit/_id.vue
+++ b/webapp/pages/groups/edit/_id.vue
@@ -87,19 +87,19 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .ds-heading {
   margin-top: 0;
 }
 </style>
 
-<style lang="scss">
+<style>
 .group-edit-layout__sidebar,
 .group-edit-layout__main {
   flex: 0 0 100%;
   width: 100%;
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .group-edit-layout__sidebar {
     flex: 0 0 200px;
     width: 200px;

--- a/webapp/pages/groups/index.vue
+++ b/webapp/pages/groups/index.vue
@@ -207,8 +207,8 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .group-add-button {
-  box-shadow: $box-shadow-x-large !important;
+  box-shadow: var(--box-shadow-x-large) !important;
 }
 </style>

--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -401,20 +401,20 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .hide-filter {
   display: none;
 }
 
 @media (max-width: 810px) {
   .feed-top-row {
-    padding-top: $space-small;
+    padding-top: var(--space-small);
   }
 }
 
 .hashtag-filter-bar {
-  margin-top: -$space-x-small;
-  margin-bottom: $space-small;
+  margin-top: calc(-1 * var(--space-x-small));
+  margin-bottom: var(--space-small);
 }
 
 .feed-top-row {
@@ -438,10 +438,10 @@ export default {
   min-height: 54px !important;
   min-width: 54px !important;
   font-size: 26px !important;
-  box-shadow: $box-shadow-x-large !important;
-  z-index: $z-index-sticky-float !important;
+  box-shadow: var(--box-shadow-x-large) !important;
+  z-index: var(--z-index-sticky-float) !important;
   position: fixed !important;
-  right: max(20px, calc((100vw - $container-max-width-x-large) / 2 + 52px)) !important;
+  right: max(20px, calc((100vw - var(--container-max-width-x-large)) / 2 + 52px)) !important;
   top: 88px !important;
   transition: top 0.3s ease !important;
 }
@@ -480,7 +480,7 @@ export default {
   max-height: 950px;
   overflow: auto;
   padding-bottom: 0px;
-  z-index: $z-index-page-submenu;
+  z-index: var(--z-index-page-submenu);
 }
 .grid-margin-top {
   margin-top: 4px;

--- a/webapp/pages/map.vue
+++ b/webapp/pages/map.vue
@@ -728,9 +728,9 @@ export default {
 </script>
 <!-- eslint-enable vue/no-reserved-component-names -->
 
-<style lang="scss">
-// description: https: //github.com/geospoc/v-mapbox/tree/v1.11.2/docs
-//   code example: https: //codesandbox.io/embed/v-mapbox-map-demo-k1l1n?autoresize=1&fontsize=14&hidenavigation=1&theme=dark
+<style>
+/*  description: https: //github.com/geospoc/v-mapbox/tree/v1.11.2/docs */
+/*    code example: https: //codesandbox.io/embed/v-mapbox-map-demo-k1l1n?autoresize=1&fontsize=14&hidenavigation=1&theme=dark */
 @import 'mapbox-gl/dist/mapbox-gl.css';
 @import 'v-mapbox/dist/v-mapbox.css';
 
@@ -744,8 +744,8 @@ export default {
   flex-direction: column;
   overflow: hidden;
   z-index: 1;
-  font-family: $font-family-text;
-  font-size: $font-size-base;
+  font-family: var(--font-family-text);
+  font-size: var(--font-size-base);
 }
 
 .mgl-map-wrapper {
@@ -772,7 +772,7 @@ export default {
   max-height: 40vh;
   overflow: hidden;
   padding: 10px;
-  border-radius: $border-radius-x-large;
+  border-radius: var(--border-radius-x-large);
 }
 
 .map-popup-container {
@@ -783,14 +783,14 @@ export default {
 }
 
 .mapboxgl-popup-close-button {
-  font-size: $font-size-large;
+  font-size: var(--font-size-large);
   padding: 2px 6px;
   z-index: 1;
 }
 
 .map-popup-header {
   font-weight: bold;
-  font-size: $font-size-large;
+  font-size: var(--font-size-large);
   margin-bottom: 4px;
   padding-right: 16px;
   flex-shrink: 0;
@@ -802,7 +802,7 @@ export default {
   min-height: 0;
 }
 
-// Smaller geocoder on mobile (expanded)
+/*  Smaller geocoder on mobile (expanded) */
 @media (max-width: 810px) {
   .mapboxgl-ctrl-geocoder {
     font-size: 13px;
@@ -840,7 +840,7 @@ export default {
     height: 29px;
     min-width: 29px;
     background-color: white;
-    border-radius: $border-radius-x-large;
+    border-radius: var(--border-radius-x-large);
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
     overflow: hidden;
 
@@ -868,10 +868,10 @@ export default {
   left: 10px;
   background: rgba(255, 255, 255, 0.75);
   backdrop-filter: blur(4px);
-  border-radius: $border-radius-x-large;
+  border-radius: var(--border-radius-x-large);
   z-index: 1;
-  font-size: $font-size-base;
-  color: $color-neutral-10;
+  font-size: var(--font-size-base);
+  color: var(--color-neutral-10);
 }
 
 .map-legend-toggle {
@@ -880,10 +880,10 @@ export default {
   padding: 4px 8px;
   border: none;
   background: rgba(0, 0, 0, 0.05);
-  color: $color-neutral-10;
-  border-radius: $border-radius-x-large;
+  color: var(--color-neutral-10);
+  border-radius: var(--border-radius-x-large);
   cursor: pointer;
-  font-size: $font-size-base;
+  font-size: var(--font-size-base);
   text-align: left;
   order: 1;
   align-items: center;
@@ -896,7 +896,7 @@ export default {
 }
 
 .map-legend-arrow {
-  font-size: $font-size-small;
+  font-size: var(--font-size-small);
   line-height: 1;
 }
 
@@ -944,7 +944,7 @@ export default {
 .map-style-switcher {
   position: relative;
   background: white;
-  border-radius: $border-radius-x-large;
+  border-radius: var(--border-radius-x-large);
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
 }
 
@@ -972,14 +972,14 @@ export default {
   right: 100%;
   margin-right: 6px;
   background: white;
-  border-radius: $border-radius-x-large;
+  border-radius: var(--border-radius-x-large);
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
   white-space: nowrap;
   overflow: hidden;
+}
 
-  &--open {
-    display: block;
-  }
+.map-style-popover--open {
+  display: block;
 }
 
 .map-style-popover-btn {
@@ -989,7 +989,7 @@ export default {
   border: none;
   background: none;
   cursor: pointer;
-  font-size: $font-size-base;
+  font-size: var(--font-size-base);
   text-align: left;
 
   &:not(:last-child) {
@@ -999,10 +999,10 @@ export default {
   &:hover {
     background: rgba(0, 0, 0, 0.05);
   }
+}
 
-  &--active {
-    font-weight: bold;
-    background: rgba(0, 0, 0, 0.08);
-  }
+.map-style-popover-btn--active {
+  font-weight: bold;
+  background: rgba(0, 0, 0, 0.08);
 }
 </style>

--- a/webapp/pages/moderation.vue
+++ b/webapp/pages/moderation.vue
@@ -61,10 +61,10 @@ export default {
 }
 </script>
 
-<style lang="scss">
-// AreaMenu owns its own responsive width (full-width select on narrow viewports,
-// 200px sidebar from $media-query-small up); the main column just fills the rest
-// and shrinks below its content's intrinsic width instead of wrapping under the menu.
+<style>
+/*  AreaMenu owns its own responsive width (full-width select on narrow viewports, */
+/*  200px sidebar from 600px up); the main column just fills the rest */
+/*  and shrinks below its content's intrinsic width instead of wrapping under the menu. */
 .moderation-layout__main {
   flex: 1 1 0;
   min-width: 0;

--- a/webapp/pages/notifications/index.vue
+++ b/webapp/pages/notifications/index.vue
@@ -176,8 +176,8 @@ export default {
   },
 }
 </script>
-<style lang="scss">
-@media #{$media-query-large} {
+<style>
+@media (min-width: 1024px) {
   .notifications-layout__title {
     flex: 0 0 85%;
     width: 85%;

--- a/webapp/pages/password-reset.vue
+++ b/webapp/pages/password-reset.vue
@@ -51,7 +51,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .back-link {
   height: 35px;
 }

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -549,22 +549,22 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .post-detail-layout__main {
   flex: 0 0 100%;
   width: 100%;
 }
-@media #{$media-query-small} {
+@media (min-width: 600px) {
   .post-detail-layout__main {
     flex: 2 0 0;
   }
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .post-detail-layout__main {
     flex: 2 0 0;
   }
 }
-@media #{$media-query-large} {
+@media (min-width: 1024px) {
   .post-detail-layout__main {
     flex: 1 0 0;
   }
@@ -602,7 +602,7 @@ export default {
   }
 
   &.--blur-image > .os-card__hero-image > .image {
-    filter: blur($blur-radius);
+    filter: blur(var(--blur-radius));
   }
 
   .blur-toggle {
@@ -623,7 +623,7 @@ export default {
   }
 
   .comments {
-    margin-top: $space-small;
+    margin-top: var(--space-small);
 
     .ProseMirror {
       min-height: 0px;
@@ -632,14 +632,14 @@ export default {
 }
 </style>
 
-<style lang="scss" scoped>
+<style scoped>
 .actions {
   display: flex;
   align-items: center;
   justify-content: right;
-  gap: $space-small;
-  margin-top: $space-small;
-  margin-bottom: calc($space-base * 2);
+  gap: var(--space-small);
+  margin-top: var(--space-small);
+  margin-bottom: calc(var(--space-base) * 2);
 }
 
 .ds-heading {

--- a/webapp/pages/post/create/_type.vue
+++ b/webapp/pages/post/create/_type.vue
@@ -250,7 +250,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .ds-heading {
   margin-top: 0;
 }
@@ -259,18 +259,18 @@ export default {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  gap: $space-x-small;
+  gap: var(--space-x-small);
 }
 
 .post-in-trigger {
   font: inherit;
-  color: $color-primary;
+  color: var(--color-primary);
   display: inline-flex;
-  // Text (.post-in-link) aligns on the text baseline with the surrounding
-  // "Veröffentlichen in" prefix; icons use align-self: center so they are
-  // vertically centered next to the text instead of floating above it.
+  /*  Text (.post-in-link) aligns on the text baseline with the surrounding */
+  /*  "Veröffentlichen in" prefix; icons use align-self: center so they are */
+  /*  vertically centered next to the text instead of floating above it. */
   align-items: baseline;
-  gap: $space-xx-small;
+  gap: var(--space-xx-small);
   pointer-events: none;
   transition: color 0.15s ease;
 }
@@ -315,16 +315,16 @@ export default {
   border: 0;
   background: transparent;
   font: inherit;
-  // Firefox needs a color so options inherit something readable when opened
-  color: $text-color-base;
+  /*  Firefox needs a color so options inherit something readable when opened */
+  color: var(--text-color-base);
 }
 
-// Hover + keyboard focus both highlight the trigger via the wrapper.
-// :focus-within (not `+ .post-in-trigger`) because the trigger sits before
-// the select in DOM order — a sibling combinator would never match.
+/*  Hover + keyboard focus both highlight the trigger via the wrapper. */
+/*  :focus-within (not `+ .post-in-trigger`) because the trigger sits before */
+/*  the select in DOM order — a sibling combinator would never match. */
 .post-in-select-wrapper:hover .post-in-trigger,
 .post-in-select-wrapper:focus-within .post-in-trigger {
-  color: $color-primary-active;
+  color: var(--color-primary-highlight);
 }
 
 .post-create-layout__sidebar,
@@ -332,7 +332,7 @@ export default {
   flex: 0 0 100%;
   width: 100%;
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .post-create-layout__sidebar {
     flex: 0 0 200px;
     width: 200px;

--- a/webapp/pages/post/edit/_id.vue
+++ b/webapp/pages/post/edit/_id.vue
@@ -115,7 +115,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .ds-heading {
   margin-top: 0;
 }
@@ -125,7 +125,7 @@ export default {
   flex: 0 0 100%;
   width: 100%;
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .post-edit-layout__sidebar {
     flex: 0 0 200px;
     width: 200px;

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -677,14 +677,14 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style scoped>
 ::v-deep .profile-page-avatar.profile-avatar {
   margin: auto;
   margin-top: -60px;
 }
 @media (max-width: 810px) {
   .profile-layout {
-    padding-top: $space-large;
+    padding-top: var(--space-large);
   }
 }
 .badge-edit-link {
@@ -695,8 +695,8 @@ export default {
 }
 .profile-layout__sidebar ::v-deep .content-menu {
   position: absolute;
-  top: $space-x-small;
-  right: $space-x-small;
+  top: var(--space-x-small);
+  right: var(--space-x-small);
 }
 .profile-layout__sidebar,
 .profile-layout__main {
@@ -704,7 +704,7 @@ export default {
   width: 100%;
   min-width: 0;
 }
-@media #{$media-query-small} {
+@media (min-width: 600px) {
   .profile-layout__sidebar {
     flex: 2 0 0;
   }
@@ -712,7 +712,7 @@ export default {
     flex: 3 0 0;
   }
 }
-@media #{$media-query-medium} {
+@media (min-width: 768px) {
   .profile-layout__sidebar {
     flex: 2 0 0;
   }
@@ -720,7 +720,7 @@ export default {
     flex: 5 0 0;
   }
 }
-@media #{$media-query-large} {
+@media (min-width: 1024px) {
   .profile-layout__sidebar {
     flex: 1 0 0;
   }
@@ -731,15 +731,15 @@ export default {
 .profile-post-add-button-container {
   display: flex;
   justify-content: center;
-  margin: $space-small 0;
+  margin: var(--space-small) 0;
 }
 ::v-deep .profile-post-add-button {
-  box-shadow: $box-shadow-x-large !important;
+  box-shadow: var(--box-shadow-x-large) !important;
 }
 .action-buttons {
   display: flex;
   flex-direction: column;
-  gap: $space-x-small;
-  margin: $space-small 0;
+  gap: var(--space-x-small);
+  margin: var(--space-small) 0;
 }
 </style>

--- a/webapp/pages/settings.vue
+++ b/webapp/pages/settings.vue
@@ -99,16 +99,16 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style scoped>
 .settings-header {
-  margin-top: $space-base;
-  margin-bottom: $space-x-small;
+  margin-top: var(--space-base);
+  margin-bottom: var(--space-x-small);
 }
 
 .settings-layout {
   display: flex;
   flex-direction: column;
-  gap: $space-xx-small;
+  gap: var(--space-xx-small);
 }
 
 .settings-content {
@@ -116,18 +116,18 @@ export default {
   min-width: 0;
 }
 
-@media #{$media-query-small} {
+@media (min-width: 600px) {
   .settings-header {
-    margin-bottom: $space-small;
+    margin-bottom: var(--space-small);
   }
 
   .settings-layout {
     flex-direction: row;
-    gap: $space-small;
+    gap: var(--space-small);
   }
 
   .settings-content {
-    padding: 0 $space-base;
+    padding: 0 var(--space-base);
   }
 }
 </style>

--- a/webapp/pages/settings/api-keys.vue
+++ b/webapp/pages/settings/api-keys.vue
@@ -389,73 +389,73 @@ export default {
 }
 </script>
 
-<style scoped lang="scss">
+<style scoped>
 .secret-banner {
-  background-color: $color-warning-inverse;
-  border: 1px solid $color-warning;
+  background-color: var(--color-warning-inverse);
+  border: 1px solid var(--color-warning);
 }
 
 .secret-display {
   display: flex;
   align-items: center;
-  gap: $space-x-small;
-  margin: $space-x-small 0;
+  gap: var(--space-x-small);
+  margin: var(--space-x-small) 0;
 }
 
 .secret-code {
   flex: 1;
-  padding: $space-x-small;
-  background: $background-color-base;
-  border: 1px solid $color-neutral-80;
-  border-radius: $border-radius-base;
+  padding: var(--space-x-small);
+  background: var(--background-color-base);
+  border: 1px solid var(--color-neutral-80);
+  border-radius: var(--border-radius-base);
   word-break: break-all;
-  font-size: $font-size-small;
+  font-size: var(--font-size-small);
 }
 
 .secret-warning {
-  color: $color-warning;
+  color: var(--color-warning);
   font-style: italic;
 }
 
 .key-counter {
   font-weight: normal;
-  font-size: $font-size-base;
-  color: $color-neutral-50;
+  font-size: var(--font-size-base);
+  color: var(--color-neutral-50);
 }
 
 .limit-warning {
-  color: $color-warning;
-  margin-bottom: $space-x-small;
+  color: var(--color-warning);
+  margin-bottom: var(--space-x-small);
 }
 
 .status-label {
-  font-size: $font-size-small;
-  color: $text-color-soft;
+  font-size: var(--font-size-small);
+  color: var(--text-color-soft);
   font-style: italic;
 }
 
 .revoked-section {
-  margin-top: $space-large;
+  margin-top: var(--space-large);
 }
 
 .revoked-toggle {
   display: flex;
   align-items: center;
-  gap: $space-x-small;
+  gap: var(--space-x-small);
   background: none;
   border: none;
   cursor: pointer;
-  color: $text-color-soft;
-  padding: $space-x-small 0;
-  font-size: $font-size-base;
+  color: var(--text-color-soft);
+  padding: var(--space-x-small) 0;
+  font-size: var(--font-size-base);
 
   &:hover {
-    color: $text-color-base;
+    color: var(--text-color-base);
   }
 }
 
 .revoked-chevron {
-  font-size: $font-size-small;
+  font-size: var(--font-size-small);
   transition: transform 0.2s;
 
   &.open {
@@ -471,7 +471,7 @@ tr > th:last-child,
 tr > td:last-child {
   position: sticky;
   right: 0;
-  background-color: $background-color-base;
+  background-color: var(--background-color-base);
   text-align: center;
 }
 
@@ -481,10 +481,10 @@ tr > td:last-child {
 
 .settings-select {
   width: 100%;
-  padding: $space-x-small;
-  font-size: $font-size-base;
-  border: 1px solid $color-neutral-80;
-  border-radius: $border-radius-base;
-  background-color: $background-color-base;
+  padding: var(--space-x-small);
+  font-size: var(--font-size-base);
+  border: 1px solid var(--color-neutral-80);
+  border-radius: var(--border-radius-base);
+  background-color: var(--background-color-base);
 }
 </style>

--- a/webapp/pages/settings/embeds.vue
+++ b/webapp/pages/settings/embeds.vue
@@ -118,12 +118,12 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 button + button {
-  margin-left: $space-x-small;
+  margin-left: var(--space-x-small);
 }
 .provider-list-item {
-  margin-top: $space-xx-small;
-  margin-bottom: $space-xx-small;
+  margin-top: var(--space-xx-small);
+  margin-bottom: var(--space-xx-small);
 }
 </style>

--- a/webapp/pages/settings/index.vue
+++ b/webapp/pages/settings/index.vue
@@ -142,12 +142,12 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .location-hint {
-  margin-top: -$space-x-small - $space-xxx-small - $space-xxx-small;
+  margin-top: calc(-1 * var(--space-x-small) - var(--space-xxx-small) - var(--space-xxx-small));
 }
 
 .location-selet {
-  margin-bottom: $space-small;
+  margin-bottom: var(--space-small);
 }
 </style>

--- a/webapp/pages/settings/my-email-address/verify.vue
+++ b/webapp/pages/settings/my-email-address/verify.vue
@@ -98,7 +98,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .message {
   display: flex;
   justify-content: space-around;

--- a/webapp/pages/settings/notifications.vue
+++ b/webapp/pages/settings/notifications.vue
@@ -149,14 +149,14 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 .notifcation-settings-section {
-  margin-left: $space-x-small;
+  margin-left: var(--space-x-small);
 }
 .label {
-  margin-left: $space-xx-small;
+  margin-left: var(--space-xx-small);
 }
 button + button {
-  margin-left: $space-x-small;
+  margin-left: var(--space-x-small);
 }
 </style>

--- a/webapp/pages/terms-and-conditions-confirm.vue
+++ b/webapp/pages/terms-and-conditions-confirm.vue
@@ -87,7 +87,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style>
 .terms-and-conditions-confirm > .os-card {
   height: 280px;
   display: flex;
@@ -96,7 +96,7 @@ export default {
   justify-content: space-between;
 
   > .os-icon {
-    font-size: $font-size-xxx-large;
+    font-size: var(--font-size-xxx-large);
   }
 }
 </style>


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

convert pages and layouts to plain CSS
Completes the conversion: after this commit no lang="scss" block remains in the webapp.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Stylesheets in zahlreichen Layouts und Seiten auf natives CSS umgestellt.
  * Designvariablen für Farben, Abstände, Schriftgrößen und Schatten verwenden nun CSS-Variablen.
  * Responsive Breakpoints und verschachtelte Selektoren wurden standardisiert.
  * Bestehende Layouts, Interaktionen und Darstellungen bleiben unverändert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->