### PR TITLE
fix(maintenance): fix healthcheck & email in maintenance

### DIFF
--- a/deployment/TODO-next-update.md
+++ b/deployment/TODO-next-update.md
@@ -96,22 +96,43 @@ nothing to do, and the running pod kept serving the old value until something un
 restart it. Those three pod templates now carry `checksum/config` and `checksum/secret` annotations
 over the rendered manifests, so a changed value is a changed pod template and Helm rolls it out.
 
-The two remaining workloads differ: imagor has no ConfigMap — it takes everything from its secret —
-so it carries `checksum/secret` alone, and maintenance carries no `checksum/*` at all because its
-env is inline in the pod template, where a change is already a template change.
+imagor differs: it has no ConfigMap — it takes everything from its secret — so it carries
+`checksum/secret` alone. Maintenance follows the same route as backend and webapp now, see below.
 
 **Action:** none — but be aware of two consequences.
 
-- **This upgrade restarts backend, webapp, imagor and Neo4j once** (maintenance is untouched),
-  because the annotations themselves are new. For the Neo4j StatefulSet that is a short database
-  restart. It happens inside the maintenance window you already need for the
-  StatefulSet-to-Deployment switch above, so plan them together.
+- **This upgrade restarts backend, webapp, imagor, maintenance and Neo4j once**, because the
+  annotations themselves are new. For the Neo4j StatefulSet that is a short database restart. It
+  happens inside the maintenance window you already need for the StatefulSet-to-Deployment switch
+  above, so plan them together.
 - **From now on, editing `neo4j.env` restarts the database.** That is the honest behaviour — the
   setting was never live before — but treat a heap-size or page-cache change as the restart it is.
 
 Neo4j's `terminationGracePeriodSeconds` is raised to `120` in the same step: the default 30 s can
 cut a flush short on a larger graph, and a SIGKILL mid-flush turns the next start into a recovery
 run.
+
+## `maintenance.supportEmail` is `maintenance.env.SUPPORT_EMAIL`
+
+The maintenance container took its one setting through a chart field of its own, while every other
+workload takes its environment through `<component>.env` → ConfigMap → `envFrom`. It follows the
+convention now: there is a `maintenance.env` map and a `<release>-maintenance-env` ConfigMap, and the
+pod template carries a `checksum/config` annotation like the others (without it a changed address
+would sit in the ConfigMap while the pod keeps serving the old one — nothing else ever restarts a
+static page).
+
+`SUPPORT_EMAIL` still **defaults to `backend.env.SUPPORT_EMAIL`**, so the address on the page and the
+one the backend uses cannot disagree.
+
+**Action:** only if you set `maintenance.supportEmail` explicitly — it is ignored now. Write
+
+```yaml
+maintenance:
+  env:
+    SUPPORT_EMAIL: "support@example.org"
+```
+
+If you never set it, there is nothing to do: the backend fallback is unchanged.
 
 ## The Neo4j volumes are protected against Helm now
 
@@ -133,9 +154,14 @@ delete the claim by hand to save the storage.
 
 Only the backend had probes. Without a `readinessProbe` a pod counts as Ready the moment its
 container process starts — for Nuxt that is seconds before it listens, so Traefik routed into a 502
-for the whole surge window of every webapp rollout. Webapp, imagor and Neo4j now have readiness
-probes (`tcpSocket`), maintenance an `httpGet` on `/`, and webapp and imagor a `preStop` sleep that
-covers the gap between endpoint removal and SIGTERM.
+for the whole surge window of every webapp rollout. Webapp, imagor, maintenance and Neo4j now have
+readiness probes (all `tcpSocket`), and webapp and imagor a `preStop` sleep that covers the gap
+between endpoint removal and SIGTERM.
+
+Maintenance is `tcpSocket` like the rest, and must stay that way: the page answers **503** to every
+page request on purpose, and kubelet counts only 2xx/3xx as probe success — an `httpGet` on `/`
+leaves the pod permanently unready and restarting, and the rollout then silently stalls on the
+previous ReplicaSet (see `templates/maintenance/deployment.yaml`).
 
 Neo4j gets **no** liveness probe on purpose: a database busy with recovery or a long GC pause is not
 one that should be killed and restarted.

