### PR TITLE
fix(e2e): fix flaky e2e tests (toast)

### DIFF
--- a/cypress/support/step_definitions/admin/NetworkPolicy/I_reset_all_policies_to_default.js
+++ b/cypress/support/step_definitions/admin/NetworkPolicy/I_reset_all_policies_to_default.js
@@ -1,7 +1,8 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
-import 'cypress-network-idle'
 
+// No network wait — same reasoning as "I save the policy form": cy.waitForNetworkIdle()
+// watches GET only and never saw the resetPolicies POST, it just ate into the lifetime of
+// the toast the next step asserts on.
 defineStep('I reset all policies to default', () => {
   cy.get('[data-test="policy-reset"]').click()
-  cy.waitForNetworkIdle(2000)
 })

--- a/cypress/support/step_definitions/admin/NetworkPolicy/I_save_the_policy_form.js
+++ b/cypress/support/step_definitions/admin/NetworkPolicy/I_save_the_policy_form.js
@@ -1,7 +1,13 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
-import 'cypress-network-idle'
 
+// No network wait here on purpose. cy.waitForNetworkIdle() defaults to watching GET requests
+// only, while every GraphQL call the webapp makes is a POST to /api — so it never observed
+// this save at all (measured: zero matching requests, a flat ~2 s). All it did was push the
+// following toast assertion that much further into the toast's lifetime, with a ceiling of
+// responseTimeout (30 s) against a toast that lives 15 s.
+//
+// The toast assertion is the barrier instead: the toast is raised only after the setPolicy
+// mutation resolves, and the assertion retries on its own.
 defineStep('I save the policy form', () => {
   cy.get('[data-test="policy-save"]').click()
-  cy.waitForNetworkIdle(2000)
 })

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
@@ -1,18 +1,64 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 
+const TOAST_CLASS = {
+  success: 'iziToast-color-green',
+  error: 'iziToast-color-red',
+}
+
+// A toast auto-dismisses after TOAST_TIMEOUT (5 s by default, 15 s in the e2e stack), so
+// asserting on the live DOM cannot tell "no toast was ever raised" from "the toast came and
+// went while an earlier step was still waiting" — both surface as "never found it". That
+// ambiguity is what made the policy steps flaky, and it is why the e2e stack had to raise
+// TOAST_TIMEOUT in the first place (see docker-compose.test.yml).
+//
+// So record every toast the moment it enters the document and assert against the record: the
+// assertion no longer races the dismissal, and a failure can name the toasts that DID appear
+// instead of just reporting an absent element.
+const toastLog = []
+
+const capture = (element) => {
+  if (!toastLog.includes(element)) toastLog.push(element)
+}
+
+// iziToast completes the class list right after inserting the element, so the log keeps
+// element references and the colour is read at assertion time rather than at capture time.
+const observeToasts = (win) => {
+  toastLog.length = 0
+  const observer = new win.MutationObserver((records) => {
+    records.forEach((record) => {
+      record.addedNodes.forEach((node) => {
+        if (node.nodeType !== win.Node.ELEMENT_NODE) return
+        if (node.classList.contains('iziToast')) capture(node)
+        node.querySelectorAll('.iziToast').forEach(capture)
+      })
+    })
+  })
+  observer.observe(win.document, { childList: true, subtree: true })
+}
+
+Cypress.on('window:before:load', observeToasts)
+
+// A page load resets the log via the hook above, which covers every scenario that visits a
+// page. This is the belt to that suspenders: without it, a scenario asserting a toast before
+// its first visit could be satisfied by the previous scenario's toast.
+beforeEach(() => {
+  toastLog.length = 0
+})
+
 defineStep('I see a toaster with status {string}', (status) => {
-  switch (status) {
-    case 'success':
-      cy.get('.iziToast.iziToast-color-green').should('be.visible')
-      break
-    case 'error':
-      cy.get('.iziToast.iziToast-color-red').should('be.visible')
-      break
-    default:
-      // The step *is* the assertion: an unknown status (typo in the feature file or an
-      // unsupported value) must fail loudly instead of passing with no check at all.
-      throw new Error(
-        `Unknown toaster status "${status}"; expected "success" or "error".`,
-      )
+  const className = TOAST_CLASS[status]
+  if (!className) {
+    // The step *is* the assertion: an unknown status (typo in the feature file or an
+    // unsupported value) must fail loudly instead of passing with no check at all.
+    throw new Error(`Unknown toaster status "${status}"; expected "success" or "error".`)
   }
+  cy.wrap(null, { log: false }).should(() => {
+    const seen = toastLog.map((element) => element.className)
+    expect(
+      seen.some((classNames) => classNames.includes(className)),
+      `a "${status}" toaster (.${className}) was raised; toasters seen: ${
+        seen.join(' | ') || '(none)'
+      }`,
+    ).to.equal(true)
+  })
 })

--- a/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
+++ b/cypress/support/step_definitions/common/I_see_a_toaster_with_status_{string}.js
@@ -1,4 +1,6 @@
-import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
+import { BeforeStep, defineStep } from '@badeball/cypress-cucumber-preprocessor'
+
+const TOAST_STEP_PREFIX = 'I see a toaster with status'
 
 const TOAST_CLASS = {
   success: 'iziToast-color-green',
@@ -38,11 +40,18 @@ const observeToasts = (win) => {
 
 Cypress.on('window:before:load', observeToasts)
 
-// A page load resets the log via the hook above, which covers every scenario that visits a
-// page. This is the belt to that suspenders: without it, a scenario asserting a toast before
-// its first visit could be satisfied by the previous scenario's toast.
-beforeEach(() => {
-  toastLog.length = 0
+// Scope the log to the action under test. Every toast assertion in the suite sits directly
+// behind the step that raises the toast, so clearing at the start of every OTHER step leaves
+// the assertion looking at exactly that one action.
+//
+// Without this scoping an earlier toast of the same colour satisfies the assertion, and the
+// step silently stops testing anything: in admin/RolesPermissions.feature:78 the toast that
+// "I confirm creating the role" raises is green and carries the same message key
+// (admin.roles.saveSuccess) as the save under test, and it is still alive when the assertion
+// runs — so a save that quietly persisted nothing passed here and only surfaced two steps
+// later, at the reload check.
+BeforeStep(({ pickleStep }) => {
+  if (!pickleStep.text.startsWith(TOAST_STEP_PREFIX)) toastLog.length = 0
 })
 
 defineStep('I see a toaster with status {string}', (status) => {

--- a/cypress/support/step_definitions/common/somebody_reported_the_following_posts.js
+++ b/cypress/support/step_definitions/common/somebody_reported_the_following_posts.js
@@ -1,7 +1,6 @@
 import { defineStep } from '@badeball/cypress-cucumber-preprocessor'
 import './../../commands'
 import './../../factories'
-import 'cypress-network-idle'
 
 defineStep('somebody reported the following posts:', table => {
   const reportIdRegex = /^[0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12}$/
@@ -37,6 +36,8 @@ defineStep('somebody reported the following posts:', table => {
           .should('have.nested.property', 'data.fileReport.reportId')
           .and('match', reportIdRegex)
       })
-      cy.waitForNetworkIdle(2000)
+      // No cy.waitForNetworkIdle() here: the two cy.wait('@postToLocalhost') above already
+      // synchronise on this row's mutation and assert its response, and the idle wait watched
+      // GET only — so it added a flat 2 s per table row and observed nothing.
   })
 })


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix flaky e2e tests (toast)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cypress-Tests warten nun gezielter auf abgeschlossene Aktionen statt auf allgemeine Netzwerkruhe.
  * Toast-Benachrichtigungen werden auch nach dem automatischen Ausblenden zuverlässig erkannt.
  * Tests zur Richtlinienverwaltung und Beitragsmeldung laufen dadurch stabiler und ohne unnötige Verzögerungen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->