### PR TITLE
fix(workflow): wait for a servable Neo4j, not just an open port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,9 +12,12 @@
 **/storybook-static
 **/playwright-report
 **/test-results
-# `backend/build/` too, and for a sharper reason than size: the `test` target is `COPY backend/ .`,
-# so whether the image contains a build output depended on whether the developer had run
-# `yarn build` — CI never has. A workflow step that reached for ./build/src worked locally and
-# died in CI with MODULE_NOT_FOUND. The production image builds its own from source and never
-# takes one from the context.
+# `backend/build/` too, and for a sharper reason than size: the `test` target — the image every
+# CI step runs in, see docker-compose.test.yml — takes the context as it finds it (`COPY
+# backend/ .`), so whether it contained a build output depended on whether the developer had run
+# `yarn build`. CI never has. A workflow step that reached for ./build/src worked locally and
+# died in CI with MODULE_NOT_FOUND.
+#
+# The `build` target copies the context too, but compiles its own output afterwards and never
+# uses one from the context — so this entry is about `test`, not about it.
 backend/build/

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,9 @@
 **/storybook-static
 **/playwright-report
 **/test-results
+# `backend/build/` too, and for a sharper reason than size: the `test` target is `COPY backend/ .`,
+# so whether the image contains a build output depended on whether the developer had run
+# `yarn build` — CI never has. A workflow step that reached for ./build/src worked locally and
+# died in CI with MODULE_NOT_FOUND. The production image builds its own from source and never
+# takes one from the context.
+backend/build/

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -195,11 +195,72 @@ jobs:
       - name: backend | docker compose
         run: docker compose -f docker-compose.yml -f docker-compose.test.yml up --detach backend
 
+      # `up --detach` returns when the CONTAINER started, not when Neo4j accepts bolt. The
+      # first migrate run then raced it: the CI log showed nine index statements failing with
+      # ECONNREFUSED while the constraints, issued moments later, went through. The indices
+      # were simply missing afterwards — silently, because the previous schema installer
+      # swallowed the error. The schema check is what made it visible.
+      #
+      # The helm chart's wait initContainer (templates/backend/deployment.yaml) uses node for a
+      # port check, because busybox's nc has no portable -z. This one goes further, see below —
+      # a port that listens is not the same as a database that answers.
+      - name: backend | Wait for Neo4j to accept connections
+        run: |
+          # The DRIVER, not a bare TCP connect: Neo4j accepts on 7687 before it will answer a
+          # query, and the step after this one runs migrations. verifyConnectivity() does the
+          # Bolt handshake and `RETURN 1` proves the database itself is servable. Measured: a
+          # net.connect probe reports READY against any listening port, this one does not.
+          #
+          # Built from `neo4j-driver` in node_modules rather than from the app's own
+          # getDriver(): the `test` image is `FROM base` + `COPY backend/`, so it has no
+          # build/ — and the production image has no src/ or tsx. node_modules is the one thing
+          # both carry, and neo4j-driver is a runtime dependency.
+          #
+          # The env fallbacks mirror config/softwareDefaults.ts, so the probe connects exactly
+          # where the migration will. With NEO4J_AUTH=none the credentials are ignored by the
+          # server, which is why no special case is needed for it.
+          #
+          # The 5s guard: the driver would otherwise wait out its own connection timeout, far
+          # past the retry interval.
+          probe='const neo4j = require("neo4j-driver")
+          const done = (code) => process.exit(code)
+          setTimeout(() => done(1), 5000)
+          const driver = neo4j.driver(
+            process.env.NEO4J_URI || "bolt://localhost:7687",
+            neo4j.auth.basic(
+              process.env.NEO4J_USERNAME || "neo4j",
+              process.env.NEO4J_PASSWORD || "neo4j",
+            ),
+          )
+          driver.verifyConnectivity()
+            .then(() => driver.session().run("RETURN 1"))
+            .then(() => done(0))
+            .catch(() => done(1))'
+          # An absolute deadline, not a number of attempts. A failing probe costs up to 5s of
+          # its own guard plus the 5s pause, so "60 attempts" was anywhere between five and ten
+          # minutes of runner time — and this step runs once per job. The wall clock is the
+          # thing worth bounding, and it makes the failure message exact by construction.
+          deadline_seconds=300
+          started=$(date +%s)
+          deadline=$(( started + deadline_seconds ))
+          attempt=0
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            attempt=$(( attempt + 1 ))
+            if docker compose exec -T backend node -e "$probe"; then
+              echo "neo4j is reachable after $attempt attempt(s)"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "neo4j was not ready: $attempt attempts over $(( $(date +%s) - started ))s (deadline ${deadline_seconds}s)"
+          exit 1
+
       - name: backend | Initialize Database
         run: docker compose exec -T backend yarn db:migrate init
 
       - name: backend | Migrate Database Up
         run: docker compose exec -T backend yarn db:migrate up