--- a/deployment/helm/charts/ocelot-social/templates/maintenance/configmap.yml
+++ b/deployment/helm/charts/ocelot-social/templates/maintenance/configmap.yml
@@ -1,0 +1,20 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-maintenance-env
+# `maintenance.env` like every other workload's `<component>.env`, with one default folded in:
+# SUPPORT_EMAIL follows the backend's value unless the brand states its own, so the address the
+# maintenance page shows and the one the backend uses cannot disagree, and a brand that already
+# configures the backend gets a correctly addressed maintenance page without a second entry.
+#
+# Deliberately no default in values.yaml: with neither side set, both fall back to the same software
+# default (backend/src/config/softwareDefaults.ts SUPPORT_EMAIL, mirrored in the maintenance app) —
+# a chart-level default would add a second place to state it and a second place to forget.
+{{- $env := deepCopy (.Values.maintenance.env | default dict) }}
+{{- if not (hasKey $env "SUPPORT_EMAIL") }}
+{{- with (.Values.backend.env).SUPPORT_EMAIL }}
+{{- $_ := set $env "SUPPORT_EMAIL" . }}
+{{- end }}
+{{- end }}
+data:
+{{ $env | toYaml | indent 2 }}

--- a/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
@@ -8,6 +8,11 @@ spec:
       app: {{ .Release.Name }}-maintenance
   template:
     metadata:
+      annotations:
+        # See the backend deployment: `envFrom` is resolved once at container start, so without this
+        # a changed SUPPORT_EMAIL would update the ConfigMap while the running pod keeps serving the
+        # old address — and the page is static, so nothing else would ever restart it.
+        checksum/config: {{ include (print $.Template.BasePath "/maintenance/configmap.yml") . | sha256sum }}
       labels:
         app: {{ .Release.Name }}-maintenance
     spec:
@@ -21,34 +26,37 @@ spec:
         env:
           - name: HOST
             value: 0.0.0.0
-          # The support address the page shows. The page is static, so its nginx entrypoint
-          # substitutes this into the built files at startup (maintenance/nginx/40-support-email.sh)
-          # rather than it being baked into a per-brand image.
-          #
-          # It follows the backend's value so the two cannot disagree. Deliberately NOT defaulted in
-          # values.yaml: with neither set, both sides already fall back to the same software default
-          # (backend/src/config/softwareDefaults.ts SUPPORT_EMAIL, mirrored in the maintenance app) —
-          # a chart-level default would add a second place to state it and a second place to forget.
-          {{- with .Values.maintenance.supportEmail | default (.Values.backend.env).SUPPORT_EMAIL }}
-          - name: SUPPORT_EMAIL
-            value: {{ quote . }}
-          {{- end }}
+        # `maintenance.env`, the same route every other workload takes. It carries SUPPORT_EMAIL: the
+        # page is static, so its nginx entrypoint substitutes the address into the built files at
+        # startup (maintenance/nginx/40-support-email.sh) rather than it being baked into a per-brand
+        # image — which is what keeps the value deployment config in this chart.
+        envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}-maintenance-env
         ports:
           - containerPort: 8080
