### PR TITLE
feat(package/branding): webapp ssr favicon, maintenance favicon, branding 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   "packages/ui": "0.0.1",
-  "packages/branding": "0.1.0"
+  "packages/branding": "0.1.1"
 }

--- a/maintenance/app/constants/metadata.ts
+++ b/maintenance/app/constants/metadata.ts
@@ -29,6 +29,11 @@ const defaults = {
   // serves from /brand/ — the filename varies (.svg / .png), so it travels as a key, not a
   // hard-coded path in app.vue.
   LOGO: "/img/custom/logo-squared.svg",
+  // The browser-tab icon. Vanilla is the committed public/favicon.ico; a brand points this at the copy
+  // the generator serves from /brand/. nuxt.config.ts reads the same overlay to emit the <link> at
+  // BUILD time — with `ssr: false` nothing from useHead reaches the prerendered index.html, so a
+  // runtime-only link would leave the browser to its implicit /favicon.ico request in the meantime.
+  FAVICON: "/favicon.ico",
 };
 
 export default {

--- a/maintenance/nuxt.config.ts
+++ b/maintenance/nuxt.config.ts
@@ -24,6 +24,32 @@ const brandStylesheets: string[] = has(BRAND_STYLESHEETS)
   ? (JSON.parse(readFileSync(file(BRAND_STYLESHEETS), "utf8")) as string[])
   : [];
 
+// The favicon is read HERE rather than declared via useHead in app.vue, because with `ssr: false`
+// useHead contributes nothing to the prerendered index.html — the link would only appear once the
+// bundle has run, and until then the browser issues its implicit /favicon.ico request and gets the
+// vanilla icon. Emitting it from the config puts it in the built markup, where it belongs.
+//
+// The same overlay app/constants/metadata.ts reads, so there is one artifact and no second file to
+// keep in step; the default below matches its own FAVICON default.
+const BRAND_METADATA = "app/constants/metadata.brand.json";
+const brandMetadata: Record<string, string> = has(BRAND_METADATA)
+  ? (JSON.parse(readFileSync(file(BRAND_METADATA), "utf8")) as Record<string, string>)
+  : {};
+const favicon = brandMetadata.FAVICON ?? "/favicon.ico";
+
+// A wrong type can make a browser discard the icon outright, so an extension we do not recognise is
+// announced as nothing at all and left to sniffing.
+const ICON_TYPES: Record<string, string> = {
+  ico: "image/x-icon",
+  png: "image/png",
+  svg: "image/svg+xml",
+  gif: "image/gif",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+};
+const faviconType = ICON_TYPES[/\.([a-z0-9]+)(?:[?#]|$)/i.exec(favicon)?.[1]?.toLowerCase() ?? ""];
+
 // Per-locale overlays holding just the namespaces this page renders. `files` is a merge list: the
 // vanilla file first, the brand's on top, so an untranslated key keeps its default.
 const localeFiles = (code: string): string[] =>
@@ -51,11 +77,14 @@ export default defineNuxtConfig({
       // `tagPriority: "low"` puts these AFTER the bundled css above — the position the brand sheet
       // held while it was the last entry in `css`. Without it unhead emits config head tags before
       // the build's own stylesheet links, and a brand rule would lose every tie on specificity.
-      link: brandStylesheets.map((href) => ({
-        rel: "stylesheet",
-        href,
-        tagPriority: "low" as const,
-      })),
+      link: [
+        { rel: "icon", href: favicon, ...(faviconType ? { type: faviconType } : {}) },
+        ...brandStylesheets.map((href) => ({
+          rel: "stylesheet",
+          href,
+          tagPriority: "low" as const,
+        })),
+      ],
     },
   },
   i18n: {

--- a/packages/branding/package.json
+++ b/packages/branding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ocelot-social/branding",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared branding override schema, framework defaults and resolver — consumed by both backend and webapp so brand-tunable constants (group limits, registration lengths, metadata, logo paths, menu, …) cannot drift between the two. Authored in TypeScript, built to dist/ (CommonJS + .d.ts).",
   "license": "MIT",
   "type": "module",

--- a/packages/branding/scripts/build-maintenance-branding.spec.ts
+++ b/packages/branding/scripts/build-maintenance-branding.spec.ts
@@ -526,6 +526,64 @@ describe('build-maintenance-branding', () => {
     assert.equal(meta.APPLICATION_NAME, 'Gap')
   })
 
+  // The build only namespaces paths a brand writes relative to its own root; absolute and external
+  // ones reach the generator verbatim. What each kind can mean differs HERE and nowhere else, because
+  // this page is served with the webapp down — so all three are pinned together.
+  describe('asset paths the build does not namespace', () => {
+    /** A brand whose logo, OG image, favicon and stylesheet are all set to `path`. */
+    function brandPointingAt(path: string): string {
+      const from = tmp('ocelot-brand-external-')
+      write(join(from, 'package.json'), JSON.stringify({ name: 'external-branding' }))
+      write(
+        join(from, 'brand.config.mjs'),
+        `export default (d) =>
+  d({
+    metadata: { applicationName: 'Ext', ogImage: ${JSON.stringify(path)} },
+    assets: { css: [${JSON.stringify(path)}], favicon: ${JSON.stringify(path)} },
+    logos: { signupPath: ${JSON.stringify(path)} },
+  })
+`,
+      )
+      return from
+    }
+
+    const overlay = (dir: string): Record<string, string> =>
+      readJson(dir, 'app/constants/metadata.brand.json') as unknown as Record<string, string>
+
+    // An external URL is the one non-archive path that still WORKS here: a CDN stays up while the
+    // webapp is down. Dropping it would replace a perfectly good asset with the vanilla one.
+    test('keeps an external url verbatim, for every slot alike', () => {
+      const to = maintenanceDir()
+      const { status, stderr } = run(brandPointingAt('https://cdn.example/brand.ico'), to)
+
+      assert.equal(status, 0)
+      const meta = overlay(to)
+      assert.equal(meta.FAVICON, 'https://cdn.example/brand.ico')
+      assert.equal(meta.LOGO, 'https://cdn.example/brand.ico')
+      assert.equal(meta.OG_IMAGE, 'https://cdn.example/brand.ico')
+      assert.deepEqual(readSheets(to), ['https://cdn.example/brand.ico'])
+      assert.equal(stderr, '')
+    })
+
+    // An absolute path into the framework's own tree is served BY THE WEBAPP. This page renders
+    // precisely when that is down, so linking it would 404 on every request — the vanilla asset is
+    // the better outcome, and the warning is what stops it being a mystery.
+    test('drops a webapp-served path with a warning and keeps the vanilla asset', () => {
+      const to = maintenanceDir()
+      const { status, stderr } = run(brandPointingAt('/img/custom/logo.svg'), to)
+
+      assert.equal(status, 0) // never fatal: one bad path must not cost a deployment its page
+      const meta = overlay(to)
+      // Omitted, not null — a present overlay key wins, so null would blank the vanilla value out
+      // instead of falling through to it.
+      for (const key of ['FAVICON', 'LOGO', 'OG_IMAGE']) assert.ok(!(key in meta), key)
+      assert.deepEqual(readSheets(to), [])
+      assert.ok(existsSync(join(to, 'public/favicon.ico'))) // the vanilla icon still answers
+      assert.match(stderr, /favicon: \/img\/custom\/logo\.svg is served by the webapp/)
+      assert.match(stderr, /stylesheet: \/img\/custom\/logo\.svg is served by the webapp/)
+    })
+  })
+
   // A brand may point at a font it serves itself (a CDN). There is nothing to copy out of the archive
   // then — reference it as given.
   test('leaves an external font url alone — the sheet travels verbatim', () => {

--- a/packages/branding/scripts/build-maintenance-branding.spec.ts
+++ b/packages/branding/scripts/build-maintenance-branding.spec.ts
@@ -69,12 +69,13 @@ function brandDir(): string {
   defineBranding({
     metadata: { applicationName: 'Acme' },
 
-    assets: { css: ['assets/brand.css'] },
+    assets: { css: ['assets/brand.css'], favicon: 'assets/favicon.ico' },
     logos: { signupPath: 'assets/logo-squared.svg' },
   })
 `,
   )
   write(join(dir, 'assets/logo-squared.svg'), '<svg id="brand"/>')
+  write(join(dir, 'assets/favicon.ico'), Buffer.from('ico-bytes'))
   write(join(dir, 'assets/fonts/acme.woff2'), Buffer.from('woff2-bytes'))
   // The font lives in the brand's own stylesheet; url() is relative to THAT file (assets/…).
   write(
@@ -166,6 +167,7 @@ describe('build-maintenance-branding', () => {
       'app/constants/metadata.brand.json',
       'app/locales/de.json',
       'public/brand/logo-squared.svg',
+      'public/brand/favicon.ico',
       'public/brand/fonts/acme.woff2',
     ]) {
       assert.ok(existsSync(join(to, rel)), `expected ${rel}`)
@@ -274,6 +276,44 @@ describe('build-maintenance-branding', () => {
     // The composed ogImage is a /branding/<id>/… path this static site never serves — it has to be
     // rewritten to the copy that IS served, or every link preview 404s.
     assert.equal(meta.OG_IMAGE, '/brand/logo-squared.svg')
+  })
+
+  // Without this the page kept its own committed public/favicon.ico — the vanilla ocelot icon — for
+  // every brand, permanently: the built index.html carries no icon link (Nuxt 4 adds none, and
+  // `ssr: false` keeps useHead out of the prerendered markup), so the browser falls back to its
+  // implicit /favicon.ico request and nothing ever pointed it elsewhere.
+  test('serves the favicon and names it in the metadata overlay', () => {
+    const to = maintenanceDir()
+    brand(brandDir(), to)
+
+    const meta = readJson(to, 'app/constants/metadata.brand.json') as unknown as Record<
+      string,
+      string
+    >
+    assert.equal(readText(to, 'public/brand/favicon.ico'), 'ico-bytes')
+    assert.equal(meta.FAVICON, '/brand/favicon.ico')
+    // The committed vanilla file is left alone — the overlay redirects the link, it does not
+    // overwrite a tracked file (that is the whole point of the overlay design).
+    assert.ok(existsSync(join(to, 'public/favicon.ico')))
+  })
+
+  // A present overlay key WINS over the vanilla default, so a brand that declares no favicon must
+  // yield no key at all — writing null would blank out the working vanilla icon.
+  test('omits FAVICON entirely for a brand that ships none', () => {
+    const to = maintenanceDir()
+    const from = tmp('ocelot-brand-')
+    write(join(from, 'package.json'), JSON.stringify({ name: 'bare-branding' }))
+    write(
+      join(from, 'brand.config.mjs'),
+      `export default (d) => d({ metadata: { applicationName: 'Bare' } })\n`,
+    )
+    brand(from, to)
+
+    const meta = readJson(to, 'app/constants/metadata.brand.json') as unknown as Record<
+      string,
+      string
+    >
+    assert.equal('FAVICON' in meta, false)
   })
 
   // Reducing an archive entry to its basename would put two of them on one file. Both cases are

--- a/packages/branding/scripts/build-maintenance-branding.ts
+++ b/packages/branding/scripts/build-maintenance-branding.ts
@@ -163,6 +163,15 @@ function serveImage(namespaced: string, label: string): string | null {
 
 const logoUrl = serveImage(config.logos.signupPath, 'logo')
 const ogImageUrl = serveImage(config.metadata.ogImage, 'og image')
+// The browser-tab icon. It travels exactly like the logo — and it has to travel at all, because this
+// page ships its own vanilla public/favicon.ico and nothing else would ever replace it: the built
+// index.html carries no icon link (Nuxt 4 adds none, and useHead cannot help with `ssr: false`), so
+// the browser falls back to its implicit /favicon.ico request. Every brand's maintenance page showed
+// the ocelot icon until this was wired up.
+//
+// Only `assets.favicon`, not `assets.icon`: apple-touch and PWA install icons exist for a site being
+// added to a home screen, which is not something anyone does with a maintenance page.
+const faviconUrl = config.assets.favicon ? serveImage(config.assets.favicon, 'favicon') : null
 // The composed ogImage is a `/branding/<id>/…` path — served by the live webapp, never by this static
 // site — so it has to become the copy just made. Falling back to the logo covers the usual case, where
 // a brand sets no separate OG image and the build derived it from the squared logo. null means the
@@ -200,6 +209,9 @@ writeFileSync(
           }
         : {}),
       ...(logoUrl ? { LOGO: logoUrl } : {}),
+      // Same omit-rather-than-null rule as above: a present key WINS, so a brand whose favicon is not
+      // in the archive must fall through to the vanilla one instead of blanking it out.
+      ...(faviconUrl ? { FAVICON: faviconUrl } : {}),
     },
     null,
     2,

--- a/packages/branding/scripts/build-maintenance-branding.ts
+++ b/packages/branding/scripts/build-maintenance-branding.ts
@@ -103,6 +103,32 @@ function archiveEntry(namespaced: string): { entry: string; data: Buffer } | nul
   return { entry, data }
 }
 
+/**
+ * Where a configured asset path can point, and what each kind means for a page nginx serves from a
+ * static root WHILE THE WEBAPP IS DOWN. The build only namespaces paths a brand writes relative to
+ * its own root (build-brandings.ts `isRelativeAsset`); absolute and external ones survive composition
+ * verbatim, so all three kinds reach this script and each needs an answer:
+ *
+ *   • `/branding/<id>/…` — the brand's own archived file. Copied out, and the served copy's URL is
+ *     what travels; the live route serving it does not exist here.
+ *   • `http(s):` / `data:` — reachable (or self-contained) with the webapp down, so kept VERBATIM,
+ *     exactly as the live app uses it. A brand hosting its logo on a CDN is the case this exists for.
+ *   • any other absolute `/…` — a path the WEBAPP serves (`/img/custom/…`). It is precisely what this
+ *     static site cannot answer, so it is dropped: a `<link>` to it would 404 on every request.
+ *
+ * Dropping is a WARNING and a null, never a written null — callers omit the overlay key, which lets
+ * the vanilla value survive (a present key wins; see the metadata overlay below).
+ */
+function servedUrl(path: string | null | undefined, label: string): string | null {
+  if (!path) return null
+  if (/^(?:https?:|data:)/.test(path)) return path
+  if (path.startsWith(`/branding/${id}/`)) return serveArchived(path, label)
+  console.warn(
+    `[maintenance] ! ${label}: ${path} is served by the webapp, which is down whenever this page shows — omitted`,
+  )
+  return null
+}
+
 // --- 1+2. Theme: unpack the brand's assets and link its own stylesheets ---------------------------
 // The maintenance page is standalone — /branding/<id>/… does not exist while the webapp is down — so
 // the brand's assets are unpacked here under public/<SERVED_DIR>/ with their directory structure
@@ -110,10 +136,12 @@ function archiveEntry(namespaced: string): { entry: string; data: Buffer } | nul
 // (@font-face, background images) resolves without anything rewriting it. An earlier version parsed
 // @font-face out of the CSS and rewrote each src by hand; unpacking makes that unnecessary, and it
 // also carries rules this page never knew about.
-const servedUrls = new Map<string, string>()
+//
+// EVERY asset entry, not just the referenced ones: a stylesheet's url() targets (fonts, background
+// images) are named inside the CSS, which nothing here parses.
 for (const [entry, data] of archive) {
   if (!entry.startsWith('assets/')) continue
-  servedUrls.set(entry, serveEntry(entry, data))
+  serveEntry(entry, data)
 }
 
 // The sheets are taken in the order the BRAND configured them, not in the order they happen to sit in
@@ -121,9 +149,14 @@ for (const [entry, data] of archive) {
 // order IS cascade order, so where two sheets set the same property at equal specificity, iterating the
 // archive would hand the win to whichever file the filesystem listed last. `assets.css` is where the
 // brand says which sheet wins; the live webapp loads them in exactly that order.
+//
+// Through the same path classifier as the images below, so `assets.css` answers the external-URL
+// question the same way everything else does: a brand's CDN stylesheet is linked as authored, and one
+// pointing into the webapp's own tree is dropped with a warning instead of silently vanishing from the
+// list. (The archived ones are already unpacked by the loop above; re-serving writes identical bytes.)
 const servedSheets = config.assets.css
-  .map((href) => servedUrls.get(href.replace(/^\/branding\/[^/]+\//, '')))
-  .filter((url): url is string => Boolean(url))
+  .map((href) => servedUrl(href, 'stylesheet'))
+  .filter((url): url is string => url !== null)
 
 // A LIST of served URLs rather than a stylesheet that pulls them in: nuxt.config turns each into a
 // <head> <link>, so the browser loads it straight from public/ — the same way the live webapp injects
@@ -152,7 +185,7 @@ console.log(
 // .svg or .png, and app.vue falls back to the vanilla one when there is no overlay. Both come out of
 // the archive as `/branding/<id>/…`, which resolves in the live webapp but NOT here — copying them and
 // rewriting the path is what makes them show up at all.
-function serveImage(namespaced: string, label: string): string | null {
+function serveArchived(namespaced: string, label: string): string | null {
   const found = archiveEntry(namespaced)
   if (!found) return null
   const url = serveEntry(found.entry, found.data)
@@ -161,8 +194,8 @@ function serveImage(namespaced: string, label: string): string | null {
   return url
 }
 
-const logoUrl = serveImage(config.logos.signupPath, 'logo')
-const ogImageUrl = serveImage(config.metadata.ogImage, 'og image')
+const logoUrl = servedUrl(config.logos.signupPath, 'logo')
+const ogImageUrl = servedUrl(config.metadata.ogImage, 'og image')
 // The browser-tab icon. It travels exactly like the logo — and it has to travel at all, because this
 // page ships its own vanilla public/favicon.ico and nothing else would ever replace it: the built
 // index.html carries no icon link (Nuxt 4 adds none, and useHead cannot help with `ssr: false`), so
@@ -171,14 +204,11 @@ const ogImageUrl = serveImage(config.metadata.ogImage, 'og image')
 //
 // Only `assets.favicon`, not `assets.icon`: apple-touch and PWA install icons exist for a site being
 // added to a home screen, which is not something anyone does with a maintenance page.
-const faviconUrl = config.assets.favicon ? serveImage(config.assets.favicon, 'favicon') : null
-// The composed ogImage is a `/branding/<id>/…` path — served by the live webapp, never by this static
-// site — so it has to become the copy just made. Falling back to the logo covers the usual case, where
-// a brand sets no separate OG image and the build derived it from the squared logo. null means the
-// brand referenced an image it does not ship: see the omission below.
-const ogImage =
-  ogImageUrl ??
-  (config.metadata.ogImage.startsWith(`/branding/${id}/`) ? logoUrl : config.metadata.ogImage)
+const faviconUrl = servedUrl(config.assets.favicon, 'favicon')
+// Falling back to the logo covers the usual case, where a brand sets no separate OG image and the
+// build derived it from the squared logo. null means the brand's OG image is unusable here — not in
+// the archive, or a webapp path — and the logo could not stand in either: see the omission below.
+const ogImage = ogImageUrl ?? logoUrl
 
 // --- 4. Metadata: identity + OG for the <head>, as an overlay the app deep-merges ------------------
 // `config` is fully merged, so every field is present (the ocelot vanilla defaults when the brand

--- a/packages/branding/scripts/lib/build-brandings.spec.ts
+++ b/packages/branding/scripts/lib/build-brandings.spec.ts
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict'
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { after, test } from 'node:test'
+import { after, describe, test } from 'node:test'
 
 import { composeArchive, readManifest } from '../../dist/discover.js'
 import { readTarGz } from '../../dist/tar.js'
@@ -466,4 +466,97 @@ test('a stylesheet listed in assets.css that does not exist is reported', async 
 
   const built = await buildBrandArchive(dir)
   assert.match(built.warnings.join('\n'), /assets\.css lists 'missing\.css', which does not exist/)
+})
+
+// assets.icon is consumed as a fixed-size square bitmap by the PWA manifest and the iOS home screen,
+// and NEITHER reports back: a wrong file surfaces as a stretched, blurred or absent icon on someone
+// else's phone. The build is the last place it is cheap to notice. (See lib/imageSize.spec.ts for the
+// header reading itself; what these pin is which files draw which warning.)
+describe('assets.icon', () => {
+  /** A minimal but genuine PNG header — enough for the check, which reads only the IHDR chunk. */
+  function pngBytes(width, height) {
+    const data = Buffer.alloc(24)
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(data)
+    data.write('IHDR', 12, 'ascii')
+    data.writeUInt32BE(width, 16)
+    data.writeUInt32BE(height, 20)
+    return data
+  }
+
+  const withIcon = (body, name = 'icon.png') =>
+    brandDir({
+      config: `export default (d) => d({ assets: { icon: 'assets/${name}' } })\n`,
+      assets: { [name]: body },
+    })
+
+  const iconWarnings = async (dir) =>
+    (await buildBrandArchive(dir)).warnings.filter((w) => w.includes('assets.icon')).join('\n')
+
+  test('a square icon at the declared size passes without comment', async () => {
+    assert.equal(await iconWarnings(withIcon(pngBytes(512, 512))), '')
+    // Larger is fine too — the manifest declares 192 and 512, and browsers downscale.
+    assert.equal(await iconWarnings(withIcon(pngBytes(1024, 1024))), '')
+  })
+
+  // The trap the extension-derived MIME type sets: nothing downstream inspects the file, so the
+  // manifest announces `image/svg+xml` and a browser that will not rasterise it drops the icon.
+  test('warns that an svg is not a raster image', async () => {
+    const warning = await iconWarnings(withIcon('<svg viewBox="0 0 512 512"></svg>', 'icon.svg'))
+
+    assert.match(warning, /is SVG, not a raster image/)
+  })
+
+  // .ico is the FAVICON format, and the two slots exist separately precisely because iOS ignores it.
+  test('warns that an ico is not a raster image', async () => {
+    const warning = await iconWarnings(
+      withIcon(Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]), 'icon.ico'),
+    )
+
+    assert.match(warning, /is ICO, not a raster image/)
+  })
+
+  test('warns about a non-square icon, naming both dimensions', async () => {
+    const warning = await iconWarnings(withIcon(pngBytes(512, 300)))
+
+    assert.match(warning, /is 512×300, not square/)
+  })
+
+  test('warns about an icon smaller than the size the manifest declares', async () => {
+    const warning = await iconWarnings(withIcon(pngBytes(192, 192)))
+
+    assert.match(warning, /is 192px — the manifest declares it at 512px/)
+  })
+
+  test('warns about a file that is not an image at all', async () => {
+    const warning = await iconWarnings(withIcon('not an image'))
+
+    assert.match(warning, /is not an image format this build recognises/)
+  })
+
+  // Reported apart from "not an image": the file IS a PNG, it just got cut off — which points at the
+  // brand's own packaging (a truncated copy, a bad LFS checkout) rather than at the wrong file.
+  test('warns about a truncated image separately from an unrecognised one', async () => {
+    const warning = await iconWarnings(withIcon(pngBytes(512, 512).subarray(0, 12)))
+
+    assert.match(warning, /is a truncated PNG file/)
+  })
+
+  // A brand may ship no icon, or point at one it hosts itself. Neither is this check's business —
+  // and a missing file is already reported by the namespacing pass, so saying it twice is noise.
+  test('says nothing when there is no local file to inspect', async () => {
+    assert.equal(await iconWarnings(brandDir({ config: ACME_CONFIG })), '')
+    assert.equal(
+      await iconWarnings(
+        brandDir({
+          config: `export default (d) => d({ assets: { icon: 'https://cdn.example/icon.png' } })\n`,
+        }),
+      ),
+      '',
+    )
+    const missing = brandDir({
+      config: `export default (d) => d({ assets: { icon: 'assets/nowhere.png' } })\n`,
+    })
+    assert.equal(await iconWarnings(missing), '')
+    assert.match((await buildBrandArchive(missing)).warnings.join('\n'), /asset not found/)
+  })
 })

--- a/packages/branding/scripts/lib/build-brandings.spec.ts
+++ b/packages/branding/scripts/lib/build-brandings.spec.ts
@@ -172,7 +172,7 @@ test('buildBrandArchive warns when a referenced asset is missing (but still buil
   assert.match(built.warnings.join('\n'), /logo-squared\.svg/)
 })
 
-test('buildBrandArchive namespaces css, favicon and html-per-locale paths', async () => {
+test('buildBrandArchive namespaces css, favicon, icon and html-per-locale paths', async () => {
   const dir = brandDir({
     config: `export default (defineBranding) =>
       defineBranding({
@@ -180,12 +180,13 @@ test('buildBrandArchive namespaces css, favicon and html-per-locale paths', asyn
         assets: {
           css: ['assets/extra.css'],
           favicon: 'assets/favicon.ico',
+          icon: 'assets/icon.png',
           html: { imprint: { en: 'html/imprint.en.html' } },
         },
         headerMenu: { customButton: { iconPath: 'assets/button.svg', url: 'https://example.test' } },
       })
 `,
-    assets: { 'extra.css': 'x', 'favicon.ico': 'x', 'button.svg': 'x' },
+    assets: { 'extra.css': 'x', 'favicon.ico': 'x', 'icon.png': 'x', 'button.svg': 'x' },
   })
   // the html/ referenced file lives outside assets/ — create it so no warning is emitted
   mkdirSync(join(dir, 'html'), { recursive: true })
@@ -194,6 +195,9 @@ test('buildBrandArchive namespaces css, favicon and html-per-locale paths', asyn
   const config = composeArchive(readTarGz((await buildBrandArchive(dir)).gz))
   assert.deepEqual(config.assets.css, ['/branding/acme/assets/extra.css'])
   assert.equal(config.assets.favicon, '/branding/acme/assets/favicon.ico')
+  // The apple-touch / PWA icon travels the same way — a favicon cannot stand in for it (.ico is not
+  // an apple-touch-icon format), so it is a slot of its own rather than a derived path.
+  assert.equal(config.assets.icon, '/branding/acme/assets/icon.png')
   assert.equal(config.assets.html.imprint.en, '/branding/acme/html/imprint.en.html')
   // the framework's /img/custom/.
   assert.equal(config.headerMenu.customButton.iconPath, '/branding/acme/assets/button.svg')

--- a/packages/branding/scripts/lib/build-brandings.ts
+++ b/packages/branding/scripts/lib/build-brandings.ts
@@ -99,6 +99,7 @@ function namespaceConfig(
   c.metadata.ogImage = ns(c.metadata.ogImage) // ogImage is always set (merged default)
   if (Array.isArray(c.assets.css)) c.assets.css = c.assets.css.map(ns)
   if (c.assets.favicon != null) c.assets.favicon = ns(c.assets.favicon)
+  if (c.assets.icon != null) c.assets.icon = ns(c.assets.icon)
   const html = c.assets.html as Record<string, Record<string, string>>
   for (const page of Object.keys(html)) {
     const locales = html[page]

--- a/packages/branding/scripts/lib/build-brandings.ts
+++ b/packages/branding/scripts/lib/build-brandings.ts
@@ -17,6 +17,7 @@ import { SCHEMA_VERSION } from '../../dist/version.js'
 import { catalogAvailable, computeCatalog } from '../theme-catalog.ts'
 
 import { customPropertiesIn } from './css.ts'
+import { readImage } from './imageSize.ts'
 import { loadConfig } from './load-config.ts'
 
 import type { ArchiveInstanceEntry } from '../../dist/buckets.js'
@@ -343,6 +344,64 @@ function warnUncompiledStylesheets(entries: TarEntry[], id: string, warnings: st
 }
 
 /**
+ * The size `assets.icon` is DECLARED at — the PWA manifest lists it as both 192×192 and 512×512
+ * (webapp/server-middleware/manifest.js), so anything smaller is upscaled by the browser to fill the
+ * larger slot.
+ */
+const ICON_MIN_PX = 512
+
+/**
+ * Warn when `assets.icon` cannot do the job the slot exists for: the iOS home-screen icon and the PWA
+ * install icon. Both consume it as a fixed-size square bitmap, and neither reports back — a wrong file
+ * shows up as a stretched or blurred icon on someone's phone, or as no icon at all, long after the
+ * build that accepted it.
+ *
+ * Warnings only, like every other check here: a brand's icon is not worth failing a deployment over,
+ * and the slot is optional to begin with.
+ */
+function warnIconAsset(dir: string, id: string, config: BrandingConfig, warnings: string[]): void {
+  const rel = config.assets.icon
+  // Only a brand-relative path names a file this build can read; an external URL or an absolute
+  // framework path is not ours to inspect (see namespacePath).
+  if (!isRelativeAsset(rel)) return
+  const file = join(dir, rel)
+  if (!existsSync(file)) return // already reported by namespacePath as "referenced asset not found"
+
+  const image = readImage(readFileSync(file))
+  if (!image) {
+    warnings.push(`  ! ${id}: assets.icon '${rel}' is not an image format this build recognises`)
+    return
+  }
+  if (!image.raster) {
+    // The consumers label the icon by EXTENSION, so this travels into the manifest as
+    // `type: image/svg+xml` — and a browser that took the declared type at its word drops an install
+    // icon it will not rasterise, rather than falling back to sniffing the file.
+    warnings.push(
+      `  ! ${id}: assets.icon '${rel}' is ${image.format.toUpperCase()}, not a raster image — the PWA ` +
+        `manifest and apple-touch-icon need a bitmap; ship a ${ICON_MIN_PX}px square PNG`,
+    )
+    return
+  }
+  if (image.width === null || image.height === null) {
+    warnings.push(
+      `  ! ${id}: assets.icon '${rel}' is a truncated ${image.format.toUpperCase()} file`,
+    )
+    return
+  }
+  if (image.width !== image.height) {
+    warnings.push(
+      `  ! ${id}: assets.icon '${rel}' is ${image.width}×${image.height}, not square — a home-screen ` +
+        `tile stretches it to fit`,
+    )
+  } else if (image.width < ICON_MIN_PX) {
+    warnings.push(
+      `  ! ${id}: assets.icon '${rel}' is ${image.width}px — the manifest declares it at ` +
+        `${ICON_MIN_PX}px, so it will be upscaled`,
+    )
+  }
+}
+
+/**
  * Warn on a leftover `public/` folder. That bucket used to be overlaid onto the BACKEND's on-disk
  * `public/` at bootstrap, and every brand used it for exactly one thing: badge SVGs. It is gone —
  * badges are served brand files like logos, so they belong in `assets/badges/` and are read straight
@@ -440,6 +499,7 @@ export async function buildBrandArchive(brandDir: string): Promise<BuiltArchive>
   }
   warnUncompiledStylesheets(entries, id, warnings)
   warnRemovedPublicBucket(dir, id, warnings)
+  warnIconAsset(dir, id, config, warnings)
   return { id, version, label, gz: writeTarGz(entries), entries, warnings }
 }
 

--- a/packages/branding/scripts/lib/imageSize.spec.ts
+++ b/packages/branding/scripts/lib/imageSize.spec.ts
@@ -1,0 +1,186 @@
+// The header reader behind the assets.icon check. Every fixture here is built byte by byte rather
+// than checked in as a binary: the parser reads nothing BUT those bytes, so a hand-built header
+// exercises exactly as much of it as a real file would — and it stays readable in review, which a
+// base64 blob does not.
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { readImage } from './imageSize.ts'
+
+/** PNG: 8-byte signature, then the mandatory IHDR chunk carrying both dimensions. */
+function png(width: number, height: number): Buffer {
+  const data = Buffer.alloc(24)
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(data)
+  data.write('IHDR', 12, 'ascii')
+  data.writeUInt32BE(width, 16)
+  data.writeUInt32BE(height, 20)
+  return data
+}
+
+function gif(width: number, height: number): Buffer {
+  const data = Buffer.alloc(10)
+  data.write('GIF89a', 0, 'ascii')
+  data.writeUInt16LE(width, 6)
+  data.writeUInt16LE(height, 8)
+  return data
+}
+
+/**
+ * JPEG with a leading APP0 segment, so the frame header is NOT at a fixed offset — which is the whole
+ * reason the parser walks the chain instead of indexing into it.
+ */
+function jpeg(width: number, height: number): Buffer {
+  const app0 = Buffer.alloc(18)
+  app0.writeUInt16BE(0xffe0, 0)
+  app0.writeUInt16BE(16, 2) // segment length, covering itself but not the marker
+  app0.write('JFIF\0', 4, 'ascii')
+  const sof = Buffer.alloc(11)
+  sof.writeUInt16BE(0xffc0, 0) // SOF0
+  sof.writeUInt16BE(9, 2)
+  sof.writeUInt8(8, 4) // sample precision
+  sof.writeUInt16BE(height, 5) // height FIRST in a JPEG frame header
+  sof.writeUInt16BE(width, 7)
+  return Buffer.concat([Buffer.from([0xff, 0xd8]), app0, sof, Buffer.alloc(8)])
+}
+
+/** WebP: one RIFF wrapper around whichever of the three payload layouts. */
+function webp(chunk: string, payload: Buffer): Buffer {
+  const head = Buffer.alloc(16)
+  head.write('RIFF', 0, 'ascii')
+  head.writeUInt32LE(payload.length + 12, 4)
+  head.write('WEBP', 8, 'ascii')
+  head.write(chunk, 12, 'ascii')
+  return Buffer.concat([head, payload, Buffer.alloc(Math.max(0, 30 - 16 - payload.length))])
+}
+
+function webpLossy(width: number, height: number): Buffer {
+  const payload = Buffer.alloc(18)
+  payload.writeUInt32LE(14, 0) // chunk size
+  Buffer.from([0x9d, 0x01, 0x2a]).copy(payload, 7) // sync code, after the 3-byte frame tag
+  payload.writeUInt16LE(width, 10)
+  payload.writeUInt16LE(height, 12)
+  return webp('VP8 ', payload)
+}
+
+function webpLossless(width: number, height: number): Buffer {
+  const payload = Buffer.alloc(13)
+  payload.writeUInt32LE(9, 0)
+  payload.writeUInt8(0x2f, 4) // lossless signature
+  // 14 bits of (width - 1), then 14 of (height - 1), in one little-endian word.
+  payload.writeUInt32LE((width - 1) | ((height - 1) << 14), 5)
+  return webp('VP8L', payload)
+}
+
+function webpExtended(width: number, height: number): Buffer {
+  const payload = Buffer.alloc(18)
+  payload.writeUInt32LE(10, 0)
+  payload.writeUIntLE(width - 1, 8, 3) // 24-bit canvas size, minus one
+  payload.writeUIntLE(height - 1, 11, 3)
+  return webp('VP8X', payload)
+}
+
+describe('readImage', () => {
+  // Table-driven: what matters is that ALL four raster formats answer the same question the same way,
+  // since the icon check treats them interchangeably.
+  const RASTER: [string, Buffer][] = [
+    ['png', png(512, 512)],
+    ['gif', gif(512, 512)],
+    ['jpeg', jpeg(512, 512)],
+    ['webp (lossy VP8)', webpLossy(512, 512)],
+    ['webp (lossless VP8L)', webpLossless(512, 512)],
+    ['webp (extended VP8X)', webpExtended(512, 512)],
+  ]
+
+  for (const [name, data] of RASTER) {
+    test(`reads the dimensions of a ${name}`, () => {
+      const image = readImage(data)
+
+      assert.equal(image?.raster, true)
+      assert.equal(image?.width, 512)
+      assert.equal(image?.height, 512)
+    })
+  }
+
+  // Non-square, and deliberately asymmetric per format: a parser that swapped the two fields would
+  // still pass every square fixture above. JPEG stores height first, so it is the likeliest to swap.
+  test('keeps width and height apart', () => {
+    assert.deepEqual(pick(readImage(png(200, 100))), { width: 200, height: 100 })
+    assert.deepEqual(pick(readImage(gif(200, 100))), { width: 200, height: 100 })
+    assert.deepEqual(pick(readImage(jpeg(200, 100))), { width: 200, height: 100 })
+    assert.deepEqual(pick(readImage(webpLossy(200, 100))), { width: 200, height: 100 })
+    assert.deepEqual(pick(readImage(webpLossless(200, 100))), { width: 200, height: 100 })
+    assert.deepEqual(pick(readImage(webpExtended(200, 100))), { width: 200, height: 100 })
+  })
+
+  // The two the icon slot must reject. Both are perfectly valid images — they just cannot be what an
+  // install icon needs, and the extension-derived MIME type means nobody downstream notices.
+  test('names svg and ico as non-raster', () => {
+    const svg = readImage(Buffer.from('<?xml version="1.0"?>\n<svg viewBox="0 0 512 512"></svg>'))
+    assert.equal(svg?.format, 'svg')
+    assert.equal(svg?.raster, false)
+
+    const ico = readImage(Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]))
+    assert.equal(ico?.format, 'ico')
+    assert.equal(ico?.raster, false)
+  })
+
+  // Bounded lookahead: a `<svg` far inside some other text file must not claim it.
+  test('does not read an svg out of an unrelated document', () => {
+    assert.equal(readImage(Buffer.from(`${'x'.repeat(2000)}<svg>`)), null)
+  })
+
+  test('returns null for bytes no format claims', () => {
+    assert.equal(readImage(Buffer.from('not an image at all')), null)
+    assert.equal(readImage(Buffer.alloc(0)), null)
+  })
+
+  // A file cut short still has to be identifiable — the caller reports a truncated PNG differently
+  // from an unrecognised one, and only a format-with-no-dimensions can tell the two apart.
+  test('identifies a truncated file but reports no dimensions', () => {
+    const cut = png(512, 512).subarray(0, 12)
+    const image = readImage(cut)
+
+    assert.equal(image?.format, 'png')
+    assert.equal(image?.raster, true)
+    assert.equal(image?.width, null)
+  })
+
+  // A RIFF/WebP wrapper around a payload chunk this reader does not know: still a WebP, no dimensions.
+  test('identifies a webp whose payload chunk is unknown', () => {
+    const image = readImage(webp('XXXX', Buffer.alloc(14)))
+
+    assert.equal(image?.format, 'webp')
+    assert.equal(image?.width, null)
+  })
+
+  // Desynchronised segment chains and broken signatures: the parser must give up, not read garbage
+  // from whatever offset it happened to reach.
+  test('gives up on a malformed payload rather than inventing a size', () => {
+    const badSync = webpLossy(512, 512)
+    badSync.writeUInt8(0x00, 23) // break the VP8 sync code
+    assert.equal(readImage(badSync)?.width, null)
+
+    const badSignature = webpLossless(512, 512)
+    badSignature.writeUInt8(0x00, 20)
+    assert.equal(readImage(badSignature)?.width, null)
+
+    // A JPEG whose segment chain does not land on a marker boundary.
+    const desynced = jpeg(512, 512)
+    desynced.writeUInt16BE(3, 4) // nonsense APP0 length
+    assert.equal(readImage(desynced)?.width, null)
+
+    // …and one whose chain simply runs out before the frame header: valid segments, no SOF. The walk
+    // has to end at the buffer rather than read past it.
+    const noFrame = jpeg(512, 512).subarray(0, 20)
+    assert.equal(readImage(noFrame)?.format, 'jpeg')
+    assert.equal(readImage(noFrame)?.width, null)
+  })
+})
+
+/** Just the dimensions, so a mismatch prints as two numbers instead of the whole record. */
+function pick(image: ReturnType<typeof readImage>): {
+  width: number | null
+  height: number | null
+} {
+  return { width: image?.width ?? null, height: image?.height ?? null }
+}

--- a/packages/branding/scripts/lib/imageSize.ts
+++ b/packages/branding/scripts/lib/imageSize.ts
@@ -1,0 +1,117 @@
+// What an image file actually IS, read from its own bytes.
+//
+// Written here rather than pulled in (image-size, probe-image-size, sharp) because this package is a
+// build-time dependency of every brand repo: a native or transitive dependency for four fixed-offset
+// header reads would cost every one of them an install, and this file is the whole of what those
+// libraries would be used for. No decoding happens — only the header that names the dimensions.
+//
+// The FORMAT comes from the magic bytes, never from the extension. That distinction is the point: the
+// consumers of `assets.icon` (the PWA manifest, `<link rel="apple-touch-icon">`) derive their `type`
+// attribute from the path (webapp/utils/iconType.js), so a mislabelled file is announced as something
+// it is not — and a browser that cannot decode what it was promised drops the icon rather than
+// sniffing it. A build-time check is the only place that mismatch is visible before a phone shows it.
+
+/** A file's container format and pixel dimensions, or null for bytes no known format claims. */
+export interface ImageInfo {
+  format: 'png' | 'gif' | 'jpeg' | 'webp' | 'svg' | 'ico'
+  /** Whether the format stores pixels. `svg` is a document, `ico` a container of several images. */
+  raster: boolean
+  /** Pixel size, or null where the format carries none (svg) or the header is truncated. */
+  width: number | null
+  height: number | null
+}
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const ICO_SIGNATURE = Buffer.from([0x00, 0x00, 0x01, 0x00])
+
+const raster = (
+  format: 'png' | 'gif' | 'jpeg' | 'webp',
+  size: { width: number; height: number } | null,
+): ImageInfo => ({ format, raster: true, width: size?.width ?? null, height: size?.height ?? null })
+
+/** PNG: the IHDR chunk is mandatory and FIRST, so both dimensions sit at fixed offsets. */
+function pngSize(data: Buffer): { width: number; height: number } | null {
+  if (data.length < 24) return null
+  return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) }
+}
+
+/** GIF: the logical-screen descriptor follows the 6-byte signature, little-endian. */
+function gifSize(data: Buffer): { width: number; height: number } | null {
+  if (data.length < 10) return null
+  return { width: data.readUInt16LE(6), height: data.readUInt16LE(8) }
+}
+
+/**
+ * JPEG: dimensions live in a start-of-frame segment, whose position depends on how many segments
+ * (EXIF, quantisation tables, comments) precede it — so the segment chain has to be walked.
+ */
+function jpegSize(data: Buffer): { width: number; height: number } | null {
+  let pos = 2 // past the SOI marker
+  while (pos + 9 < data.length) {
+    if (data[pos] !== 0xff) return null // desynchronised — not a segment boundary any more
+    const marker = data[pos + 1]
+    // SOF0..SOF15 carry the frame header. The three exceptions in that range are other things
+    // entirely: DHT (c4), JPG (c8) and DAC (cc).
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      // Height precedes width here, unlike every other format in this file.
+      return { height: data.readUInt16BE(pos + 5), width: data.readUInt16BE(pos + 7) }
+    }
+    pos += 2 + data.readUInt16BE(pos + 2) // segment length covers itself but not the marker
+  }
+  return null
+}
+
+/**
+ * WebP: one RIFF container, three incompatible payloads. VP8 is the original lossy bitstream, VP8L
+ * the lossless one, VP8X the extended header a file with alpha / animation / ICC starts with — each
+ * stores the canvas size differently, and a brand's icon (alpha, hence usually VP8X) hits the one
+ * that looks least like the others.
+ */
+function webpSize(data: Buffer): { width: number; height: number } | null {
+  if (data.length < 30) return null
+  const chunk = data.toString('ascii', 12, 16)
+  if (chunk === 'VP8 ') {
+    // Lossy: a 3-byte frame tag, then the 3-byte sync code that confirms the layout.
+    if (data[23] !== 0x9d || data[24] !== 0x01 || data[25] !== 0x2a) return null
+    // 14 bits each; the top 2 are a scaling hint this does not apply.
+    return { width: data.readUInt16LE(26) & 0x3fff, height: data.readUInt16LE(28) & 0x3fff }
+  }
+  if (chunk === 'VP8L') {
+    if (data[20] !== 0x2f) return null // lossless signature byte
+    // 14 bits of (width - 1) then 14 of (height - 1), packed into one little-endian word.
+    const bits = data.readUInt32LE(21)
+    return { width: (bits & 0x3fff) + 1, height: ((bits >> 14) & 0x3fff) + 1 }
+  }
+  if (chunk === 'VP8X') {
+    // Extended: canvas size as two 24-bit little-endian (size - 1) values.
+    return {
+      width: data.readUIntLE(24, 3) + 1,
+      height: data.readUIntLE(27, 3) + 1,
+    }
+  }
+  return null
+}
+
+/**
+ * Identify an image by its bytes. Returns null when nothing claims them — a caller should treat that
+ * as "unknown", not as "invalid": being unable to name a format is not evidence the file is broken.
+ */
+export function readImage(data: Buffer): ImageInfo | null {
+  if (data.subarray(0, 8).equals(PNG_SIGNATURE)) return raster('png', pngSize(data))
+  if (data.subarray(0, 4).equals(ICO_SIGNATURE)) {
+    return { format: 'ico', raster: false, width: null, height: null }
+  }
+  if (data[0] === 0xff && data[1] === 0xd8) return raster('jpeg', jpegSize(data))
+  const ascii6 = data.toString('ascii', 0, 6)
+  if (ascii6 === 'GIF87a' || ascii6 === 'GIF89a') return raster('gif', gifSize(data))
+  if (ascii6.startsWith('RIFF') && data.toString('ascii', 8, 12) === 'WEBP') {
+    return raster('webp', webpSize(data))
+  }
+  // SVG last and by content: it is text, so it has no magic number — an XML declaration, a doctype or
+  // a comment may precede the root element. Bounded to the head of the file so a stray `<svg` deep
+  // inside some other text format cannot claim it.
+  if (/<svg[\s>]/i.test(data.toString('utf8', 0, 1024))) {
+    return { format: 'svg', raster: false, width: null, height: null }
+  }
+  return null
+}

--- a/packages/branding/scripts/schema-shape.snapshot.json
+++ b/packages/branding/scripts/schema-shape.snapshot.json
@@ -7,6 +7,7 @@
     "assets.css: array",
     "assets.favicon: null",
     "assets.html: object",
+    "assets.icon: null",
     "badges.trophyBadgesSelectedMax: number",
     "category.max: number",
     "category.min: number",
@@ -81,7 +82,8 @@
     ],
     "logos": [
       "logos",
-      "assets.favicon"
+      "assets.favicon",
+      "assets.icon"
     ],
     "legal": [
       "termsAndConditions",

--- a/packages/branding/src/buckets.ts
+++ b/packages/branding/src/buckets.ts
@@ -134,7 +134,7 @@ export const BUCKET_PATHS: Record<BucketName, string[]> = {
   // brand's self-description. (locales is CROSS-CUTTING — see below — not owned by a bucket.)
   identity: ['metadata', 'about'],
   // The instance's marks.
-  logos: ['logos', 'assets.favicon'],
+  logos: ['logos', 'assets.favicon', 'assets.icon'],
   // Static / legal content: page HTML, T&C version, per-page link overrides (external URLs).
   legal: ['termsAndConditions', 'assets.html', 'links.pages'],
   // Menus and footer ordering / landing target.

--- a/packages/branding/src/defaults.ts
+++ b/packages/branding/src/defaults.ts
@@ -120,5 +120,6 @@ export const brandingDefaults: BrandingConfig = {
     css: [],
     html: {},
     favicon: null,
+    icon: null,
   },
 }

--- a/packages/branding/src/schema.ts
+++ b/packages/branding/src/schema.ts
@@ -265,8 +265,19 @@ export interface BrandingConfig {
     /** Static-page HTML per page per locale code, e.g. `html.imprint.de = 'html/de/imprint.html'`.
      * Loaded at runtime by the InternalPage view (replaces the build-bundled html i18n). */
     html: Partial<Record<LinkPageKey, Record<string, string>>>
-    /** Favicon path, e.g. 'assets/favicon.ico'. */
+    /** Favicon path, e.g. 'assets/favicon.ico'. The browser-tab icon; `.ico` is what every brand
+     * ships and what the vanilla fallback is, but any format a browser accepts works — the consumer
+     * derives the `type` attribute from the extension. */
     favicon: string | null
+    /** Square raster icon, e.g. 'assets/icon.png'. Used where a favicon will not do: the iOS
+     * home-screen icon (`apple-touch-icon`, which ignores .ico) and the PWA manifest's install icon.
+     * Must be a raster format and reasonably large (512px square is the useful size — the manifest
+     * declares it at both 192 and 512, and browsers downscale).
+     *
+     * Every brand already ships `assets/icon.png`: the pre-runtime build copied it over the
+     * framework's own webapp/static/icon.png at image-build time. Runtime branding cannot do that, so
+     * the file sat unread in every brand repo until this slot named it. */
+    icon: string | null
   }
 }
 

--- a/packages/branding/src/schema.ts
+++ b/packages/branding/src/schema.ts
@@ -281,6 +281,12 @@ export interface BrandingConfig {
      * Must be a raster format and reasonably large (512px square is the useful size — the manifest
      * declares it at both 192 and 512, and browsers downscale).
      *
+     * The build CHECKS this (a warning, never fatal — see build-brandings.ts `warnIconAsset`), by
+     * reading the file's own header rather than trusting its extension. It has to: both consumers
+     * derive the `type` they announce from the PATH (webapp/utils/iconType.js), so an SVG here is
+     * published as `image/svg+xml` and a browser that will not rasterise it drops the install icon
+     * altogether — a failure that otherwise first appears on someone's phone.
+     *
      * Every brand already ships `assets/icon.png`: the pre-runtime build copied it over the
      * framework's own webapp/static/icon.png at image-build time. Runtime branding cannot do that, so
      * the file sat unread in every brand repo until this slot named it. */

--- a/packages/branding/src/schema.ts
+++ b/packages/branding/src/schema.ts
@@ -253,6 +253,13 @@ export interface BrandingConfig {
    * build namespaces them to `/branding/<brand>/…` so multiple brands never collide, and warns when
    * the referenced file does not exist. (Logo & OG-image paths in `logos` / `metadata.ogImage` are
    * asset paths too and are namespaced the same way.)
+   *
+   * A path that is NOT brand-relative is left exactly as written — an `http(s):`/`data:` URL (a brand
+   * hosting an asset itself) and an absolute `/…` path into the framework's own tree both survive the
+   * build untouched. The live webapp serves either. The MAINTENANCE page cannot: it is a static site
+   * nginx serves while the webapp is down, so an external URL still resolves there but a `/…` webapp
+   * path answers nothing — its generator drops those with a warning and keeps the vanilla asset
+   * (scripts/build-maintenance-branding.ts `servedUrl`).
    */
   assets: {
     /** Extra stylesheets, injected as <link> at runtime (bespoke component rules, fonts via

--- a/packages/branding/src/version.ts
+++ b/packages/branding/src/version.ts
@@ -5,4 +5,4 @@
 // import.meta (unavailable in the CJS emit) or __dirname (unavailable in the ESM source).
 // The trailing marker lets release-please bump this in lock-step with package.json (see
 // release-please-config.json `extra-files`), so the drift guard in version.spec never trips on a release.
-export const SCHEMA_VERSION = '0.1.0' // x-release-please-version
+export const SCHEMA_VERSION = '0.1.1' // x-release-please-version

--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -106,9 +106,22 @@ export default {
     ],
     link: [
       {
+        // `hid` is what makes this a SLOT rather than a fixed tag: plugins/branding-favicon.js
+        // rewrites this entry per request, so a branded instance server-renders its own icon instead
+        // of shipping the vanilla one and swapping it after hydration. Everything below is the
+        // fallback for an unbranded (vanilla) instance.
+        hid: 'icon',
         rel: 'icon',
         type: 'image/x-icon',
         href: '/favicon.ico',
+      },
+      {
+        // Declared here rather than by @nuxtjs/pwa (`icon: false` below): the module bakes the hash of
+        // a build-time static/icon.png into the href and adds no `hid`, which makes it impossible to
+        // retarget per brand. branding-favicon.js points it at the brand's `assets.icon`; iOS only.
+        hid: 'apple-touch-icon',
+        rel: 'apple-touch-icon',
+        href: '/icon.png',
       },
       {
         // Points at the dynamic serverMiddleware route (content per active brand); href is stable.
@@ -192,6 +205,10 @@ export default {
     // First: $authCookie is what the auth store reads/writes the session with.
     { src: '~/plugins/auth-cookie.js', ssr: true },
     { src: '~/plugins/branding.js', ssr: true },
+    // Directly after branding.js — it reads the accessor that one sets. Runs on BOTH sides on purpose:
+    // the server renders the branded <link rel="icon"> and the client resolves the same value, so
+    // there is no vanilla icon to swap out after hydration.
+    '~/plugins/branding-favicon.js',
     { src: '~/plugins/branding-head.js', ssr: false },
     { src: '~/plugins/policy.js', ssr: true },
     { src: '~/plugins/policy-subscribe.js', ssr: false },
@@ -333,6 +350,16 @@ export default {
     // server-middleware/manifest.js (see serverMiddleware + the head.link[rel=manifest] above), so
     // the installed-app name / theme colour follow a live brand switch without a rebuild.
     manifest: false,
+    // Icon module disabled — with `manifest: false` its only remaining output was two head links
+    // generated from the build-time static/icon.png:
+    //   <link rel="shortcut icon" href="/_nuxt/icons/icon_64.<hash>.png">
+    //   <link rel="apple-touch-icon" href="/_nuxt/icons/icon_512.<hash>.png" sizes="512x512">
+    // `shortcut icon` is a legacy alias of `icon`, so that vanilla 64px PNG COMPETED with the brand's
+    // favicon — and since the module adds no `hid` and hashes the href at build time, neither vue-meta
+    // nor the client plugin could retarget it. A branded instance kept the ocelot icon in the tab
+    // whichever candidate the browser happened to prefer. The two links are declared in head.link
+    // above instead, with hids, so branding-favicon.js can rewrite them.
+    icon: false,
     meta: {
       // Prevent @nuxtjs/pwa from auto-generating description from package.json;
       // we set description and og:description manually in head.meta above.

--- a/webapp/nuxt.config.spec.js
+++ b/webapp/nuxt.config.spec.js
@@ -33,3 +33,35 @@ describe('nuxt.config ssr branding head hook', () => {
     expect(render(undefined)).toBe('<link rel="stylesheet" href="/_nuxt/app.css">')
   })
 })
+
+// The head slots plugins/branding-favicon.js writes into. It rewrites the entry carrying `hid: 'icon'`
+// and adds nothing of its own, so these declarations are half of that contract — drop the hid, or let
+// @nuxtjs/pwa push a competing icon link again, and a branded instance silently falls back to the
+// vanilla ocelot icon. Neither failure shows up in the plugin's own tests.
+describe('nuxt.config head icons', () => {
+  const links = (rel) => config.head.link.filter((link) => link.rel === rel)
+
+  it('declares the favicon as a hid slot the branding plugin can rewrite', () => {
+    expect(links('icon')).toEqual([
+      { hid: 'icon', rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+    ])
+  })
+
+  // The pwa meta module only skips its own push when a link with this exact `rel` is already declared
+  // (lib/meta/module.js), and what it pushes is hashed at build time and carries no hid — unbrandable.
+  it('declares the apple-touch-icon itself rather than leaving it to @nuxtjs/pwa', () => {
+    expect(links('apple-touch-icon')).toEqual([
+      { hid: 'apple-touch-icon', rel: 'apple-touch-icon', href: '/icon.png' },
+    ])
+  })
+
+  // `rel="shortcut icon"` is a legacy alias of `rel="icon"`, so that module's build-time PNG competed
+  // with the brand's favicon for the tab. Disabling the icon submodule is what stops it being emitted.
+  it('disables the pwa icon submodule that emitted the competing shortcut icon', () => {
+    expect(config.pwa.icon).toBe(false)
+  })
+
+  it('keeps exactly one manifest link, pointing at the per-brand middleware route', () => {
+    expect(links('manifest')).toEqual([{ rel: 'manifest', href: '/manifest.webmanifest' }])
+  })
+})

--- a/webapp/nuxt.config.spec.js
+++ b/webapp/nuxt.config.spec.js
@@ -65,3 +65,36 @@ describe('nuxt.config head icons', () => {
     expect(links('manifest')).toEqual([{ rel: 'manifest', href: '/manifest.webmanifest' }])
   })
 })
+
+// The other half of that contract, and the half nothing else can catch: branding-favicon.js reads the
+// runtime accessor at plugin-EXECUTION time, and plugins/branding.js is what sets it. Nuxt runs the
+// list in order and awaits the async one, so reordering these two costs nothing at build time and
+// leaves every brand on the vanilla icon at run time — on deployments with a brand archive only, i.e.
+// never on a developer's machine.
+describe('nuxt.config branding plugin order', () => {
+  // Entries are either a bare path or `{ src, ssr | mode }`; both forms are in this list.
+  const entryFor = (src) =>
+    config.plugins.map((p) => (typeof p === 'string' ? { src: p } : p)).find((p) => p.src === src)
+  const indexOf = (src) =>
+    config.plugins.findIndex((p) => (typeof p === 'string' ? p : p.src) === src)
+
+  it('registers branding-favicon.js after the branding.js that sets the accessor', () => {
+    const branding = indexOf('~/plugins/branding.js')
+    const favicon = indexOf('~/plugins/branding-favicon.js')
+
+    // Asserted separately: `favicon > branding` alone also holds when branding.js is absent (-1),
+    // which is the more thorough way to break the same thing.
+    expect(branding).toBeGreaterThanOrEqual(0)
+    expect(favicon).toBeGreaterThan(branding)
+  })
+
+  // Both render paths on purpose. Restricting this one to the client would put the vanilla icon in the
+  // server's first byte and swap it after hydration — the exact behaviour the hid slot removed.
+  it('leaves branding-favicon.js running on the server as well as the client', () => {
+    const entry = entryFor('~/plugins/branding-favicon.js')
+
+    expect(entry).toBeDefined()
+    expect(entry.ssr).not.toBe(false)
+    expect(entry.mode).not.toBe('client')
+  })
+})

--- a/webapp/plugins/branding-favicon.js
+++ b/webapp/plugins/branding-favicon.js
@@ -1,0 +1,50 @@
+// The brand's favicon, on BOTH render paths — so the FIRST byte the browser receives already names the
+// right icon and nothing has to be swapped afterwards.
+//
+// This one goes through vue-meta, unlike the brand's stylesheets in utils/brandingHead.js. That file's
+// reason for avoiding vue-meta is purely about cascade POSITION (vue-meta's tags precede the app's CSS
+// bundles, so `:root` vs `:root` loses on equal specificity). An icon link takes part in no cascade,
+// so the objection does not apply — and vue-meta buys the one thing the string-append hook cannot:
+// `hid` deduplication. The tag declared in nuxt.config is REWRITTEN rather than joined by a second
+// one, which is exactly what previously forced the favicon to be a client-only retarget.
+//
+// Runs on both server and client (no `ssr: false`): the server renders the branded href, and the
+// client resolves the identical value from window.__NUXT__.branding, so hydration matches. Must be
+// registered AFTER plugins/branding.js — that is what sets the runtime accessor this reads.
+import { branding } from '@ocelot-social/branding'
+
+import { iconType } from '~/utils/iconType.js'
+
+/**
+ * Points the `hid`'d icon slot at `href`, rewriting the entry in place so vue-meta still renders
+ * exactly one link for it. Appends only if the slot is missing entirely — two entries sharing a hid
+ * would collapse to one anyway, but an absent one has to come from somewhere.
+ */
+export function setIcon(links, hid, href) {
+  const type = iconType(href)
+  const existing = links.find((link) => link && link.hid === hid)
+  const target = existing || { hid, rel: hid }
+  target.href = href
+  // The type is REPLACED, not merged: nuxt.config's fallback says `image/x-icon` for the vanilla .ico,
+  // and a brand shipping an .svg would otherwise be announced as an icon file it is not. An
+  // unrecognised extension drops the attribute entirely and lets the browser sniff.
+  if (type) target.type = type
+  else delete target.type
+  if (!existing) links.push(target)
+}
+
+export default ({ app }) => {
+  const assets = (branding && branding.assets) || {}
+
+  const links = app && app.head && app.head.link
+  // `app.head` is built per request inside createApp() (see .nuxt/index.js), so mutating it here
+  // brands THIS render only — it cannot leak into the next request the way a module-scope value would.
+  if (!Array.isArray(links)) return
+
+  // Each slot is independent: a brand supplying only one of the two keeps the vanilla fallback for the
+  // other rather than losing it. Same reason nuxt.config declares both up front.
+  if (assets.favicon) setIcon(links, 'icon', assets.favicon)
+  // `assets.icon`, not the favicon: iOS ignores an .ico for the home screen, and .ico is what every
+  // brand ships as its favicon. The two are separate slots in the schema for exactly this reason.
+  if (assets.icon) setIcon(links, 'apple-touch-icon', assets.icon)
+}

--- a/webapp/plugins/branding-favicon.spec.js
+++ b/webapp/plugins/branding-favicon.spec.js
@@ -1,0 +1,143 @@
+// Same hoisting constraint as branding-head.spec.js: a plain `const` with a PURE initializer is the
+// only shape babel-plugin-jest-hoist lifts together with the jest.mock call.
+import brandingFavicon, { setIcon } from './branding-favicon.js'
+
+const BRAND = {
+  assets: { favicon: '/branding/acme/assets/favicon.ico', icon: '/branding/acme/assets/icon.png' },
+}
+
+jest.mock('@ocelot-social/branding', () => ({ branding: BRAND }))
+
+// The head as nuxt.config declares it: the vanilla fallback the plugin is meant to overwrite.
+const vanillaHead = () => ({
+  link: [
+    { hid: 'icon', rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+    { hid: 'apple-touch-icon', rel: 'apple-touch-icon', href: '/icon.png' },
+    { rel: 'manifest', href: '/manifest.webmanifest' },
+  ],
+})
+
+const icons = (head) => head.link.filter((l) => l.hid === 'icon')
+
+describe('setIcon', () => {
+  it('rewrites the declared slot instead of adding a second icon link', () => {
+    const head = vanillaHead()
+
+    setIcon(head.link, 'icon', '/branding/acme/assets/favicon.ico')
+
+    expect(icons(head)).toEqual([
+      { hid: 'icon', rel: 'icon', type: 'image/x-icon', href: '/branding/acme/assets/favicon.ico' },
+    ])
+  })
+
+  it('replaces the fallback type rather than leaving a stale one behind', () => {
+    const head = vanillaHead()
+
+    setIcon(head.link, 'icon', '/branding/acme/assets/favicon.svg')
+
+    expect(icons(head)[0].type).toBe('image/svg+xml')
+  })
+
+  it('drops the type for an extension it cannot vouch for', () => {
+    const head = vanillaHead()
+
+    setIcon(head.link, 'icon', '/branding/acme/assets/favicon')
+
+    expect(icons(head)[0]).not.toHaveProperty('type')
+  })
+
+  it('adds the slot when nothing declared it', () => {
+    const head = { link: [{ rel: 'manifest', href: '/manifest.webmanifest' }] }
+
+    setIcon(head.link, 'icon', '/branding/acme/assets/favicon.ico')
+
+    expect(icons(head)).toEqual([
+      { hid: 'icon', rel: 'icon', type: 'image/x-icon', href: '/branding/acme/assets/favicon.ico' },
+    ])
+  })
+
+  it('leaves the other head links alone', () => {
+    const head = vanillaHead()
+
+    setIcon(head.link, 'icon', '/branding/acme/assets/favicon.ico')
+
+    expect(head.link.filter((l) => l.hid !== 'icon')).toEqual(vanillaHead().link.slice(1))
+  })
+})
+
+describe('branding-favicon plugin', () => {
+  const original = { ...BRAND.assets }
+  afterEach(() => {
+    BRAND.assets = { ...original }
+  })
+
+  it('brands both icons the head declares', () => {
+    const app = { head: vanillaHead() }
+
+    brandingFavicon({ app })
+
+    expect(app.head.link).toEqual([
+      { hid: 'icon', rel: 'icon', type: 'image/x-icon', href: '/branding/acme/assets/favicon.ico' },
+      {
+        hid: 'apple-touch-icon',
+        rel: 'apple-touch-icon',
+        type: 'image/png',
+        href: '/branding/acme/assets/icon.png',
+      },
+      { rel: 'manifest', href: '/manifest.webmanifest' },
+    ])
+  })
+
+  // iOS ignores an .ico, and .ico is what every brand ships as its favicon — so the apple-touch icon
+  // has to come from its own slot. Pointing it at the favicon would look branded and render nothing.
+  it('takes the apple-touch icon from assets.icon, never from the favicon', () => {
+    BRAND.assets = { favicon: '/branding/acme/assets/favicon.ico' }
+    const app = { head: vanillaHead() }
+
+    brandingFavicon({ app })
+
+    expect(app.head.link.find((l) => l.hid === 'apple-touch-icon').href).toBe('/icon.png')
+  })
+
+  // The slots are independent: a brand supplying only one must not cost the other its fallback.
+  it('brands the apple-touch icon on its own when the brand ships no favicon', () => {
+    BRAND.assets = { icon: '/branding/acme/assets/icon.png' }
+    const app = { head: vanillaHead() }
+
+    brandingFavicon({ app })
+
+    expect(icons(app.head)[0].href).toBe('/favicon.ico')
+    expect(app.head.link.find((l) => l.hid === 'apple-touch-icon').href).toBe(
+      '/branding/acme/assets/icon.png',
+    )
+  })
+
+  // Vanilla is not a degraded brand: nuxt.config's own icons have to survive untouched, or an
+  // unbranded instance loses them.
+  it.each([
+    ['a brand with no assets at all', {}],
+    ['empty paths', { favicon: '', icon: '' }],
+    ['nulls', { favicon: null, icon: null }],
+  ])('leaves the vanilla icons in place for %s', (_name, assets) => {
+    BRAND.assets = assets
+    const app = { head: vanillaHead() }
+
+    brandingFavicon({ app })
+
+    expect(app.head).toEqual(vanillaHead())
+  })
+
+  // The plugin runs before anything renders; throwing here would take the whole app down over a
+  // favicon, so an unexpected head shape is a no-op rather than a crash.
+  it.each([
+    ['no head', {}],
+    ['a head without links', { head: {} }],
+    ['links that are not an array', { head: { link: null } }],
+  ])('does not throw on %s', (_name, app) => {
+    expect(() => brandingFavicon({ app })).not.toThrow()
+  })
+
+  it('does not throw without an app at all', () => {
+    expect(() => brandingFavicon({})).not.toThrow()
+  })
+})

--- a/webapp/plugins/branding-head.js
+++ b/webapp/plugins/branding-head.js
@@ -1,29 +1,19 @@
-// Dynamic branding <head> assets (client). The favicon and any extra stylesheets/fonts a brand
-// ships are referenced as data in branding.assets (namespaced to /branding/<id>/… and served by
-// the branding-assets middleware). The markup itself is built by utils/brandingHead.js, which the
-// SSR hook (nuxt.config.js → 'vue-renderer:ssr:templateParams') uses too — so a server-rendered page
+// Dynamic branding <head> assets (client). The extra stylesheets and fonts a brand ships are
+// referenced as data in branding.assets (namespaced to /branding/<id>/… and served by the
+// branding-assets middleware). The markup itself is built by utils/brandingHead.js, which the SSR
+// hook (nuxt.config.js → 'vue-renderer:ssr:templateParams') uses too — so a server-rendered page
 // arrives ALREADY branded and this plugin finds its own tags in place and does nothing. It still
-// matters for a brand that only becomes known on the client, and it keeps the favicon (the one thing
-// SSR deliberately leaves alone — see brandingHead.js).
+// matters for a brand that only becomes known on the client, and for re-appending the tags after
+// vue-style-loader injects the app CSS during hydration (see below).
+//
+// NOT the favicon: that is a vue-meta slot now (plugins/branding-favicon.js), which brands it on the
+// server too instead of retargeting a vanilla link after hydration.
 import { branding } from '@ocelot-social/branding'
 
 import { CSS_LINK_ATTR, brandingCssHrefs } from '~/utils/brandingHead.js'
 
 export default () => {
   if (typeof document === 'undefined') return
-  const assets = branding.assets || {}
-
-  // Retargets the <link rel="icon"> nuxt.config already renders, rather than adding a second one —
-  // which is why the SSR side skips the favicon and only this path sets it.
-  if (assets.favicon) {
-    let link = document.querySelector('link[rel="icon"]')
-    if (!link) {
-      link = document.createElement('link')
-      link.rel = 'icon'
-      document.head.appendChild(link)
-    }
-    link.href = assets.favicon
-  }
 
   // Reuse the <link> the SSR hook emitted rather than adding a second one, but ALWAYS re-append: a
   // brand's own rules mostly match framework selectors on equal specificity and win by being last,

--- a/webapp/plugins/branding-head.spec.js
+++ b/webapp/plugins/branding-head.spec.js
@@ -24,22 +24,32 @@ describe('branding-head plugin', () => {
     document.head.innerHTML = ''
   })
 
-  it('adds the brand stylesheet and retargets the favicon', () => {
-    document.head.innerHTML = '<link rel="icon" href="/favicon.ico">'
+  it('adds the brand stylesheet', () => {
     brandingHead()
 
-    expect(document.querySelector('link[rel="icon"]').getAttribute('href')).toBe(
-      '/branding/acme/assets/favicon.ico',
-    )
     expect(document.querySelectorAll(`link[${CSS_LINK_ATTR}]`)).toHaveLength(1)
+  })
+
+  // The favicon moved to plugins/branding-favicon.js, which brands it through vue-meta on both render
+  // paths. This plugin must not touch the icon link any more — doing both would mean two mechanisms
+  // writing the same tag, and the DOM one would win over the server-rendered value after hydration.
+  it('leaves the icon link to the vue-meta slot', () => {
+    document.head.innerHTML = '<link rel="icon" href="/branding/acme/assets/favicon.ico">'
+
+    brandingHead()
+
+    expect(
+      [...document.querySelectorAll('link[rel="icon"]')].map((l) => l.getAttribute('href')),
+    ).toEqual(['/branding/acme/assets/favicon.ico'])
   })
 
   // The SSR hook (nuxt.config.js) writes the same tags into the rendered HEAD. Running the plugin on
   // top of a server-branded page must be a no-op — otherwise every hydration would duplicate the
   // stylesheet and rewrite the theme block.
   it('leaves the tags the server already rendered untouched', () => {
-    // a server-rendered page: nuxt.config's favicon link, then what the SSR hook appended
-    document.head.innerHTML = `<link rel="icon" href="/favicon.ico">${brandingHeadHtml(BRAND)}`
+    // a server-rendered page: the vue-meta icon link (already branded), then what the SSR hook appended
+    const icon = '<link rel="icon" href="/branding/acme/assets/favicon.ico">'
+    document.head.innerHTML = `${icon}${brandingHeadHtml(BRAND)}`
     const rendered = brandingHeadHtml(BRAND)
 
     brandingHead()
@@ -47,12 +57,7 @@ describe('branding-head plugin', () => {
     // nothing duplicated, and the SSR markup is still there verbatim
     expect(document.querySelectorAll(`link[${CSS_LINK_ATTR}]`)).toHaveLength(1)
     expect(document.head.innerHTML).toContain(rendered)
-    // the favicon is the ONE thing SSR leaves alone (it retargets nuxt's link instead of adding a
-    // second icon), so this is the only mutation the plugin still makes.
-    expect(document.querySelectorAll('link[rel="icon"]')).toHaveLength(1)
-    expect(document.querySelector('link[rel="icon"]').getAttribute('href')).toBe(
-      '/branding/acme/assets/favicon.ico',
-    )
+    expect(document.head.innerHTML).toContain(icon)
   })
 
   // A brand's own rules mostly match framework selectors on equal specificity and win by being LAST.

--- a/webapp/server-middleware/manifest.js
+++ b/webapp/server-middleware/manifest.js
@@ -3,15 +3,23 @@
 // (@nuxtjs/pwa `manifest: false`) so the installed-app name / short name / description / theme colour
 // follow a live brand switch WITHOUT a rebuild. The <link rel="manifest"> href is fixed
 // (/manifest.webmanifest); only the served content is dynamic. Served no-cache so a switch is picked
-// up. (Icons follow the brand's square image via metadata.ogImage; a brand that wants its own PWA
-// icon points ogImage at its squared asset.)
+// up.
 const { getBranding, resolveThemeColor } = require('@ocelot-social/branding')
+
+const { iconType } = require('../utils/iconType.js')
 
 module.exports = function manifest(req, res) {
   const branding = getBranding()
   const { metadata } = branding
-  const icon = metadata.ogImage
-  const iconType = metadata.ogImageType || 'image/png'
+  // `assets.icon` first — the square raster icon a brand ships for exactly this (and for
+  // apple-touch-icon). ogImage stays the fallback it used to be, but it is a SHARE image: sized for a
+  // link preview (1200×1140 by default) rather than an install icon, and often an .svg, which several
+  // browsers refuse in a manifest. A brand that sets neither still ends up with no icons — what the
+  // empty array below already meant.
+  const icon = (branding.assets && branding.assets.icon) || metadata.ogImage
+  // Derived from the path rather than taken from metadata.ogImageType: that field describes the OG
+  // image, and it would mislabel `assets.icon` whenever the two are different files.
+  const type = iconType(icon) || metadata.ogImageType || 'image/png'
 
   const body = {
     name: metadata.applicationName,
@@ -25,8 +33,8 @@ module.exports = function manifest(req, res) {
     lang: 'en',
     icons: icon
       ? [
-          { src: icon, sizes: '192x192', type: iconType },
-          { src: icon, sizes: '512x512', type: iconType },
+          { src: icon, sizes: '192x192', type },
+          { src: icon, sizes: '512x512', type },
         ]
       : [],
   }

--- a/webapp/server-middleware/manifest.spec.js
+++ b/webapp/server-middleware/manifest.spec.js
@@ -60,7 +60,7 @@ describe('manifest serverMiddleware', () => {
     expect(json.icons).toEqual([])
   })
 
-  it('derives the 192/512 PWA icons from the brand ogImage + ogImageType', () => {
+  it('falls back to the 192/512 PWA icons from the brand ogImage + ogImageType', () => {
     setBranding({
       ...brandingDefaults,
       metadata: {
@@ -73,6 +73,27 @@ describe('manifest serverMiddleware', () => {
     expect(json.icons).toEqual([
       { src: '/branding/acme/assets/logo-squared.svg', sizes: '192x192', type: 'image/svg+xml' },
       { src: '/branding/acme/assets/logo-squared.svg', sizes: '512x512', type: 'image/svg+xml' },
+    ])
+  })
+
+  // ogImage is a SHARE image — 1200×1140 by default and often an .svg, which several browsers refuse
+  // in a manifest. `assets.icon` is the square raster icon a brand ships for installing, so it wins.
+  it('prefers the brand assets.icon over the ogImage', () => {
+    setBranding({
+      ...brandingDefaults,
+      assets: { ...brandingDefaults.assets, icon: '/branding/acme/assets/icon.png' },
+      metadata: {
+        ...brandingDefaults.metadata,
+        ogImage: '/branding/acme/assets/logo-squared.svg',
+        ogImageType: 'image/svg+xml',
+      },
+    })
+    const { json } = run()
+    // The type follows the ICON's own extension — carrying ogImageType across would label the png
+    // image/svg+xml and browsers do reject on that mismatch.
+    expect(json.icons).toEqual([
+      { src: '/branding/acme/assets/icon.png', sizes: '192x192', type: 'image/png' },
+      { src: '/branding/acme/assets/icon.png', sizes: '512x512', type: 'image/png' },
     ])
   })
 })

--- a/webapp/utils/brandingHead.js
+++ b/webapp/utils/brandingHead.js
@@ -14,8 +14,11 @@
 // renderStyles(), which puts these tags at the END of <head> — the same position the client plugin
 // appends them to, so one cascade for both paths.
 //
-// NOT handled here: the favicon. The client plugin retargets the <link rel="icon"> that nuxt.config
-// already renders; emitting a second one from SSR would leave two competing icon links.
+// NOT handled here: the favicon. Appending one from this hook would leave two competing icon links
+// next to the one nuxt.config renders, so it goes through vue-meta instead — see
+// plugins/branding-favicon.js, which REWRITES that link via its `hid` and therefore brands the first
+// paint without duplicating anything. The cascade argument above is what keeps the stylesheets out of
+// vue-meta; an icon link takes part in no cascade, so it does not apply to them.
 
 // The marker attribute both paths use, so each recognises what the other already emitted and
 // nothing is applied twice.

--- a/webapp/utils/iconType.js
+++ b/webapp/utils/iconType.js
@@ -1,0 +1,28 @@
+// The MIME type of an icon asset, derived from its path.
+//
+// CommonJS, unlike the rest of utils/: both consumers are on different module systems and neither can
+// be moved. plugins/branding-favicon.js is an ESM plugin bundled by webpack (which interops CJS
+// fine), while server-middleware/manifest.js is required by Node at runtime and cannot `import`.
+// Duplicating the table was the alternative, and a favicon announced as one type in <head> and
+// another in the manifest is exactly the sort of drift that survives review.
+//
+// A brand's `assets.favicon` / `assets.icon` are free-form paths (packages/branding schema.ts), so an
+// extension we do not recognise yields NOTHING rather than a guess: an absent type lets the browser
+// sniff the file, while a wrong one can make it discard the icon outright.
+const ICON_TYPES = {
+  ico: 'image/x-icon',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  gif: 'image/gif',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+}
+
+/** The MIME type for an icon href, or undefined when the extension says nothing useful. */
+function iconType(href) {
+  const match = /\.([a-z0-9]+)(?:[?#]|$)/i.exec(String(href || ''))
+  return match ? ICON_TYPES[match[1].toLowerCase()] : undefined
+}
+
+module.exports = { ICON_TYPES, iconType }

--- a/webapp/utils/iconType.spec.js
+++ b/webapp/utils/iconType.spec.js
@@ -1,0 +1,31 @@
+const { iconType } = require('./iconType.js')
+
+describe('iconType', () => {
+  it.each([
+    ['/a/favicon.ico', 'image/x-icon'],
+    ['/a/icon.PNG', 'image/png'],
+    ['/a/icon.svg', 'image/svg+xml'],
+    ['/a/icon.jpeg', 'image/jpeg'],
+    ['/a/icon.webp', 'image/webp'],
+  ])('reads %s', (href, type) => {
+    expect(iconType(href)).toBe(type)
+  })
+
+  it('ignores a cache-busting query', () => {
+    expect(iconType('/a/favicon.ico?v=2')).toBe('image/x-icon')
+  })
+
+  // A dot in a directory name must not be mistaken for the file's extension.
+  it('reads the extension of the FILE, not of a folder on the way there', () => {
+    expect(iconType('/branding/social.darmbulanz.net/assets/icon.png')).toBe('image/png')
+  })
+
+  // A wrong type can make the browser discard the icon; no type lets it sniff. So an extension we do
+  // not know must yield nothing rather than a guess.
+  it.each(['/a/favicon.xyz', '/a/favicon', '', null, undefined])(
+    'says nothing about %s',
+    (href) => {
+      expect(iconType(href)).toBeUndefined()
+    },
+  )
+})

--- a/webapp/utils/iconType.spec.js
+++ b/webapp/utils/iconType.spec.js
@@ -11,9 +11,13 @@ describe('iconType', () => {
     expect(iconType(href)).toBe(type)
   })
 
-  it('ignores a cache-busting query', () => {
-    expect(iconType('/a/favicon.ico?v=2')).toBe('image/x-icon')
-  })
+  // Both suffixes the extension match accepts, so neither can be dropped from the pattern unnoticed.
+  it.each(['/a/favicon.ico?v=2', '/a/favicon.ico#v=2', '/a/favicon.ico?v=2#top'])(
+    'ignores what follows the extension in %s',
+    (href) => {
+      expect(iconType(href)).toBe('image/x-icon')
+    },
+  )
 
   // A dot in a directory name must not be mistaken for the file's extension.
   it('reads the extension of the FILE, not of a folder on the way there', () => {


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

webapp ssr favicon, maintenance favicon, branding 0.1.1

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Neue Funktionen**
  * Branding unterstützt jetzt Favicons sowie quadratische Icons für Apple-Touch- und PWA-Anwendungen.
  * Favicons und Icons werden automatisch mit passenden MIME-Typen eingebunden.
  * PWA-Manifeste verwenden bevorzugt das konfigurierte Branding-Icon und bieten einen Fallback.

* **Verbesserungen**
  * Nicht konfigurierte Branding-Icons behalten die vorhandenen Standard-Fallbacks.
  * Icon-Pfade werden zuverlässig verarbeitet, einschließlich Großschreibung und URL-Parametern.
  * Branding-Schema und Version wurden aktualisiert.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->