### PR TITLE
refactor(other): improve e2e bottlenecks on ci

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -73,15 +73,18 @@ jobs:
           docker pull quay.io/minio/mc:latest
           docker pull maildev/maildev:latest
 
-      # gzip on the way out: `docker save` writes UNCOMPRESSED layer tars, and every byte here is
-      # paid 40 times over on the matrix side. `docker load` detects the gzip itself.
+      # Compressed on the way out: `docker save` writes UNCOMPRESSED layer tars, and every byte here is
+      # paid 40 times over on the matrix side. zstd rather than gzip -1 — smaller AND faster on both
+      # ends, and `-T0` uses all the runner's cores, which gzip cannot. It is preinstalled on
+      # ubuntu-latest. The matrix side pipes it through `zstd -dc` explicitly instead of relying on
+      # `docker load` sniffing the format.
       - name: Save all images
         run: |
-          docker save "ghcr.io/ocelot-social-community/ocelot-social/backend:test" | gzip -1 > /tmp/backend.tar.gz
-          docker save "ghcr.io/ocelot-social-community/ocelot-social/neo4j:community" | gzip -1 > /tmp/neo4j.tar.gz
-          docker save "quay.io/minio/minio:latest" | gzip -1 > /tmp/minio.tar.gz
-          docker save "quay.io/minio/mc:latest" | gzip -1 > /tmp/minio-mc.tar.gz
-          docker save "maildev/maildev:latest" | gzip -1 > /tmp/mailserver.tar.gz
+          docker save "ghcr.io/ocelot-social-community/ocelot-social/backend:test" | zstd -T0 -3 > /tmp/backend.tar.zst
+          docker save "ghcr.io/ocelot-social-community/ocelot-social/neo4j:community" | zstd -T0 -3 > /tmp/neo4j.tar.zst
+          docker save "quay.io/minio/minio:latest" | zstd -T0 -3 > /tmp/minio.tar.zst
+          docker save "quay.io/minio/mc:latest" | zstd -T0 -3 > /tmp/minio-mc.tar.zst
+          docker save "maildev/maildev:latest" | zstd -T0 -3 > /tmp/mailserver.tar.zst
 
       # ARTIFACT, not cache. These are run-scoped hand-offs between jobs, which is what artifacts are
       # for; `actions/cache` with a `run_id` key can never hit on a later run, yet it occupies the