-        # httpGet here, unlike the other workloads: this is nginx serving a static page, so a real
-        # request is cheap and proves more than an open socket — namely that the entrypoint has
-        # finished substituting SUPPORT_EMAIL into the built files. No checksum/* annotation is
-        # needed either, because this deployment's env is inline in the template rather than in a
+        # tcpSocket, like every other workload — an httpGet here CANNOT work: the maintenance page
+        # answers 503 to every page request on purpose (maintenance/nginx/custom.conf), and kubelet
+        # counts only 2xx/3xx as success. Probing `/` therefore left the pod permanently unready and
+        # restarting, while the previous ReplicaSet — the one still holding the Service endpoint —
+        # went on serving a page built before SUPPORT_EMAIL existed.
+        #
+        # The socket proves everything an httpGet would prove here anyway: nginx execs only after
+        # /docker-entrypoint.d/40-support-email.sh has substituted SUPPORT_EMAIL into the built
+        # files, and it refuses to start at all on a config it cannot parse. No checksum/* annotation
+        # is needed either, because this deployment's env is inline in the template rather than in a
         # ConfigMap: changing it already changes the pod template.
+        #
+        # Keep this independent of the image: brands pin their maintenance image to an OCELOT_VERSION
+        # but pull this chart from master, so a probe that needs a location added here today would
+        # break every brand whose image predates it.
         readinessProbe:
-          httpGet:
-            path: /
+          tcpSocket:
             port: 8080
           initialDelaySeconds: 3
           periodSeconds: 5
         livenessProbe:
-          httpGet:
-            path: /
+          tcpSocket:
             port: 8080
           initialDelaySeconds: 15
           periodSeconds: 20

--- a/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
+++ b/deployment/helm/charts/ocelot-social/templates/maintenance/deployment.yaml
@@ -43,9 +43,7 @@ spec:
         #
         # The socket proves everything an httpGet would prove here anyway: nginx execs only after
         # /docker-entrypoint.d/40-support-email.sh has substituted SUPPORT_EMAIL into the built
-        # files, and it refuses to start at all on a config it cannot parse. No checksum/* annotation
-        # is needed either, because this deployment's env is inline in the template rather than in a
-        # ConfigMap: changing it already changes the pod template.
+        # files, and it refuses to start at all on a config it cannot parse.
         #
         # Keep this independent of the image: brands pin their maintenance image to an OCELOT_VERSION
         # but pull this chart from master, so a probe that needs a location added here today would

--- a/deployment/helm/charts/ocelot-social/values.yaml
+++ b/deployment/helm/charts/ocelot-social/values.yaml
@@ -75,10 +75,15 @@ webapp:
 maintenance:
   image:
     repository: ghcr.io/ocelot-social-community/ocelot-social/maintenance
-  # The support address shown on the maintenance page. Defaults to backend.env.SUPPORT_EMAIL — the
-  # page is static, so its nginx entrypoint substitutes the value at startup instead of it being baked
-  # into a per-brand image. Set this only to show a DIFFERENT address than the backend uses.
-  supportEmail: ""
+  # Environment of the maintenance container, like backend.env and webapp.env.
+  #
+  #   env:
+  #     # The support address the page shows. The page is static, so its nginx entrypoint substitutes
+  #     # this into the built files at startup instead of it being baked into a per-brand image.
+  #     # Unset it follows backend.env.SUPPORT_EMAIL, so the two cannot disagree — state it here only
+  #     # to show a DIFFERENT address than the backend uses.
+  #     SUPPORT_EMAIL: "hello@ocelot.social"
+  env: {}
 
 imagor:
   image:


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix healthcheck & email in maintenance

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Die Maintenance-Konfiguration unterstützt Umgebungsvariablen über eine ConfigMap.
  * Support-E-Mail-Adressen lassen sich flexibler konfigurieren; standardmäßig bleibt die bisherige Fallback-Adresse erhalten.
  * Imagor verwendet zusätzlich eine Prüfsummen-/Secret-Annotation zur zuverlässigeren Aktualisierung.

* **Verbesserungen**
  * Webapp, Imagor, Maintenance und Neo4j nutzen TCP-basierte Bereitschaftsprüfungen.
  * Neo4j erhält eine verlängerte Beendigungsfrist für kontrollierte Abschaltungen.
  * Bestehende Wartezeiten beim Beenden von Webapp und Imagor bleiben erhalten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->