### PR TITLE
fix(workflow): fix e2e cache + define if image is cached

### DIFF
--- a/.github/images.json
+++ b/.github/images.json
@@ -4,69 +4,89 @@
     "context": "neo4j",
     "file": "neo4j/Dockerfile",
     "target": "community",
-    "release": true
+    "release": true,
+    "cacheScope": "neo4j",
+    "cacheTo": true
   },
   {
     "name": "backend-base",
     "context": ".",
     "file": "backend/Dockerfile",
     "target": "base",
-    "release": false
+    "release": false,
+    "cacheScope": "backend",
+    "cacheTo": false
   },
   {
     "name": "backend-build",
     "context": ".",
     "file": "backend/Dockerfile",
     "target": "build",
-    "release": false
+    "release": false,
+    "cacheScope": "backend",
+    "cacheTo": false
   },
   {
     "name": "backend",
     "context": ".",
     "file": "backend/Dockerfile",
     "target": "production",
-    "release": true
+    "release": true,
+    "cacheScope": "backend",
+    "cacheTo": true
   },
   {
     "name": "webapp-base",
     "context": ".",
     "file": "webapp/Dockerfile",
     "target": "base",
-    "release": false
+    "release": false,
+    "cacheScope": "webapp",
+    "cacheTo": false
   },
   {
     "name": "webapp-build",
     "context": ".",
     "file": "webapp/Dockerfile",
     "target": "build",
-    "release": false
+    "release": false,
+    "cacheScope": "webapp",
+    "cacheTo": false
   },
   {
     "name": "webapp",
     "context": ".",
     "file": "webapp/Dockerfile",
     "target": "production",
-    "release": true
+    "release": true,
+    "cacheScope": "webapp",
+    "cacheTo": true
   },
   {
     "name": "maintenance-base",
     "context": ".",
     "file": "maintenance/Dockerfile",
     "target": "production",
-    "release": false
+    "release": false,
+    "cacheScope": "maintenance",
+    "cacheTo": false
   },
   {
     "name": "maintenance-build",
     "context": ".",
     "file": "maintenance/Dockerfile",
     "target": "build",
-    "release": false
+    "release": false,
+    "cacheScope": "maintenance",
+    "cacheTo": false
   },
   {
     "name": "maintenance",
     "context": ".",
     "file": "maintenance/Dockerfile",
     "target": "production",
-    "release": true
+    "release": true,
+    "cacheScope": "maintenance",
+    "cacheTo": true
   }
 ]

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -122,5 +122,19 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.app.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.app.name }}
+          # One cache scope per DOCKERFILE, not per image, and only one image per scope writes it.
+          #
+          # `mode=max` exports every stage a build touched. The three images built from one Dockerfile
+          # are nested — for backend, `production` is `FROM base` plus a COPY out of `production_build`
+          # (`FROM build`), so building it involves base, base-build, build and production_build. Its
+          # cache therefore already CONTAINS everything the `base` and `build` images would export;
+          # writing all three meant storing the same layers under three keys. A cache key of a step in
+          # `base` does not depend on which target the build was aiming for, so the two readers hit the
+          # writer's entries exactly as they hit their own before.
+          #
+          # Letting all three WRITE one shared scope would not work: Actions cache keys are immutable,
+          # the three matrix jobs run concurrently, and the losers fail with "cache already exists"
+          # after mixing up the index. Hence `cacheTo` on the one target that subsumes the others —
+          # see .github/images.json, which also documents which target that is per Dockerfile.
+          cache-from: type=gha,scope=${{ matrix.app.cacheScope }}
+          cache-to: ${{ matrix.app.cacheTo && format('type=gha,mode=max,scope={0}', matrix.app.cacheScope) || '' }}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -136,5 +136,12 @@ jobs:
           # the three matrix jobs run concurrently, and the losers fail with "cache already exists"
           # after mixing up the index. Hence `cacheTo` on the one target that subsumes the others —
           # see .github/images.json, which also documents which target that is per Dockerfile.
+          #
+          # `ignore-error=true` because the export runs as part of the same solve as the push and
+          # defaults to being fatal: a throttled or briefly unavailable Actions cache service would
+          # turn a run whose images are ALREADY IN THE REGISTRY into a red one. On master that is
+          # not just noise — `publish` waits for this workflow to succeed before it retags those
+          # images into the version tags, so a cache hiccup would hold up a release. A failed export
+          # only costs the next build its cache hits, which is the cheaper failure by a wide margin.
           cache-from: type=gha,scope=${{ matrix.app.cacheScope }}