+
 
       - name: backend | Unit test incl. coverage check
         run: docker compose exec -T backend yarn test

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -244,13 +244,21 @@ jobs:
           started=$(date +%s)
           deadline=$(( started + deadline_seconds ))
           attempt=0
-          while [ "$(date +%s)" -lt "$deadline" ]; do
+          while :; do
+            remaining=$(( deadline - $(date +%s) ))
+            [ "$remaining" -gt 0 ] || break
             attempt=$(( attempt + 1 ))
-            if docker compose exec -T backend node -e "$probe"; then
+            # Both waits are capped by what is left of the deadline. The probe guards itself at 5s,
+            # but that guard runs INSIDE the container while the deadline lives out here — without the
+            # cap a probe starting one second before the deadline still burns its five, and the pause
+            # adds five more. 6s so the normal path is decided by the probe's own guard, not by this.
+            if timeout "$(( remaining < 6 ? remaining : 6 ))" docker compose exec -T backend node -e "$probe"; then
               echo "neo4j is reachable after $attempt attempt(s)"
               exit 0
             fi
-            sleep 5
+            remaining=$(( deadline - $(date +%s) ))
+            [ "$remaining" -gt 0 ] || break
+            sleep "$(( remaining < 5 ? remaining : 5 ))"
           done
           echo "neo4j was not ready: $attempt attempts over $(( $(date +%s) - started ))s (deadline ${deadline_seconds}s)"
           exit 1

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -321,6 +321,57 @@ jobs:
           await backend 120 'curl -sf -X POST -H "Content-Type: application/json" -d "{\"query\":\"{__typename}\"}" http://localhost:4000 > /dev/null 2>&1'
           await webapp 120 'curl -sf http://localhost:3000 > /dev/null 2>&1'
 