@@ -91,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: e2e-backend-environment
-          path: /tmp/*.tar.gz
+          path: /tmp/*.tar.zst
           retention-days: 1
           compression-level: 0
 
@@ -105,25 +108,34 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Webapp | Build 'test' image
+      # `e2e`, not `test`: same build, but assembled `FROM base` around the finished /build and started
+      # with nuxt-start instead of the dev server (see webapp/Dockerfile). `test` stays what the webapp
+      # UNIT tests in test-webapp.yml need — sources plus devDependencies for Jest — and is far too fat
+      # for an image that gets shipped to 40 runners.
+      #
+      # Tagged `:test` regardless, because docker-compose.test.yml names that image for the `webapp`
+      # service and this workflow feeds compose from `docker load` alone. The two workflows never share
+      # a machine, so the tag collision is not one. The buildx cache scope IS separate — the two stages
+      # differ only in their final layers, but mixing their manifests under one scope buys nothing.
+      - name: Webapp | Build 'e2e' image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: webapp/Dockerfile
-          target: test
+          target: e2e
           load: true
           tags: ghcr.io/ocelot-social-community/ocelot-social/webapp:test
-          cache-from: type=gha,scope=webapp-test
-          cache-to: type=gha,mode=max,scope=webapp-test
+          cache-from: type=gha,scope=webapp-e2e
+          cache-to: type=gha,mode=max,scope=webapp-e2e
 
       - name: Save image for test jobs
-        run: docker save "ghcr.io/ocelot-social-community/ocelot-social/webapp:test" | gzip -1 > /tmp/webapp.tar.gz
+        run: docker save "ghcr.io/ocelot-social-community/ocelot-social/webapp:test" | zstd -T0 -3 > /tmp/webapp.tar.zst
 
       - name: Upload image for the test jobs
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: e2e-webapp-image
-          path: /tmp/webapp.tar.gz
+          path: /tmp/webapp.tar.zst
           retention-days: 1
           compression-level: 0
 
@@ -213,11 +225,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # Deliberately WITHOUT `cache: 'yarn'`, unlike `prepare_cypress`: this job never runs an install.
+      # The restore below brings the whole workspace INCLUDING every node_modules tree, so downloading
+      # and unpacking the yarn download cache on top of it is a few hundred megabytes that nothing
+      # reads — 40 times per run.
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: 'backend/.nvmrc'
-          cache: 'yarn'
 
       # Exact key only — see the note in `prepare_cypress`. This step restores over the checkout above,
       # so anything but this commit's own workspace would mean testing a different revision than the
@@ -255,20 +270,19 @@ jobs:
 
       - name: Boot up test system | docker compose
         run: |
-          docker load < /tmp/neo4j.tar.gz
-          docker load < /tmp/backend.tar.gz
-          docker load < /tmp/minio.tar.gz
-          docker load < /tmp/minio-mc.tar.gz
-          docker load < /tmp/mailserver.tar.gz
-          docker load < /tmp/webapp.tar.gz
+          for image in neo4j backend minio minio-mc mailserver webapp; do
+            zstd -dc "/tmp/${image}.tar.zst" | docker load
+          done
           docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach backend mailserver webapp
 
+          # `sleep 1`, not 5: the loop costs one curl per second against a local port, and the wait is
+          # paid in every matrix job. A 5 s step wasted 2.5 s per service on average for nothing.
           echo "Waiting for backend (max 120s)..."
-          timeout 120 bash -c 'until curl -sf -X POST -H "Content-Type: application/json" -d "{\"query\":\"{__typename}\"}" http://localhost:4000 > /dev/null 2>&1; do sleep 5; done'
+          timeout 120 bash -c 'until curl -sf -X POST -H "Content-Type: application/json" -d "{\"query\":\"{__typename}\"}" http://localhost:4000 > /dev/null 2>&1; do sleep 1; done'
           echo "Backend is ready."
 
           echo "Waiting for webapp (max 120s)..."
-          timeout 120 bash -c 'until curl -sf http://localhost:3000 > /dev/null 2>&1; do sleep 5; done'
+          timeout 120 bash -c 'until curl -sf http://localhost:3000 > /dev/null 2>&1; do sleep 1; done'
           echo "Webapp is ready."
 
       - name: Initialize database

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -275,15 +275,28 @@ jobs:
           done
           docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach backend mailserver webapp
 
+          # A service that never comes up used to fail this step as a bare `exit 124` with nothing to
+          # go on — the same empty result whether the image was broken, the port wrong or the boot
+          # merely slow, times 40 identical matrix jobs. Dump the compose state and logs on timeout
+          # instead; a container that dies on a missing module says so in its own log.
+          #
           # `sleep 1`, not 5: the loop costs one curl per second against a local port, and the wait is
           # paid in every matrix job. A 5 s step wasted 2.5 s per service on average for nothing.
-          echo "Waiting for backend (max 120s)..."
-          timeout 120 bash -c 'until curl -sf -X POST -H "Content-Type: application/json" -d "{\"query\":\"{__typename}\"}" http://localhost:4000 > /dev/null 2>&1; do sleep 1; done'
-          echo "Backend is ready."
-
-          echo "Waiting for webapp (max 120s)..."
-          timeout 120 bash -c 'until curl -sf http://localhost:3000 > /dev/null 2>&1; do sleep 1; done'
-          echo "Webapp is ready."
+          compose() { docker compose -f docker-compose.yml -f docker-compose.test.yml "$@"; }
+          await() {
+            local name="$1" seconds="$2"; shift 2
+            echo "Waiting for ${name} (max ${seconds}s)..."
+            if timeout "$seconds" bash -c "until $*; do sleep 1; done"; then
+              echo "${name} is ready."
+            else
+              echo "::error::${name} did not become ready within ${seconds}s"
+              compose ps
+              compose logs --tail=100
+              return 1
+            fi
+          }
+          await backend 120 'curl -sf -X POST -H "Content-Type: application/json" -d "{\"query\":\"{__typename}\"}" http://localhost:4000 > /dev/null 2>&1'
+          await webapp 120 'curl -sf http://localhost:3000 > /dev/null 2>&1'
 
       - name: Initialize database
         run: docker compose -f docker-compose.yml -f docker-compose.test.yml exec -T backend yarn db:migrate init

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -59,6 +59,11 @@ CMD ["/bin/bash", "-c", "yarn run start"]
 # finished /build.
 FROM base AS base-build
 RUN apk --no-cache add python3 make g++ linux-headers
+# `strip` comes along with g++ (binutils), so this needs no package of its own. The helper is used
+# after every `yarn install` below — see the script for what it removes and why it has to share the
+# install's layer.
+COPY backend/scripts/prune-native-build-artifacts.sh /usr/local/bin/prune-native-build-artifacts
+RUN chmod +x /usr/local/bin/prune-native-build-artifacts
 
 # Installs at container START, hence the toolchain.
 FROM base-build AS development
@@ -78,7 +83,8 @@ COPY --from=branding-tools ./app/ /brand-tools/
 # (python3/make/g++ sit in `base` for exactly them) recompiled on every push.
 COPY backend/package.json backend/yarn.lock ./
 RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
-    yarn install --production=false --frozen-lockfile --non-interactive --cache-folder /yarn-cache
+    yarn install --production=false --frozen-lockfile --non-interactive --cache-folder /yarn-cache && \
+    prune-native-build-artifacts
 # Repo-root build context now (for /packages/branding): copy only the backend subtree to /app.
 COPY backend/ .
 # Optional per-brand overlays (code/seed data not yet ported to the runtime archive). The `[g]` glob
@@ -114,7 +120,8 @@ ONBUILD RUN mkdir /build && \
     cp -r ./build ./package.json ./yarn.lock /build && \
     if [ -d ./deployment ]; then cp -r ./deployment /build/deployment; fi
 ONBUILD RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
-    cd /build && yarn install --production=true --frozen-lockfile --non-interactive --cache-folder /yarn-cache
+    cd /build && yarn install --production=true --frozen-lockfile --non-interactive --cache-folder /yarn-cache && \
+    prune-native-build-artifacts
 
 # Deliberately NOT `FROM build`: the test image runs `yarn dev` → `nodemon --exec tsx src/index.ts`,
 # straight off the sources. Everything `build` adds on top — `yarn run build` (tsc), the /build copy and
@@ -141,7 +148,8 @@ ONBUILD RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
 FROM base-build AS test-modules
 COPY backend/package.json backend/yarn.lock ./
 RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
-    yarn install --production=false --frozen-lockfile --non-interactive --cache-folder /yarn-cache
+    yarn install --production=false --frozen-lockfile --non-interactive --cache-folder /yarn-cache && \
+    prune-native-build-artifacts
 
 FROM base AS test
 # Before the sources, so a src/ change does not invalidate the dependency layer.

--- a/backend/scripts/prune-native-build-artifacts.sh
+++ b/backend/scripts/prune-native-build-artifacts.sh
@@ -21,11 +21,10 @@ cd "${1:-.}"
 
 [ -d node_modules ] || exit 0
 
-# Assert the toolchain up front. Without this, a missing binutils would make the `readelf` probe below
-# fail for EVERY addon, each one would be classified as "not an ELF object" and skipped, and the
-# script would report success having stripped nothing — the exact silent pass this script must not
-# have. Both binaries come from binutils, which `base-build` gets via g++.
-for tool in strip readelf du; do
+# Assert the toolchain up front. Without this a missing binutils would be indistinguishable from
+# "nothing to strip": the script would report success having stripped nothing, which is the silent
+# pass it exists to prevent. `strip` comes from binutils, which `base-build` gets via g++.
+for tool in strip od du; do
   command -v "$tool" >/dev/null || {
     echo "prune-native: required tool '$tool' not found" >&2
     exit 1
@@ -42,17 +41,26 @@ rm -rf node_modules/re2/vendor
 
 # Debug symbols. Applies to every addon, not just re2, so a future native dependency is covered too.
 #
-# A `.node` that is not an ELF object is the ONE expected failure — packages do ship such files as
-# fixtures, and `strip` rejects them. That case is detected and skipped explicitly; everything else
-# still fails the build. `readelf` ships in the same binutils package as `strip`, so testing with it
-# costs no extra dependency.
-find node_modules -name '*.node' -type f | while IFS= read -r addon; do
-  if readelf -h "$addon" >/dev/null 2>&1; then
-    strip --strip-unneeded "$addon"
-  else
-    echo "prune-native: not an ELF object, left alone: $addon"
-  fi
-done
+# Deliberately `-exec … +` and NOT `find … | while read`: a pipeline reports the status of its LAST
+# command, so a failing `find` would pass unnoticed. POSIX requires find to exit non-zero when an
+# `-exec … +` invocation does, which — combined with `set -e` here and `sh -e` in the child — makes
+# every failure below fatal.
+#
+# The ELF magic decides, rather than asking a tool whether the file parses. Packages do ship .node
+# files that are fixtures rather than addons, and skipping those is legitimate; a file that HAS the
+# magic but cannot be stripped is a broken build artefact and must fail. A probe like `readelf -h`
+# cannot tell those two apart — it exits non-zero for both, and inside an `if` condition `set -e`
+# does not fire, so the broken case would silently take the "skip" path.
+find node_modules -name '*.node' -type f -exec sh -ec '
+  for addon do
+    [ -r "$addon" ] || { echo "prune-native: cannot read $addon" >&2; exit 1; }
+    if [ "$(od -An -tx1 -N4 "$addon" | tr -d " \n")" = "7f454c46" ]; then
+      strip --strip-unneeded "$addon"
+    else
+      echo "prune-native: not an ELF object, left alone: $addon"
+    fi
+  done
+' _ {} +
 
 after=$(du -sk node_modules | cut -f1)
 echo "prune-native: node_modules $((before / 1024)) MB -> $((after / 1024)) MB"

--- a/backend/scripts/prune-native-build-artifacts.sh
+++ b/backend/scripts/prune-native-build-artifacts.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Remove what building a native addon leaves behind in node_modules.
+#
+# MUST run in the same RUN layer as the `yarn install` it cleans up after: a delete in a later layer
+# only writes a whiteout on top and reclaims nothing.
+#
+# `re2` is the only native addon in backend/yarn.lock and it occupies 74 MB after a node-gyp build.
+# The runtime needs two of those: re2.js (the package main) and build/Release/re2.node. Everything
+# else is scaffolding — the bundled C++ sources it was compiled FROM (vendor/, 17 MB) and the object
+# files it was compiled THROUGH (build/Release/obj.target/, 57 MB, which also hardlinks the addon
+# itself). Stripping the debug symbols off the addon takes it from 22.8 MB down to 1.4 MB; the
+# dynamic symbols Node needs to dlopen it (napi_register_module_v1 and friends) survive
+# --strip-unneeded, which is why the addon still loads afterwards.
+#
+# Measured on the backend production image: node_modules 371 MB -> 300 MB.
+#
+# Usage: prune-native-build-artifacts [directory containing node_modules]
+set -eu
+
+cd "${1:-.}"
+
+[ -d node_modules ] || exit 0
+
+# Object files and the vendored sources. `-prune` so find does not descend into what it just removed.
+find node_modules -type d -name obj.target -prune -exec rm -rf {} + 2>/dev/null || true
+rm -rf node_modules/re2/vendor
+
+# Debug symbols. Applies to every addon, not just re2, so a future native dependency is covered too.
+find node_modules -name '*.node' -exec strip --strip-unneeded {} + 2>/dev/null || true

--- a/backend/scripts/prune-native-build-artifacts.sh
+++ b/backend/scripts/prune-native-build-artifacts.sh
@@ -21,9 +21,27 @@ cd "${1:-.}"
 
 [ -d node_modules ] || exit 0
 
-# Object files and the vendored sources. `-prune` so find does not descend into what it just removed.
-find node_modules -type d -name obj.target -prune -exec rm -rf {} + 2>/dev/null || true
+before=$(du -sk node_modules | cut -f1)
+
+# Object files and the vendored sources. `-prune` so find does not descend into what it is removing.
+# No error suppression anywhere below: `set -e` plus a missing `2>/dev/null` is what keeps a failure
+# here — a read-only layer, a `strip` that is not installed — from silently shipping a fat image.
+find node_modules -type d -name obj.target -prune -exec rm -rf {} +
 rm -rf node_modules/re2/vendor
 
 # Debug symbols. Applies to every addon, not just re2, so a future native dependency is covered too.
-find node_modules -name '*.node' -exec strip --strip-unneeded {} + 2>/dev/null || true
+#
+# A `.node` that is not an ELF object is the ONE expected failure — packages do ship such files as
+# fixtures, and `strip` rejects them. That case is detected and skipped explicitly; everything else
+# still fails the build. `readelf` ships in the same binutils package as `strip`, so testing with it
+# costs no extra dependency.
+find node_modules -name '*.node' -type f | while IFS= read -r addon; do
+  if readelf -h "$addon" >/dev/null 2>&1; then
+    strip --strip-unneeded "$addon"
+  else
+    echo "prune-native: not an ELF object, left alone: $addon"
+  fi
+done
+
+after=$(du -sk node_modules | cut -f1)
+echo "prune-native: node_modules $((before / 1024)) MB -> $((after / 1024)) MB"

--- a/backend/scripts/prune-native-build-artifacts.sh
+++ b/backend/scripts/prune-native-build-artifacts.sh
@@ -21,6 +21,17 @@ cd "${1:-.}"
 
 [ -d node_modules ] || exit 0
 
+# Assert the toolchain up front. Without this, a missing binutils would make the `readelf` probe below
+# fail for EVERY addon, each one would be classified as "not an ELF object" and skipped, and the
+# script would report success having stripped nothing — the exact silent pass this script must not
+# have. Both binaries come from binutils, which `base-build` gets via g++.
+for tool in strip readelf du; do
+  command -v "$tool" >/dev/null || {
+    echo "prune-native: required tool '$tool' not found" >&2
+    exit 1
+  }
+done
+
 before=$(du -sk node_modules | cut -f1)
 
 # Object files and the vendored sources. `-prune` so find does not descend into what it is removing.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,13 @@ services:
       - NODE_ENV=test
       - API_KEYS_ENABLED=true
       - API_KEYS_MAX_PER_USER=5
+      # Toasts live 15 s instead of iziToast's 5 s. Several Cypress steps assert on a toast AFTER a
+      # wait (see cypress/support/step_definitions/admin/NetworkPolicy/I_save_the_policy_form.js,
+      # which calls waitForNetworkIdle first), and with the default the assertion loses that race
+      # whenever the action triggers enough follow-up traffic — it then retries for 60 s against an
+      # element that has already dismissed itself. Not raised further on purpose: the toasts sit
+      # bottom-right, and one that outlives the scenario could cover an element a later step clicks.
+      - TOAST_TIMEOUT=15000
     volumes:
       - ./coverage:/app/coverage
 

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -177,11 +177,13 @@ COPY webapp/. .
 RUN yarn run build
 RUN mkdir /build && \
     cp -r ./.nuxt ./nuxt.config.js ./config ./constants ./static ./locales ./server-middleware ./utils ./package.json ./yarn.lock ./scripts /build
-# `--production=true`, like the `build` stage above: what runs below is `nuxt-start` (a dependency),
-# not `nuxt` (a devDependency), so the 45 devDeps are dead weight in an image the e2e matrix
-# downloads once per feature file.
-RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
-    cd /build && yarn install --production=true --frozen-lockfile --non-interactive --cache-folder /yarn-cache
+# FULL install, deliberately — do NOT add `--production=true` here the way the `build` stage above
+# does. Nuxt 2 does not bundle node_modules into the SSR build; it externalises them and `require`s
+# them at request time. `vue-template-compiler` is one of those (grep the built .nuxt/dist/server/
+# server.js), it arrives only as a transitive dependency of `nuxt` — a devDependency — and it is
+# needed on the code path that renders /groups/:id/:slug. With a production install that route
+# answers 500 while /login and /profile/* still render fine, so the failure looks like a broken page
+# rather than a missing module. Measured: production install → 500, full install → 302, same commit.
 
 # The test image has TWO consumers with opposite needs, hence two stages off the same build:
 #   • test — the webapp UNIT tests (.github/workflows/test-webapp.yml runs `docker compose exec webapp

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -177,13 +177,16 @@ COPY webapp/. .
 RUN yarn run build
 RUN mkdir /build && \
     cp -r ./.nuxt ./nuxt.config.js ./config ./constants ./static ./locales ./server-middleware ./utils ./package.json ./yarn.lock ./scripts /build
-# FULL install, deliberately — do NOT add `--production=true` here the way the `build` stage above
-# does. Nuxt 2 does not bundle node_modules into the SSR build; it externalises them and `require`s
-# them at request time. `vue-template-compiler` is one of those (grep the built .nuxt/dist/server/
-# server.js), it arrives only as a transitive dependency of `nuxt` — a devDependency — and it is
-# needed on the code path that renders /groups/:id/:slug. With a production install that route
-# answers 500 while /login and /profile/* still render fine, so the failure looks like a broken page
-# rather than a missing module. Measured: production install → 500, full install → 302, same commit.
+# Production install — which is only safe because `vue-template-compiler` is now a real dependency in
+# webapp/package.json. Nuxt 2 does not bundle node_modules into the SSR build; it externalises them
+# and `require`s them at request time (grep the built .nuxt/dist/server/server.js). That compiler
+# arrived only as a transitive dependency of `nuxt`, a devDependency, so a production install dropped
+# it — and the route that needs it, /groups/:id/:slug, answered 500 while /login and /profile/*
+# rendered fine. The container logs nothing in that case, so it reads as a broken page rather than a
+# missing module. Before adding a `--production` flag anywhere in this file, re-run the check that
+# found it: extract every bare `require("…")` from .nuxt/dist/server/ and diff against node_modules/.
+RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
+    cd /build && yarn install --production=true --frozen-lockfile --non-interactive --cache-folder /yarn-cache
 
 # The test image has TWO consumers with opposite needs, hence two stages off the same build:
 #   • test — the webapp UNIT tests (.github/workflows/test-webapp.yml runs `docker compose exec webapp

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -177,11 +177,34 @@ COPY webapp/. .
 RUN yarn run build
 RUN mkdir /build && \
     cp -r ./.nuxt ./nuxt.config.js ./config ./constants ./static ./locales ./server-middleware ./utils ./package.json ./yarn.lock ./scripts /build
+# `--production=true`, like the `build` stage above: what runs below is `nuxt-start` (a dependency),
+# not `nuxt` (a devDependency), so the 45 devDeps are dead weight in an image the e2e matrix
+# downloads once per feature file.
 RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
-    cd /build && yarn install --frozen-lockfile --non-interactive --cache-folder /yarn-cache
+    cd /build && yarn install --production=true --frozen-lockfile --non-interactive --cache-folder /yarn-cache
 
+# The test image has TWO consumers with opposite needs, hence two stages off the same build:
+#   • test — the webapp UNIT tests (.github/workflows/test-webapp.yml runs `docker compose exec webapp
+#            yarn test`). Jest needs the sources and all 45 devDependencies, so this one keeps the whole
+#            /app tree. Its CMD only has to keep the container alive for the `exec`.
+#   • e2e  — the CYPRESS matrix (.github/workflows/test-e2e.yml). That workflow `docker save`s the image
+#            and pulls it down again in EVERY one of the 40 matrix jobs, so nothing that only the build
+#            needed may ride along.
 FROM test_build AS test
 CMD ["/bin/bash", "-c", "yarn run dev"]
+
+# Same shape as `production` below — `FROM base` + the assembled /build — and for the same reason.
+# Deriving this from `test_build` shipped the node-gyp toolchain, the webapp sources and a second,
+# complete node_modules tree to all 40 jobs.
+#
+# It also inherits base's `yarn run start` (nuxt-start) instead of `yarn run dev`. The dev server
+# rebuilt the entire webpack bundle at container start — in every matrix job, while the workflow sat in
+# its `until curl localhost:3000` loop — and then ignored the `.nuxt` that `yarn run build` above had
+# already produced. Nothing in the e2e run needs it: coverage is not instrumented in this build (no
+# babel-plugin-istanbul in nuxt.config.js — the ./coverage mount in docker-compose.test.yml is Jest's),
+# and HMR has no consumer when the client is Cypress.
+FROM base AS e2e
+COPY --from=test_build /build .
 
 FROM build AS production_build
 

--- a/webapp/config/index.js
+++ b/webapp/config/index.js
@@ -98,6 +98,18 @@ const organization = {
   SUPPORT_EMAIL: process.env.SUPPORT_EMAIL || 'hello@ocelot.social',
 }
 
+// How long a toast stays on screen, in milliseconds (iziToast's own default is 5000). In CONFIG so
+// nuxt-env exposes it at runtime as `$env.TOAST_TIMEOUT` — same channel as SUPPORT_EMAIL — which is
+// what lets the e2e stack raise it on the pre-built image (docker-compose.test.yml).
+//
+// It has to be raisable because a toast is the only evidence some Cypress steps have that an action
+// succeeded, and asserting on it is a race against this timeout: any wait between the action and the
+// assertion (`cy.waitForNetworkIdle` in the policy steps, for instance) eats into the window, and a
+// toast that has already auto-dismissed is indistinguishable from one that never appeared.
+const notifications = {
+  TOAST_TIMEOUT: toPositiveNumber(process.env.TOAST_TIMEOUT, 5000),
+}
+
 const CONFIG = {
   ...environment,
   ...server,
@@ -105,6 +117,7 @@ const CONFIG = {
   ...options,
   ...language,
   ...organization,
+  ...notifications,
 }
 
 // override process.env with the values here since they contain default values

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -66,6 +66,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-scrollto": "^2.20.0",
     "vue-sweetalert-icons": "~4.3.1",
+    "vue-template-compiler": "^2.7.16",
     "vue-virtual-scroller": "^1.1.2",
     "vue2-datepicker": "^3.11.1",
     "vuex-i18n": "~1.13.1",

--- a/webapp/plugins/izi-toast.js
+++ b/webapp/plugins/izi-toast.js
@@ -3,11 +3,16 @@ import VueIziToast from 'vue-izitoast'
 
 import 'izitoast/dist/css/iziToast.css'
 
-export default ({ app }) => {
+// `$env` rather than an import of ~/config: the config module's values are inlined at BUILD time,
+// and this image is built once and started with per-deployment env afterwards. nuxt-env's plugin is
+// registered as a module and therefore runs before this one, so $env is populated here. The fallback
+// covers both a missing key and a non-numeric value.
+export default ({ $env }) => {
   Vue.use(VueIziToast, {
     position: 'bottomRight',
     transitionIn: 'bounceInLeft',
     layout: 2,
     theme: 'dark',
+    timeout: Number($env && $env.TOAST_TIMEOUT) || 5000,
   })
 }

--- a/webapp/plugins/izi-toast.js
+++ b/webapp/plugins/izi-toast.js
@@ -3,16 +3,27 @@ import VueIziToast from 'vue-izitoast'
 
 import 'izitoast/dist/css/iziToast.css'
 
+// iziToast's own default, and what any unusable configured value falls back to.
+export const DEFAULT_TOAST_TIMEOUT = 5000
+
+// Same rule as config/index.js' toPositiveNumber, and for the same reason: an env var arrives as a
+// string. A bare `Number(value) || DEFAULT` would accept "-1" (iziToast dismisses immediately, so
+// every toast assertion in the e2e suite would fail) and "Infinity" (no toast ever goes away, so
+// they stack up and cover the elements later steps click).
+export const toTimeout = (value) => {
+  const timeout = Number(value)
+  return Number.isFinite(timeout) && timeout > 0 ? timeout : DEFAULT_TOAST_TIMEOUT
+}
+
 // `$env` rather than an import of ~/config: the config module's values are inlined at BUILD time,
 // and this image is built once and started with per-deployment env afterwards. nuxt-env's plugin is
-// registered as a module and therefore runs before this one, so $env is populated here. The fallback
-// covers both a missing key and a non-numeric value.
+// registered as a module and therefore runs before this one, so $env is populated here.
 export default ({ $env }) => {
   Vue.use(VueIziToast, {
     position: 'bottomRight',
     transitionIn: 'bounceInLeft',
     layout: 2,
     theme: 'dark',
-    timeout: Number($env && $env.TOAST_TIMEOUT) || 5000,
+    timeout: toTimeout($env && $env.TOAST_TIMEOUT),
   })
 }

--- a/webapp/plugins/izi-toast.spec.js
+++ b/webapp/plugins/izi-toast.spec.js
@@ -1,0 +1,58 @@
+import Vue from 'vue'
+import VueIziToast from 'vue-izitoast'
+
+import iziToastPlugin, { toTimeout, DEFAULT_TOAST_TIMEOUT } from './izi-toast.js'
+
+const optionsFor = (context) => {
+  const use = jest.spyOn(Vue, 'use').mockImplementation(() => {})
+  iziToastPlugin(context)
+  const [plugin, options] = use.mock.calls[0]
+  use.mockRestore()
+  return { plugin, options }
+}
+
+describe('izi-toast plugin', () => {
+  it('registers vue-izitoast with the app-wide presentation options', () => {
+    const { plugin, options } = optionsFor({ $env: {} })
+    expect(plugin).toBe(VueIziToast)
+    expect(options).toMatchObject({
+      position: 'bottomRight',
+      transitionIn: 'bounceInLeft',
+      layout: 2,
+      theme: 'dark',
+    })
+  })
+
+  describe('timeout', () => {
+    // The value reaches the client through nuxt-env, i.e. straight out of the environment as a
+    // STRING, and it decides how long a toast stays on screen. Several Cypress steps assert on a
+    // toast after a wait, so a value that dismisses instantly or never fails the e2e suite in a way
+    // that looks like a broken feature rather than a bad config.
+    it.each([
+      ['a configured string', '15000', 15000],
+      ['a configured number', 15000, 15000],
+      ['an unset key', undefined, DEFAULT_TOAST_TIMEOUT],
+      ['an empty string', '', DEFAULT_TOAST_TIMEOUT],
+      ['a non-numeric value', 'soon', DEFAULT_TOAST_TIMEOUT],
+      ['zero', '0', DEFAULT_TOAST_TIMEOUT],
+      ['a negative value', '-1', DEFAULT_TOAST_TIMEOUT],
+      ['infinity', 'Infinity', DEFAULT_TOAST_TIMEOUT],
+      ['negative infinity', '-Infinity', DEFAULT_TOAST_TIMEOUT],
+      ['NaN', NaN, DEFAULT_TOAST_TIMEOUT],
+      ['null', null, DEFAULT_TOAST_TIMEOUT],
+    ])('resolves %s', (_label, value, expected) => {
+      expect(toTimeout(value)).toBe(expected)
+    })
+
+    it('passes the configured timeout to vue-izitoast', () => {
+      const { options } = optionsFor({ $env: { TOAST_TIMEOUT: '15000' } })
+      expect(options.timeout).toBe(15000)
+    })
+
+    it('falls back when nuxt-env injected no $env at all', () => {
+      // Defensive: the plugin must not throw if it somehow runs before nuxt-env's own plugin.
+      const { options } = optionsFor({})
+      expect(options.timeout).toBe(DEFAULT_TOAST_TIMEOUT)
+    })
+  })
+})


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

improve e2e bottlenecks on ci

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Verbesserungen**
  * E2E-Testumgebungen starten schneller und prüfen regelmäßig die Bereitschaft.
  * Docker-Images werden effizienter gespeichert, übertragen und geladen.
  * Das E2E-Image ist schlanker und enthält nur benötigte Laufzeitabhängigkeiten.
  * Nicht benötigte native Build-Artefakte werden entfernt.
* **Neue Funktionen**
  * Die Anzeigedauer von Toast-Benachrichtigungen ist konfigurierbar und beträgt standardmäßig fünf Sekunden.
  * Für Testumgebungen können Toasts bis zu 15 Sekunden sichtbar bleiben.
* **Tests**
  * Die E2E-Testausführung liefert bei Zeitüberschreitungen zusätzliche Status- und Protokollinformationen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->