-          cache-to: ${{ matrix.app.cacheTo && format('type=gha,mode=max,scope={0}', matrix.app.cacheScope) || '' }}
+          cache-to: ${{ matrix.app.cacheTo && format('type=gha,mode=max,ignore-error=true,scope={0}', matrix.app.cacheScope) || '' }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -182,25 +182,44 @@ jobs:
           cd ..
           yarn install
       
-      # This is a HAND-OFF to the matrix jobs below, not a dependency cache: the path includes the whole
-      # workspace (sources, cypress specs, the backend `yarn build` output), so it is only ever valid
-      # for the commit that produced it. Hence `github.sha` in the key and deliberately NO
-      # `restore-keys`.
+      # ARTIFACT, not cache — for the same reason as the images above, which this step used to
+      # contradict. It is a HAND-OFF to the matrix jobs: the payload is the whole installed workspace
+      # (sources, cypress specs, every node_modules, the backend `yarn build` output), so it is only
+      # ever valid for the commit that produced it. Its cache key therefore ended in `github.sha`,
+      # which can never hit on a later run — a write-once entry of roughly a gigabyte, produced by
+      # EVERY push to EVERY branch, evicting by LRU the caches that could actually hit. It also
+      # evicted itself: with the budget full, entries of newer runs displaced this one before all 40
+      # matrix jobs had restored it, and `fail-on-cache-miss` turned that into a red run.
       #
-      # A lockfile-only fallback would be actively wrong here. `actions/cache` extracts over the
-      # existing tree, so it runs AFTER `actions/checkout` and overwrites what checkout just put there.
-      # A fallback key matches any earlier commit with the same lockfiles — which is most commits, since
-      # most do not touch dependencies — and the end-to-end suite would then silently exercise an older
-      # revision and report green for it. Missing the cache outright is the far better failure: the
-      # matrix job finds no node_modules and fails loudly.
-      - name: Cache cypress + installed workspace
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.0.2
+      # A lockfile-only fallback key would have been actively wrong, which is why none existed: it
+      # matches any earlier commit with the same lockfiles — most commits, since most do not touch
+      # dependencies — and the suite would then silently exercise an older revision and report green
+      # for it. An artifact has no such fallback to get wrong, and unlike a cache entry it cannot be
+      # evicted mid-run.
+      #
+      # `.git` is left out: the matrix job checks out the same commit before extracting this over it,
+      # so its own .git is already correct and shipping a second copy to 40 runners buys nothing.
+      # /opt/cucumber-json-formatter is left out too — the matrix job re-downloads it when missing.
+      - name: Pack installed workspace for the test jobs
+        run: |
+          set -euo pipefail
+          tar -I 'zstd -T0 -3' -cf /tmp/e2e-workspace.tar.zst \
+            -C / \
+            --exclude="${GITHUB_WORKSPACE#/}/.git" \
+            "${GITHUB_WORKSPACE#/}" \
+            "${HOME#/}/.cache/Cypress"
+
+      - name: Upload installed workspace for the test jobs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: |
-            /opt/cucumber-json-formatter
-            /home/runner/.cache/Cypress
-            /home/runner/work/Ocelot-Social/Ocelot-Social
-          key: e2e-cypress-${{ hashFiles('yarn.lock', 'backend/yarn.lock', 'packages/branding/package-lock.json') }}-${{ github.sha }}
+          name: e2e-cypress-workspace
+          path: /tmp/e2e-workspace.tar.zst
+          # 7, not 1: "Re-run failed jobs" does NOT re-run the prepare jobs, so the matrix jobs
+          # download an artifact produced by the original run. At one day, any re-run attempted
+          # later fails on a missing artifact — which reads like an infrastructure fault rather
+          # than an expiry. 7 days matches what a cache would have offered.
+          retention-days: 7
+          compression-level: 0
 
   list_features:
     name: List Feature Files
@@ -242,26 +261,22 @@ jobs:
         with:
           node-version-file: 'backend/.nvmrc'
 
-      # Exact key only — see the note in `prepare_cypress`. This step restores over the checkout above,
-      # so anything but this commit's own workspace would mean testing a different revision than the
-      # one the run reports on.
-      - name: Restore cypress cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.0.2
-        with:
-          path: |
-            /opt/cucumber-json-formatter
-            /home/runner/.cache/Cypress
-            /home/runner/work/Ocelot-Social/Ocelot-Social
-          key: e2e-cypress-${{ hashFiles('yarn.lock', 'backend/yarn.lock', 'packages/branding/package-lock.json') }}-${{ github.sha }}
-          fail-on-cache-miss: true
-
-      - name: Download images
+      - name: Download images and installed workspace
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: e2e-*
           merge-multiple: true
           path: /tmp
-          
+
+      # Extracts over the checkout above, exactly as the cache this replaced did — see the note in
+      # `prepare_cypress` for why only this commit's own workspace may ever land here. No guard is
+      # needed for a missing archive: `zstd -dc` on an absent file fails the step, which is the same
+      # loud failure `fail-on-cache-miss: true` used to provide.
+      - name: Unpack installed workspace
+        run: |
+          set -euo pipefail
+          zstd -dc /tmp/e2e-workspace.tar.zst | tar -x -C /
+
       - name: Copy env files
         run: |
           cp webapp/.env.template webapp/.env


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix e2e cache + define if image is cached

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Verbesserungen**
  * Docker-Builds verwenden effizientere, gemeinsam genutzte Caches für schnellere und zuverlässigere Builds.
  * Fehlgeschlagene Cache-Exporte verhindern nicht mehr die erfolgreiche Veröffentlichung von Images.

* **Tests**
  * End-to-End-Testdaten werden als kurzzeitig verfügbare Artefakte übertragen und zwischen Testschritten wiederverwendet.
  * Arbeitsbereiche und Test-Images lassen sich zuverlässiger gemeinsam bereitstellen und wiederherstellen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->