+      # Same race as in test-backend.yml: `up --detach` returns before Neo4j accepts bolt.
+      - name: Wait for Neo4j to accept connections
+        run: |
+          # The DRIVER, not a bare TCP connect: Neo4j accepts on 7687 before it will answer a
+          # query, and the steps after this one run migrations. verifyConnectivity() does the
+          # Bolt handshake and `RETURN 1` proves the database itself is servable. Measured: a
+          # net.connect probe reports READY against any listening port, this one does not.
+          #
+          # Built from `neo4j-driver` in node_modules rather than from the app's own
+          # getDriver(): the `test` image is `FROM base` + `COPY backend/`, so it has no
+          # build/ — and the production image has no src/ or tsx. node_modules is the one thing
+          # both carry, and neo4j-driver is a runtime dependency.
+          #
+          # The env fallbacks mirror config/softwareDefaults.ts, so the probe connects exactly
+          # where the migration will. With NEO4J_AUTH=none the credentials are ignored by the
+          # server, which is why no special case is needed for it.
+          #
+          # The 5s guard: the driver would otherwise wait out its own connection timeout, far
+          # past the retry interval.
+          probe='const neo4j = require("neo4j-driver")
+          const done = (code) => process.exit(code)
+          setTimeout(() => done(1), 5000)
+          const driver = neo4j.driver(
+            process.env.NEO4J_URI || "bolt://localhost:7687",
+            neo4j.auth.basic(
+              process.env.NEO4J_USERNAME || "neo4j",
+              process.env.NEO4J_PASSWORD || "neo4j",
+            ),
+          )
+          driver.verifyConnectivity()
+            .then(() => driver.session().run("RETURN 1"))
+            .then(() => done(0))
+            .catch(() => done(1))'
+          # An absolute deadline, not a number of attempts. A failing probe costs up to 5s of
+          # its own guard plus the 5s pause, so "60 attempts" was anywhere between five and ten
+          # minutes of runner time — times every job in this matrix. The wall clock is the thing
+          # worth bounding, and it makes the failure message exact by construction.
+          deadline_seconds=300
+          started=$(date +%s)
+          deadline=$(( started + deadline_seconds ))
+          attempt=0
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            attempt=$(( attempt + 1 ))
+            if docker compose -f docker-compose.yml -f docker-compose.test.yml exec -T backend node -e "$probe"; then
+              echo "neo4j is reachable after $attempt attempt(s)"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "neo4j was not ready: $attempt attempts over $(( $(date +%s) - started ))s (deadline ${deadline_seconds}s)"; exit 1
+
       - name: Initialize database
         run: docker compose -f docker-compose.yml -f docker-compose.test.yml exec -T backend yarn db:migrate init
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -362,13 +362,21 @@ jobs:
           started=$(date +%s)
           deadline=$(( started + deadline_seconds ))
           attempt=0
-          while [ "$(date +%s)" -lt "$deadline" ]; do
+          while :; do
+            remaining=$(( deadline - $(date +%s) ))
+            [ "$remaining" -gt 0 ] || break
             attempt=$(( attempt + 1 ))
-            if docker compose -f docker-compose.yml -f docker-compose.test.yml exec -T backend node -e "$probe"; then
+            # Both waits are capped by what is left of the deadline. The probe guards itself at 5s,
+            # but that guard runs INSIDE the container while the deadline lives out here — without the
+            # cap a probe starting one second before the deadline still burns its five, and the pause
+            # adds five more. 6s so the normal path is decided by the probe's own guard, not by this.
+            if timeout "$(( remaining < 6 ? remaining : 6 ))" docker compose -f docker-compose.yml -f docker-compose.test.yml exec -T backend node -e "$probe"; then
               echo "neo4j is reachable after $attempt attempt(s)"
               exit 0
             fi
-            sleep 5
+            remaining=$(( deadline - $(date +%s) ))
+            [ "$remaining" -gt 0 ] || break
+            sleep "$(( remaining < 5 ? remaining : 5 ))"
           done
           echo "neo4j was not ready: $attempt attempts over $(( $(date +%s) - started ))s (deadline ${deadline_seconds}s)"; exit 1
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

`up --detach` returns when the container started, not when Neo4j answers queries. The migrate step that follows raced it: index statements failed with ECONNREFUSED while constraints issued moments later went through.

The probe now uses the driver — verifyConnectivity() for the Bolt handshake and `RETURN 1` for the database itself. Measured: a net.connect probe reports READY against any listening port, this one does not. It is built from neo4j-driver in node_modules, the one thing both the test and the production image carry.

The retry loop runs against an absolute deadline instead of a fixed attempt count, and the failure message reports the elapsed time rather than a wall-clock claim that was only ever the best case.

`backend/build/` is excluded from the docker build context: whether the test image contained a build output depended on whether the developer had run `yarn build`, and a workflow step that reached for ./build/src worked locally and died in CI.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Verbesserungen**
  * Docker-Builds schließen lokale Backend-Builddateien aus und bleiben dadurch schlanker.
  * Backend- und End-to-End-Tests prüfen vor der Datenbankinitialisierung zuverlässig die Erreichbarkeit der Datenbank.
  * Bei verzögerter Datenbankverfügbarkeit wird automatisch bis zu fünf Minuten gewartet; bei anhaltenden Problemen wird der Testlauf verständlich abgebrochen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->