### PR TITLE
test(backend): migrate to Vitest — middleware, db/role/policy, remain…

### DIFF
--- a/backend/src/branding/bootstrap.spec.ts
+++ b/backend/src/branding/bootstrap.spec.ts
@@ -5,61 +5,71 @@
 
 import { resolve } from 'node:path'
 
-import { jest } from '@jest/globals'
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
+
+import type { Mock, MockInstance } from 'vitest'
+
+// vitest has no `isolateModulesAsync`: resetting the registry before the dynamic import does the
+// same job, since a module graph is only shared within a file. Wrapped so the call sites keep
+// reading as "load this in isolation".
+const isolateModules = async (run: () => Promise<void>): Promise<void> => {
+  vi.resetModules()
+  await run()
+}
 
 const BRANDING = '@ocelot-social/branding'
 const DISCOVER = '@ocelot-social/branding/dist/discover.js'
-// `jest.requireActual` is synchronous and has no ESM counterpart; the real module is
+// The mock factory cannot await, so `vi.importActual` is no use inside it; the real module is
 // pulled in once here and the factory below reaches into it.
 const actualDiscover = await import('@ocelot-social/branding/dist/discover.js')
 
 interface LoadMocks {
-  discoverArchives?: jest.Mock
-  readArchiveConfig?: jest.Mock
-  readArchive?: jest.Mock
-  readDefaultMarker?: jest.Mock
-  setBranding?: jest.Mock
-  checkSchemaCompat?: jest.Mock
+  discoverArchives?: Mock
+  readArchiveConfig?: Mock
+  readArchive?: Mock
+  readDefaultMarker?: Mock
+  setBranding?: Mock
+  checkSchemaCompat?: Mock
 }
 
 const ORIGINAL_ENV = process.env
 
 async function loadBootstrap(mocks: LoadMocks) {
-  const setBranding = mocks.setBranding ?? jest.fn()
-  const overlayBrandRuntimeFiles = jest.fn()
-  jest.unstable_mockModule(BRANDING, () => ({
+  const setBranding = mocks.setBranding ?? vi.fn()
+  const overlayBrandRuntimeFiles = vi.fn()
+  vi.doMock(BRANDING, () => ({
     setBranding,
-    checkSchemaCompat: mocks.checkSchemaCompat ?? jest.fn(() => 'ok'),
-    describeSchemaCompat: jest.fn(() => 'schema mismatch'),
+    checkSchemaCompat: mocks.checkSchemaCompat ?? vi.fn(() => 'ok'),
+    describeSchemaCompat: vi.fn(() => 'schema mismatch'),
   }))
-  jest.unstable_mockModule(DISCOVER, () => ({
-    discoverArchives: mocks.discoverArchives ?? jest.fn(() => new Map()),
-    readArchiveConfig: mocks.readArchiveConfig ?? jest.fn(() => null),
-    readArchive: mocks.readArchive ?? jest.fn(() => null),
-    readDefaultMarker: mocks.readDefaultMarker ?? jest.fn(() => ''),
+  vi.doMock(DISCOVER, () => ({
+    discoverArchives: mocks.discoverArchives ?? vi.fn(() => new Map()),
+    readArchiveConfig: mocks.readArchiveConfig ?? vi.fn(() => null),
+    readArchive: mocks.readArchive ?? vi.fn(() => null),
+    readDefaultMarker: mocks.readDefaultMarker ?? vi.fn(() => ''),
     // Real: it turns an unset $OCELOT_BRANDING_ASSETS_DIR into the conventional archive locations, so
     // a stub would hide whether bootstrap still resolves a brand without configuration. Pure (paths).
     searchPath: actualDiscover.searchPath,
   }))
   // Mock the on-disk overlay so bootstrap doesn't write brand files into the test's real dirs.
-  jest.unstable_mockModule('./overlayRuntimeFiles', () => ({ overlayBrandRuntimeFiles }))
-  await jest.isolateModulesAsync(async () => {
+  vi.doMock('./overlayRuntimeFiles', () => ({ overlayBrandRuntimeFiles }))
+  await isolateModules(async () => {
     await import('./bootstrap')
   })
   return { setBranding, overlayBrandRuntimeFiles }
 }
 
 describe('branding bootstrap', () => {
-  let warnSpy: jest.Spied<typeof console.warn>
-  let errorSpy: jest.Spied<typeof console.error>
+  let warnSpy: MockInstance<typeof console.warn>
+  let errorSpy: MockInstance<typeof console.error>
 
   beforeEach(() => {
-    jest.resetModules()
+    vi.resetModules()
     process.env = { ...ORIGINAL_ENV }
     delete process.env.OCELOT_BRANDING_ASSETS_DIR
     delete process.env.OCELOT_ACTIVE_BRANDING
-    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
-    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
   })
 
   afterEach(() => {
@@ -71,8 +81,9 @@ describe('branding bootstrap', () => {
   // No env needed to find archives (the search path defaults), but a brand still has to be ACTIVE —
   // pinned by $OCELOT_ACTIVE_BRANDING or named by a DEFAULT marker. Neither → vanilla, silently.
   it('does nothing when no brand is active', async () => {
-    const discoverArchives = jest.fn()
+    const discoverArchives = vi.fn()
     const { setBranding } = await loadBootstrap({ discoverArchives })
+
     expect(discoverArchives).not.toHaveBeenCalled()
     expect(setBranding).not.toHaveBeenCalled()
     expect(warnSpy).not.toHaveBeenCalled()
@@ -89,13 +100,14 @@ describe('branding bootstrap', () => {
     ]
     const archive = { file: 'acme.tar.gz', schemaVersion: '0.0.1' }
     const config = { metadata: { applicationName: 'Acme' } }
-    const readDefaultMarker = jest.fn(() => 'acme')
-    const discoverArchives = jest.fn(() => new Map([['acme', archive]]))
+    const readDefaultMarker = vi.fn(() => 'acme')
+    const discoverArchives = vi.fn(() => new Map([['acme', archive]]))
     const { setBranding } = await loadBootstrap({
       readDefaultMarker,
       discoverArchives,
-      readArchiveConfig: jest.fn(() => config),
+      readArchiveConfig: vi.fn(() => config),
     })
+
     expect(readDefaultMarker).toHaveBeenCalledWith(CONVENTIONAL)
     expect(discoverArchives).toHaveBeenCalledWith(CONVENTIONAL)
     expect(setBranding).toHaveBeenCalledWith(config)
@@ -107,9 +119,10 @@ describe('branding bootstrap', () => {
     const archive = { file: '/assets/acme.tar.gz', schemaVersion: '0.0.1' }
     const config = { metadata: { applicationName: 'Acme' } }
     const { setBranding } = await loadBootstrap({
-      discoverArchives: jest.fn(() => new Map([['acme', archive]])),
-      readArchiveConfig: jest.fn(() => config),
+      discoverArchives: vi.fn(() => new Map([['acme', archive]])),
+      readArchiveConfig: vi.fn(() => config),
     })
+
     expect(setBranding).toHaveBeenCalledWith(config)
     expect(warnSpy).not.toHaveBeenCalled()
     expect(errorSpy).not.toHaveBeenCalled()
@@ -121,13 +134,14 @@ describe('branding bootstrap', () => {
     const archive = { file: '/assets/acme.tar.gz', schemaVersion: '0.0.1' }
     const files = new Map([['emails/templates/registration/html.pug', Buffer.from('p brand')]])
     const { overlayBrandRuntimeFiles } = await loadBootstrap({
-      discoverArchives: jest.fn(() => new Map([['acme', archive]])),
-      readArchiveConfig: jest.fn(() => ({ metadata: {} })),
-      readArchive: jest.fn(() => files),
+      discoverArchives: vi.fn(() => new Map([['acme', archive]])),
+      readArchiveConfig: vi.fn(() => ({ metadata: {} })),
+      readArchive: vi.fn(() => files),
     })
     const calls = overlayBrandRuntimeFiles.mock.calls as Array<
       [Map<string, Buffer>, { emailsDir: string }]
     >
+
     expect(calls).toHaveLength(1)
     expect(calls[0][0]).toBe(files)
     // The RESOLVED path, not a substring: bootstrap derives it from its own location, and this spec
@@ -141,8 +155,9 @@ describe('branding bootstrap', () => {
     process.env.OCELOT_BRANDING_ASSETS_DIR = '/assets'
     process.env.OCELOT_ACTIVE_BRANDING = 'missing'
     const { setBranding } = await loadBootstrap({
-      discoverArchives: jest.fn(() => new Map()), // does not contain 'missing'
+      discoverArchives: vi.fn(() => new Map()), // does not contain 'missing'
     })
+
     expect(setBranding).not.toHaveBeenCalled()
     expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/not found/))
   })
@@ -152,9 +167,10 @@ describe('branding bootstrap', () => {
     process.env.OCELOT_ACTIVE_BRANDING = 'acme'
     const archive = { file: '/assets/acme.tar.gz', schemaVersion: '0.0.1' }
     const { setBranding } = await loadBootstrap({
-      discoverArchives: jest.fn(() => new Map([['acme', archive]])),
-      readArchiveConfig: jest.fn(() => null),
+      discoverArchives: vi.fn(() => new Map([['acme', archive]])),
+      readArchiveConfig: vi.fn(() => null),
     })
+
     expect(setBranding).not.toHaveBeenCalled()
     expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/no readable config/))
   })
@@ -165,10 +181,11 @@ describe('branding bootstrap', () => {
     const archive = { file: '/assets/acme.tar.gz', schemaVersion: '9.9.9' }
     const config = { metadata: { applicationName: 'Acme' } }
     const { setBranding } = await loadBootstrap({
-      discoverArchives: jest.fn(() => new Map([['acme', archive]])),
-      readArchiveConfig: jest.fn(() => config),
-      checkSchemaCompat: jest.fn(() => 'archive-newer'),
+      discoverArchives: vi.fn(() => new Map([['acme', archive]])),
+      readArchiveConfig: vi.fn(() => config),
+      checkSchemaCompat: vi.fn(() => 'archive-newer'),
     })
+
     expect(setBranding).toHaveBeenCalledWith(config)
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('schema mismatch'))
   })
@@ -177,10 +194,11 @@ describe('branding bootstrap', () => {
     process.env.OCELOT_BRANDING_ASSETS_DIR = '/assets'
     process.env.OCELOT_ACTIVE_BRANDING = 'acme'
     const { setBranding } = await loadBootstrap({
-      discoverArchives: jest.fn(() => {
+      discoverArchives: vi.fn(() => {
         throw new Error('boom')
       }),
     })
+
     expect(setBranding).not.toHaveBeenCalled()
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringMatching(/failed to load active brand/),

--- a/backend/src/branding/index.spec.ts
+++ b/backend/src/branding/index.spec.ts
@@ -1,3 +1,5 @@
+import { describe, afterEach, it, expect } from 'vitest'
+
 import { branding, brandingDefaults, setBranding, getBranding } from '@src/branding'
 
 // Integration check that the backend resolves the shared @ocelot-social/branding package
@@ -29,11 +31,13 @@ describe('branding (shared package)', () => {
       metadata: { ...brandingDefaults.metadata, applicationName: 'MyNet' },
     }
     setBranding(brand)
+
     expect(branding.group.nameLengthMax).toBe(99)
     expect(branding.metadata.applicationName).toBe('MyNet')
     expect(getBranding().group.nameLengthMax).toBe(99)
 
     setBranding(undefined)
+
     expect(branding.group.nameLengthMax).toBe(brandingDefaults.group.nameLengthMax)
     expect(branding.metadata.applicationName).toBe('ocelot.social')
   })

--- a/backend/src/branding/overlayRuntimeFiles.spec.ts
+++ b/backend/src/branding/overlayRuntimeFiles.spec.ts
@@ -12,9 +12,11 @@ import {
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
+
 import { overlayBrandRuntimeFiles } from './overlayRuntimeFiles'
 
-describe('overlayBrandRuntimeFiles', () => {
+describe(overlayBrandRuntimeFiles, () => {
   let root: string
   let emailsDir: string
 
@@ -35,6 +37,7 @@ describe('overlayBrandRuntimeFiles', () => {
 
   it('overlays e-mail templates (replacing the default)', () => {
     run([['emails/templates/registration/html.pug', 'p brand registration']])
+
     expect(readFileSync(path.join(emailsDir, 'templates/registration/html.pug'), 'utf8')).toBe(
       'p brand registration',
     )
@@ -51,6 +54,7 @@ describe('overlayBrandRuntimeFiles', () => {
     const merged = JSON.parse(
       readFileSync(path.join(emailsDir, 'locales/en.json'), 'utf8'),
     ) as unknown
+
     expect(merged).toEqual({ greeting: { hello: 'Welcome', bye: 'Bye' }, keep: 'z', extra: 'x' })
   })
 
@@ -59,6 +63,7 @@ describe('overlayBrandRuntimeFiles', () => {
       ['emails/templates/../../evil.pug', 'x'],
       ['emails/locales/../../evil.json', '{}'],
     ])
+
     expect(existsSync(path.join(root, 'evil.pug'))).toBe(false)
     expect(existsSync(path.join(root, 'evil.json'))).toBe(false)
     expect(existsSync(path.join(root, 'emails/evil.pug'))).toBe(false)
@@ -69,6 +74,7 @@ describe('overlayBrandRuntimeFiles', () => {
     const written = JSON.parse(
       readFileSync(path.join(emailsDir, 'locales/eo.json'), 'utf8'),
     ) as unknown
+
     expect(written).toEqual({ greeting: 'Saluton' })
   })
 
@@ -76,6 +82,7 @@ describe('overlayBrandRuntimeFiles', () => {
     const target = path.join(emailsDir, 'locales/en.json')
     writeFileSync(target, JSON.stringify({ greeting: 'Hi' }))
     run([['emails/locales/en.json', '{ not json']])
+
     // Clobbering the default with a broken file would take every e-mail down; skipping keeps the
     // instance sending in its own language, just without the brand's overrides.
     expect(JSON.parse(readFileSync(target, 'utf8')) as unknown).toEqual({ greeting: 'Hi' })
@@ -92,6 +99,7 @@ describe('overlayBrandRuntimeFiles', () => {
       ['public/img/badges/legacy.svg', 'x'],
       ['manifest.json', '{}'],
     ])
+
     expect(readdirSync(root)).toEqual(['emails'])
     expect(readdirSync(emailsDir).sort()).toEqual(['locales', 'templates'])
     expect(readdirSync(path.join(emailsDir, 'templates'))).toEqual([])

--- a/backend/src/branding/routes.spec.ts
+++ b/backend/src/branding/routes.spec.ts
@@ -5,42 +5,42 @@ import { PassThrough, Readable } from 'node:stream'
 import { finished } from 'node:stream/promises'
 import { setImmediate as tick } from 'node:timers/promises'
 
-/* eslint-disable n/prefer-process-get-builtin-module -- these two must go through Jest's module
+/* eslint-disable n/prefer-process-get-builtin-module -- these two must go through the runner's module
    registry to pick up the fs mocks below; process.getBuiltinModule() bypasses it and returns the
    real module. */
-import { jest } from '@jest/globals'
+
+import { describe, beforeEach, it, expect } from 'vitest'
 
 import type { BrandingRouterDeps } from './routes'
 import type { Request, Response } from 'express'
+import type { Mock } from 'vitest'
 
-jest.unstable_mockModule('node:fs', () => ({ createReadStream: jest.fn() }))
-jest.unstable_mockModule('node:fs/promises', () => ({ stat: jest.fn() }))
+vi.mock('node:fs', () => ({ createReadStream: vi.fn() }))
+vi.mock('node:fs/promises', () => ({ stat: vi.fn() }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { createReadStream } = await import('node:fs')
 const { stat } = await import('node:fs/promises')
 /* eslint-enable n/prefer-process-get-builtin-module */
 const { brandingRouter } = await import('./routes')
 
 // The two disk readers are INJECTED, not module-mocked. `@ocelot-social/branding/dist/discover.js` is
-// a subpath of a `file:` dependency, and whether jest bound a mock of it to routes.ts depended on the
+// a subpath of a `file:` dependency, and whether the runner bound a mock of it to routes.ts depended on the
 // environment: green here, silently ignored in the CI container, where the router then read the real
 // filesystem and every fixture-based expectation failed. Passing the fakes in removes the question.
 // The id guard is NOT faked — routes.ts keeps importing the real one, so a tightening of
 // BRAND_ID_PATTERN is exercised here instead of being shadowed by a stub.
-const mockDiscover = jest.fn<(...args: unknown[]) => unknown>() as jest.MockedFunction<
-  BrandingRouterDeps['discoverArchives']
->
-const mockDefaultMarker = jest.fn<(...args: unknown[]) => unknown>() as jest.MockedFunction<
-  BrandingRouterDeps['readDefaultMarker']
->
+const mockDiscover = vi.fn<BrandingRouterDeps['discoverArchives']>()
+const mockDefaultMarker = vi.fn<BrandingRouterDeps['readDefaultMarker']>()
 const deps: BrandingRouterDeps = {
   discoverArchives: mockDiscover,
   readDefaultMarker: mockDefaultMarker,
 }
-const mockStat = stat as jest.Mock<(...args: unknown[]) => Promise<unknown>>
-const mockCreateReadStream = createReadStream as jest.Mock<(...args: unknown[]) => unknown>
+// Cast, not vi.mocked(stat): the real signature is overloaded (Stats vs BigIntStats) and the
+// fixture only needs the two fields the route reads.
+const mockStat = stat as unknown as Mock<(...args: unknown[]) => Promise<unknown>>
+const mockCreateReadStream = createReadStream as unknown as Mock<(...args: unknown[]) => unknown>
 
 const ARCHIVE = {
   id: 'stage',
@@ -61,12 +61,12 @@ interface MockRes extends PassThrough {
   statusCode?: number
   headers: Record<string, string>
   body?: string
-  status: jest.Mock<(this: MockRes, code: number) => MockRes>
-  setHeader: jest.Mock<(this: MockRes, k: string, v: string) => void>
-  json: jest.Mock<(this: MockRes, value: unknown) => MockRes>
+  status: Mock<(this: MockRes, code: number) => MockRes>
+  setHeader: Mock<(this: MockRes, k: string, v: string) => void>
+  json: Mock<(this: MockRes, value: unknown) => MockRes>
 }
 
-// A REAL Writable, not a bag of jest.fn()s: the archive route hands the response to
+// A REAL Writable, not a bag of vi.fn()s: the archive route hands the response to
 // stream.pipeline(), which only accepts an actual stream and whose whole point (tearing the file
 // stream down when the response dies) is unobservable against a fake. Everything a stream does not
 // provide — status/setHeader/json — is bolted on the way express does.
@@ -83,19 +83,21 @@ function makeRes(): MockRes {
     },
     configurable: true,
   })
-  res.status = jest.fn(function status(this: MockRes, code: number) {
+  // Direct assignment, not vi.spyOn: PassThrough has no status/setHeader/json to spy ON — these
+  // are the express additions the fake is missing, so they have to be created, not intercepted.
+  res.status = vi.fn(function status(this: MockRes, code: number) {
     this.statusCode = code
     return this
   })
-  res.setHeader = jest.fn(function setHeader(this: MockRes, k: string, v: string) {
+  res.setHeader = vi.fn(function setHeader(this: MockRes, k: string, v: string) {
     this.headers[k.toLowerCase()] = v
   })
-  res.json = jest.fn(function json(this: MockRes, value: unknown) {
+  res.json = vi.fn(function json(this: MockRes, value: unknown) {
     this.body = JSON.stringify(value)
     return this
   })
-  jest.spyOn(res, 'end')
-  jest.spyOn(res, 'destroy')
+  vi.spyOn(res, 'end')
+  vi.spyOn(res, 'destroy')
   // pipeline propagates a source failure by destroying the response WITH that error; an unhandled
   // 'error' on a stream would take the process down instead of failing the test.
   res.on('error', () => {})
@@ -116,9 +118,9 @@ async function call(
   url: string,
   headers: Record<string, string> = {},
   method = 'GET',
-): Promise<{ res: MockRes; next: jest.Mock }> {
+): Promise<{ res: MockRes; next: Mock }> {
   const res = makeRes()
-  const next = jest.fn()
+  const next = vi.fn()
   router({ method, url, headers } as unknown as Request, res as unknown as Response, next)
   await tick()
   return { res, next }
@@ -126,7 +128,7 @@ async function call(
 
 describe('branding/routes', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    vi.clearAllMocks()
     mockDiscover.mockReturnValue(new Map([[ARCHIVE.id, ARCHIVE]]))
     mockStat.mockResolvedValue({ size: 4096, mtimeMs: 1_700_000_000_123 })
     mockDefaultMarker.mockReturnValue('stage')
@@ -144,6 +146,7 @@ describe('branding/routes', () => {
 
       expect(parseManifest(res.body)).toEqual({ default: '', brands: [] })
       expect(mockDiscover).not.toHaveBeenCalled()
+
       // eslint-disable-next-line n/no-process-env -- see above
       delete process.env.OCELOT_BRANDING_ASSETS_DIR
     })
@@ -179,7 +182,7 @@ describe('branding/routes', () => {
 
   // A broken assets dir must degrade to "unknown brand", never to a 500.
   it('answers 404 when discovery throws while resolving an archive', async () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockDiscover.mockImplementation(() => {
       throw new Error('EACCES')
     })
@@ -191,6 +194,7 @@ describe('branding/routes', () => {
       expect.stringContaining('cannot read /brands'),
       expect.anything(),
     )
+
     warn.mockRestore()
   })
 
@@ -256,12 +260,13 @@ describe('branding/routes', () => {
       mockDiscover.mockImplementation(() => {
         throw new Error('EACCES')
       })
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
       const { res } = await call(brandingRouter('/brands', deps), '/manifest.json')
 
       expect(res.statusCode).toBe(503)
       expect(parseManifest(res.body)).toEqual({ default: '', brands: [] })
+
       warn.mockRestore()
     })
   })

--- a/backend/src/branding/routes.ts
+++ b/backend/src/branding/routes.ts
@@ -32,7 +32,7 @@ import type { Request, Response } from 'express'
 /**
  * The two disk readers this router is built on. Injectable so a test can hand in fakes DIRECTLY
  * instead of mocking the package subpath: `@ocelot-social/branding/dist/discover.js` is a subpath of a
- * `file:` dependency, and whether jest binds a mock of it to this module turned out to depend on the
+ * `file:` dependency, and whether the runner binds a mock of it to this module turned out to depend on the
  * environment — green locally, silently ignored in the CI container, where the router then read the
  * real filesystem and every fixture-based assertion failed. Production passes nothing and keeps the
  * real readers.

--- a/backend/src/config/categories.spec.ts
+++ b/backend/src/config/categories.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { ENV_CATEGORIES, categoryRank } from './categories'
 
 describe('ENV_CATEGORIES', () => {
@@ -11,11 +13,12 @@ describe('ENV_CATEGORIES', () => {
     const featureOrder = ENV_CATEGORIES.filter((category) =>
       ['registration', 'features', 'layout', 'video'].includes(category),
     )
+
     expect(featureOrder).toEqual(['registration', 'features', 'layout', 'video'])
   })
 })
 
-describe('categoryRank', () => {
+describe(categoryRank, () => {
   it('is the category index in the global display order', () => {
     expect(categoryRank('server')).toBe(0)
     expect(categoryRank(ENV_CATEGORIES[ENV_CATEGORIES.length - 1])).toBe(ENV_CATEGORIES.length - 1)

--- a/backend/src/config/envRegistry.spec.ts
+++ b/backend/src/config/envRegistry.spec.ts
@@ -10,6 +10,8 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { describe, it, expect } from 'vitest'
+
 import { ENV_REGISTRY, ENV_SPEC_BY_NAME } from './envRegistry'
 
 // Env vars config/index.ts reads that are intentionally NOT admin config rows (derived or
@@ -37,12 +39,15 @@ const configEnvReads = (): Set<string> => {
 describe('envRegistry ↔ config/index.ts env vars', () => {
   it('declares every env var the runtime config reads', () => {
     const reads = configEnvReads()
+
     // Sanity: the extraction found the reads at all (guards against a refactor that moves
     // env access behind a helper and silently empties this check).
     expect(reads.size).toBeGreaterThan(20)
+
     const missing = [...reads].filter(
       (name) => !(name in ENV_SPEC_BY_NAME) && !NON_REGISTRY_ENV_READS.has(name),
     )
+
     expect(missing).toEqual([])
   })
 
@@ -51,6 +56,7 @@ describe('envRegistry ↔ config/index.ts env vars', () => {
     const unread = ENV_REGISTRY.map((spec) => spec.name).filter(
       (name) => !reads.has(name) && !REGISTRY_ONLY_VARS.has(name),
     )
+
     expect(unread).toEqual([])
   })
 })

--- a/backend/src/config/jwtExpires.spec.ts
+++ b/backend/src/config/jwtExpires.spec.ts
@@ -3,6 +3,7 @@
    analysis and misses these), so `import { verify }` type-checks and then throws at load.
    Reaching through the default import is the only form that works at runtime. */
 import jwt from 'jsonwebtoken'
+import { describe, expect, it } from 'vitest'
 
 import { isValidJwtExpires, resolveJwtExpires } from './jwtExpires'
 import { SOFTWARE_DEFAULTS } from './softwareDefaults'
@@ -22,7 +23,7 @@ const lifetimeOf = (expires: JwtExpires): number => {
   return (payload?.exp ?? 0) - (payload?.iat ?? 0)
 }
 
-describe('isValidJwtExpires', () => {
+describe(isValidJwtExpires, () => {
   it.each(['2y', '10 hours', '1.5h', '30m', '600s', '86400000'])(
     'accepts the ms timespan %s',
     (value) => {
@@ -61,7 +62,7 @@ describe('isValidJwtExpires', () => {
   })
 })
 
-describe('resolveJwtExpires', () => {
+describe(resolveJwtExpires, () => {
   it('keeps a parseable lifetime', () => {
     expect(resolveJwtExpires('10 hours', FALLBACK)).toBe('10 hours')
   })
@@ -95,6 +96,7 @@ describe('the resolved value against jsonwebtoken itself', () => {
         algorithm: 'HS256',
         expiresIn: resolveJwtExpires(value, FALLBACK),
       })
+
       expect(() => verify(token, 'secret', { algorithms: ['HS256'] })).not.toThrow()
       expect(lifetimeOf(resolveJwtExpires(value, FALLBACK))).toBeGreaterThan(0)
     },
@@ -102,6 +104,7 @@ describe('the resolved value against jsonwebtoken itself', () => {
 
   it('shows the failure being prevented: an unresolved sub-second value expires instantly', () => {
     const token = sign({}, 'secret', { algorithm: 'HS256', expiresIn: '600' })
+
     expect(() => verify(token, 'secret', { algorithms: ['HS256'] })).toThrow('jwt expired')
   })
 
@@ -110,6 +113,7 @@ describe('the resolved value against jsonwebtoken itself', () => {
     // what the old `env.JWT_EXPIRES || default` did for any non-empty string.
     const signRaw = (value: string) =>
       sign({}, 'secret', { algorithm: 'HS256', expiresIn: value as JwtExpires })
+
     expect(() => signRaw('foo')).toThrow(/expiresIn/)
     expect(() => signRaw('')).toThrow(/expiresIn/)
   })

--- a/backend/src/config/locales.spec.ts
+++ b/backend/src/config/locales.spec.ts
@@ -1,6 +1,8 @@
 import { readdir } from 'node:fs/promises'
 import path from 'node:path'
 
+import { describe, it, expect } from 'vitest'
+
 import { SUPPORTED_LOCALES, isSupportedLocale, resolveLocale } from './locales'
 import { SOFTWARE_DEFAULTS } from './softwareDefaults'
 
@@ -11,6 +13,7 @@ describe('SUPPORTED_LOCALES', () => {
       .filter((file) => file.endsWith('.json'))
       .map((file) => file.replace(/\.json$/, ''))
       .sort()
+
     expect([...SUPPORTED_LOCALES].sort()).toEqual(onDisk)
   })
 
@@ -19,7 +22,7 @@ describe('SUPPORTED_LOCALES', () => {
   })
 })
 
-describe('isSupportedLocale', () => {
+describe(isSupportedLocale, () => {
   it('accepts a supported locale case-insensitively, rejects everything else', () => {
     expect(isSupportedLocale('fr')).toBe(true)
     expect(isSupportedLocale('FR')).toBe(true)
@@ -29,7 +32,7 @@ describe('isSupportedLocale', () => {
   })
 })
 
-describe('resolveLocale', () => {
+describe(resolveLocale, () => {
   const FALLBACK = SOFTWARE_DEFAULTS.LANGUAGE_DEFAULT // 'en'
 
   it('keeps a supported locale', () => {

--- a/backend/src/config/softwareDefaults.spec.ts
+++ b/backend/src/config/softwareDefaults.spec.ts
@@ -1,7 +1,8 @@
 // Keys iterated below come from the fixed SOFTWARE_DEFAULTS / config module, never user
 // input — the object-injection lint is a false positive here.
 /* eslint-disable security/detect-object-injection */
-import { jest } from '@jest/globals'
+
+import { describe, it, expect } from 'vitest'
 
 import { ENV_SPEC_BY_NAME } from './envRegistry'
 import { SOFTWARE_DEFAULTS } from './softwareDefaults'
@@ -26,9 +27,12 @@ describe('SOFTWARE_DEFAULTS ↔ envRegistry display', () => {
   it('surfaces each canonical default as the registry display string', () => {
     for (const [name, value] of Object.entries(SOFTWARE_DEFAULTS)) {
       const spec = ENV_SPEC_BY_NAME[name]
+
       expect(spec).toBeDefined()
+
       // Lists are surfaced as a JSON array ([] / ["a","b"]); scalars via String().
       const expected = Array.isArray(value) ? JSON.stringify(value) : String(value)
+
       expect(spec.softwareDefault).toBe(expected)
     }
   })
@@ -61,7 +65,7 @@ describe('SOFTWARE_DEFAULTS ↔ config runtime default (logic-gated defaults)', 
   // SMTP_* etc.) would mask the true software defaults we mean to assert.
   // async because ESM has no synchronous module load: `await import()` replaces require().
   const loadConfigWithFlagsUnset = async (): Promise<LoadedConfig> => {
-    jest.resetModules()
+    vi.resetModules()
     const g = global as unknown as { Cypress?: { env: () => Record<string, string> } }
     g.Cypress = { env: () => ({ ...REQUIRED }) }
     try {
@@ -74,6 +78,7 @@ describe('SOFTWARE_DEFAULTS ↔ config runtime default (logic-gated defaults)', 
   it('defaults SMTP ignoreTLS / secure / rejectUnauthorized to the map values', async () => {
     const { nodemailerTransportOptions } = await loadConfigWithFlagsUnset()
     const tls = nodemailerTransportOptions.tls as { rejectUnauthorized: boolean }
+
     expect(nodemailerTransportOptions.ignoreTLS).toBe(SOFTWARE_DEFAULTS.SMTP_IGNORE_TLS)
     expect(nodemailerTransportOptions.secure).toBe(SOFTWARE_DEFAULTS.SMTP_SECURE)
     expect(tls.rejectUnauthorized).toBe(SOFTWARE_DEFAULTS.SMTP_REJECT_UNAUTHORIZED)
@@ -81,6 +86,7 @@ describe('SOFTWARE_DEFAULTS ↔ config runtime default (logic-gated defaults)', 
 
   it('defaults PRODUCTION_DB_CLEAN_ALLOW to the map value', async () => {
     const { default: CONFIG } = await loadConfigWithFlagsUnset()
+
     expect(CONFIG.PRODUCTION_DB_CLEAN_ALLOW).toBe(SOFTWARE_DEFAULTS.PRODUCTION_DB_CLEAN_ALLOW)
   })
 
@@ -89,12 +95,14 @@ describe('SOFTWARE_DEFAULTS ↔ config runtime default (logic-gated defaults)', 
     // production), so it is guarded as falsy rather than strictly `false`; the map records
     // its off baseline (false) as the single display source.
     const { default: CONFIG } = await loadConfigWithFlagsUnset()
+
     expect(CONFIG.DEBUG).toBeFalsy()
     expect(SOFTWARE_DEFAULTS.DEBUG).toBe(false)
   })
 
   it('defaults DISABLED_MIDDLEWARES to the empty list', async () => {
     const { default: CONFIG } = await loadConfigWithFlagsUnset()
+
     expect(CONFIG.DISABLED_MIDDLEWARES).toEqual(SOFTWARE_DEFAULTS.DISABLED_MIDDLEWARES)
   })
 })

--- a/backend/src/config/systemConfig.spec.ts
+++ b/backend/src/config/systemConfig.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { createInMemoryPolicyService } from '@src/policy'
 
 import { categoryRank } from './categories'
@@ -30,14 +32,16 @@ const rowFor = (
   return row
 }
 
-describe('systemConfigStatus', () => {
+describe(systemConfigStatus, () => {
   it('emits one row per env var with no duplicates', () => {
     const keys = rowsFor().map((row) => row.envKey)
+
     expect(new Set(keys).size).toBe(keys.length)
   })
 
   it('includes plain infrastructure vars alongside the policy-governed ones', () => {
     const keys = rowsFor().map((row) => row.envKey)
+
     // plain infra (never surfaced before)
     expect(keys).toContain('NEO4J_URI')
     expect(keys).toContain('SMTP_HOST')
@@ -49,6 +53,7 @@ describe('systemConfigStatus', () => {
 
   it('does not duplicate a policy-governed var as a plain row', () => {
     const liveKitRows = rowsFor().filter((row) => row.envKey === 'LIVEKIT_API_SECRET')
+
     expect(liveKitRows).toHaveLength(1)
     expect(liveKitRows[0].policyKey).toBe('videoConference')
   })
@@ -58,12 +63,14 @@ describe('systemConfigStatus', () => {
     // tab renders straight from row order, so this contract must hold at the source.
     const ranks = rowsFor().map((row) => categoryRank(row.category))
     const sorted = [...ranks].sort((a, b) => a - b)
+
     expect(ranks).toEqual(sorted)
   })
 
   describe('secret hygiene', () => {
     it('never returns a secret value, only its presence', () => {
       const row = rowFor('JWT_SECRET', { JWT_SECRET: 'super-secret' })
+
       expect(row.secret).toBe(true)
       expect(row.state).toBe('set')
       expect(row.envValue).toBeNull()
@@ -78,6 +85,7 @@ describe('systemConfigStatus', () => {
 
     it("surfaces a secret's software default (a public code constant) but never its env value", () => {
       const row = rowFor('NEO4J_PASSWORD', { NEO4J_PASSWORD: 'deployed-secret' })
+
       expect(row.secret).toBe(true)
       expect(row.state).toBe('set')
       // deployed value withheld …
@@ -91,11 +99,13 @@ describe('systemConfigStatus', () => {
   describe('plain non-secret infrastructure var', () => {
     it('shows the env value and falls back to the software default when unset', () => {
       const set = rowFor('NEO4J_URI', { NEO4J_URI: 'bolt://db:7687' })
+
       expect(set.secret).toBe(false)
       expect(set.envValue).toBe('bolt://db:7687')
       expect(set.effective).toBe('bolt://db:7687')
 
       const unset = rowFor('NEO4J_URI', {})
+
       expect(unset.envValue).toBeNull()
       // effective falls back to the registry software default
       expect(unset.effective).toBe('bolt://localhost:7687')
@@ -104,21 +114,25 @@ describe('systemConfigStatus', () => {
 
     it('shows a boolean toggle (DEBUG) as off by default rather than "no default"', () => {
       const unset = rowFor('DEBUG', {})
+
       // Off by default — falls back to 'false', not an em-dashed "no default".
       expect(unset.softwareDefault).toBe('false')
       expect(unset.effective).toBe('false')
 
       const set = rowFor('DEBUG', { DEBUG: 'app:*' })
+
       expect(set.envValue).toBe('app:*')
     })
 
     it('shows a list var (DISABLED_MIDDLEWARES) as a JSON array, empty by default', () => {
       const unset = rowFor('DISABLED_MIDDLEWARES', {})
+
       expect(unset.softwareDefault).toBe('[]')
       expect(unset.effective).toBe('[]') // falls back to the empty-list default
 
       // The comma-separated env value becomes a JSON array (entries trimmed, blanks dropped).
       const set = rowFor('DISABLED_MIDDLEWARES', { DISABLED_MIDDLEWARES: 'm_a, m_b' })
+
       expect(set.envValue).toBe('["m_a","m_b"]')
       expect(set.effective).toBe('["m_a","m_b"]')
     })
@@ -126,17 +140,20 @@ describe('systemConfigStatus', () => {
     it('drops blank and whitespace-only entries when parsing a list var', () => {
       // Empty entries (double comma) and whitespace-only entries must not survive the parse.
       const set = rowFor('DISABLED_MIDDLEWARES', { DISABLED_MIDDLEWARES: 'm_a,, m_b , ,m_c' })
+
       expect(set.envValue).toBe('["m_a","m_b","m_c"]')
       expect(set.effective).toBe('["m_a","m_b","m_c"]')
 
       // An all-blank value collapses to the empty list, not [""].
       const blank = rowFor('DISABLED_MIDDLEWARES', { DISABLED_MIDDLEWARES: ' , ,' })
+
       expect(blank.envValue).toBe('[]')
       expect(blank.effective).toBe('[]')
     })
 
     it('is never overridable and carries no policy key', () => {
       const row = rowFor('SMTP_HOST', { SMTP_HOST: 'mail.example.org' })
+
       expect(row.overridable).toBe(false)
       expect(row.policyKey).toBeNull()
       expect(row.blocking).toBe(false)
@@ -151,6 +168,7 @@ describe('systemConfigStatus', () => {
         { API_KEYS_ENABLED: 'true' },
         { apiKeysEnabled: false },
       )
+
       expect(row.overridable).toBe(true)
       expect(row.policyKey).toBe('apiKeysEnabled')
       expect(row.effective).toBe('false')
@@ -163,12 +181,14 @@ describe('systemConfigStatus', () => {
       // Realistic seeded state: the env seed was materialised into storage on boot,
       // so the stored value matches the configured default → no admin override.
       const row = rowFor('API_KEYS_ENABLED', { API_KEYS_ENABLED: 'true' }, { apiKeysEnabled: true })
+
       expect(row.effective).toBe('true')
       expect(row.override).toBeNull()
     })
 
     it('em-dashes the env value when the seed var is unset', () => {
       const row = rowFor('PUBLIC_REGISTRATION', {})
+
       expect(row.state).toBe('missing')
       expect(row.envValue).toBeNull()
     })
@@ -183,6 +203,7 @@ describe('systemConfigStatus', () => {
 
     it('exposes a non-secret requirement value (the URL) but shows presence, not a value, as effective', () => {
       const url = rowFor('LIVEKIT_URL', LIVEKIT)
+
       expect(url.secret).toBe(false)
       expect(url.envValue).toBe('wss://lk.example.org')
       expect(url.effective).toBeNull()
@@ -192,6 +213,7 @@ describe('systemConfigStatus', () => {
 
     it('hides a secret requirement value and flags a missing one as blocking', () => {
       const secret = rowFor('LIVEKIT_API_SECRET', { ...LIVEKIT, LIVEKIT_API_SECRET: undefined })
+
       expect(secret.secret).toBe(true)
       expect(secret.envValue).toBeNull()
       expect(secret.state).toBe('missing')
@@ -209,6 +231,7 @@ describe('systemConfigStatus', () => {
   describe('normalized var (LANGUAGE_DEFAULT, validated against the supported locales)', () => {
     it('shows a supported locale as-is', () => {
       const row = rowFor('LANGUAGE_DEFAULT', { LANGUAGE_DEFAULT: 'de' })
+
       expect(row.effective).toBe('de')
       expect(row.envValue).toBe('de')
     })
@@ -217,18 +240,21 @@ describe('systemConfigStatus', () => {
       // The runtime falls back to 'en' for an unsupported code, so the config tab must show the
       // SAME effective value — while the admin still sees the raw 'xx' they set (envValue).
       const row = rowFor('LANGUAGE_DEFAULT', { LANGUAGE_DEFAULT: 'xx' })
+
       expect(row.effective).toBe('en')
       expect(row.envValue).toBe('xx')
     })
 
     it('resolves an empty env value to the fallback (matching the runtime, not shown verbatim)', () => {
       const row = rowFor('LANGUAGE_DEFAULT', { LANGUAGE_DEFAULT: '' })
+
       expect(row.state).toBe('empty')
       expect(row.effective).toBe('en')
     })
 
     it('falls back to the default language when unset', () => {
       const row = rowFor('LANGUAGE_DEFAULT', {})
+
       expect(row.state).toBe('missing')
       expect(row.effective).toBe('en')
     })

--- a/backend/src/context/loaders.spec.ts
+++ b/backend/src/context/loaders.spec.ts
@@ -2,7 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { jest } from '@jest/globals'
+
+import { beforeAll, afterAll, describe, it, expect } from 'vitest'
 
 import Factory, { cleanDatabase } from '@db/factories'
 import { closeDriver, getDriver } from '@db/neo4j'
@@ -195,6 +196,7 @@ describe('forField', () => {
         .load('x')
 
     await Promise.all([load('A.one'), load('B.two')])
+
     expect(seen.sort()).toEqual(['A.one', 'B.two'])
   })
 })
@@ -215,9 +217,9 @@ describe('Room.unreadCount', () => {
   })
 
   it('resolves a whole room list in a single query', async () => {
-    const sessionSpy = jest.spyOn(driver, 'session')
+    const sessionSpy = vi.spyOn(driver, 'session')
 
-    // Restored in `finally`: jest is configured without `restoreMocks`, so a failing
+    // Restored in `finally`: the runner is configured without `restoreMocks`, so a failing
     // assertion would leave the spy on the shared driver for every later test in this file.
     // Milder than the same omission in queryBatching.spec.ts — there is no mockImplementation
     // here, so the real session still opens and only the call count keeps accumulating — but

--- a/backend/src/context/pubsub.spec.ts
+++ b/backend/src/context/pubsub.spec.ts
@@ -1,28 +1,27 @@
-import { jest } from '@jest/globals'
+import { beforeEach, describe, it, expect } from 'vitest'
 
 import type { RedisOptions } from 'ioredis'
 
-const mockConfig: {
+interface MockRedisConfig {
   REDIS_DOMAIN?: string
   REDIS_PORT?: number
   REDIS_PASSWORD?: string
-} = {}
+}
 
-jest.unstable_mockModule('@config/index', () => ({
+// `vi.hoisted` lifts the object to where the (hoisted) mock factory can see it. The Jest version
+// reached the same end through a getter, which only existed to dodge the TDZ its hoisting caused.
+const { mockConfig } = vi.hoisted((): { mockConfig: MockRedisConfig } => ({ mockConfig: {} }))
+
+vi.mock('@config/index', () => ({ __esModule: true, default: mockConfig }))
+
+vi.mock('ioredis', () => ({
   __esModule: true,
-  get default() {
-    return mockConfig
-  },
+  default: vi.fn(),
 }))
 
-jest.unstable_mockModule('ioredis', () => ({
+vi.mock('graphql-redis-subscriptions', () => ({
   __esModule: true,
-  default: jest.fn(),
-}))
-
-jest.unstable_mockModule('graphql-redis-subscriptions', () => ({
-  __esModule: true,
-  RedisPubSub: jest.fn(),
+  RedisPubSub: vi.fn(),
 }))
 
 // The module memoises its client in module scope, so every case needs a fresh registry. The
@@ -31,17 +30,17 @@ jest.unstable_mockModule('graphql-redis-subscriptions', () => ({
 // object (which is also why `PubSub` is pulled in here rather than imported above — otherwise
 // `toBeInstanceOf` compares against a class from the discarded registry).
 const load = async () => {
-  jest.resetModules()
-  const [pubsubModule, ioredis, redisSubscriptions, subscriptions] = await Promise.all([
-    import('./pubsub'),
-    import('ioredis'),
-    import('graphql-redis-subscriptions'),
-    import('graphql-subscriptions'),
-  ])
+  vi.resetModules()
+  // Sequential, not Promise.all: the mocked modules have to be resolved before the module under
+  // test evaluates and captures its bindings.
+  const ioredis = await import('ioredis')
+  const redisSubscriptions = await import('graphql-redis-subscriptions')
+  const subscriptions = await import('graphql-subscriptions')
+  const pubsubModule = await import('./pubsub')
   return {
     pubsub: pubsubModule.default,
-    Redis: jest.mocked(ioredis.default),
-    RedisPubSub: jest.mocked(redisSubscriptions.RedisPubSub),
+    Redis: vi.mocked(ioredis.default),
+    RedisPubSub: vi.mocked(redisSubscriptions.RedisPubSub),
     PubSub: subscriptions.PubSub,
   }
 }
@@ -57,6 +56,9 @@ const redisOptions = (Redis: { mock: { calls: unknown[][] } }): RedisOptions =>
   Redis.mock.calls[0][0] as RedisOptions
 
 beforeEach(() => {
+  // vitest evaluates a mock factory once and reuses the result, so call counts survive across
+  // tests — under Jest each resetModules produced fresh mock instances.
+  vi.clearAllMocks()
   mockConfig.REDIS_DOMAIN = undefined
   mockConfig.REDIS_PORT = undefined
   mockConfig.REDIS_PASSWORD = undefined
@@ -65,6 +67,7 @@ beforeEach(() => {
 describe('without Redis configured', () => {
   it('falls back to the in-process PubSub', async () => {
     const { pubsub, PubSub, RedisPubSub } = await load()
+
     expect(pubsub()).toBeInstanceOf(PubSub)
     expect(RedisPubSub).not.toHaveBeenCalled()
   })
@@ -79,6 +82,7 @@ describe('without Redis configured', () => {
       configureRedis()
       unset()
       const { pubsub, PubSub, RedisPubSub } = await load()
+
       expect(pubsub()).toBeInstanceOf(PubSub)
       expect(RedisPubSub).not.toHaveBeenCalled()
     },
@@ -86,6 +90,7 @@ describe('without Redis configured', () => {
 
   it('memoises, so publishers and subscribers share one instance', async () => {
     const { pubsub } = await load()
+
     expect(pubsub()).toBe(pubsub())
   })
 })
@@ -96,16 +101,20 @@ describe('with Redis configured', () => {
   it('gives RedisPubSub a dedicated publisher and subscriber', async () => {
     const { pubsub, Redis, RedisPubSub } = await load()
     pubsub()
+
     // Two clients, not one: a connection in subscriber mode cannot publish.
     expect(Redis).toHaveBeenCalledTimes(2)
     expect(RedisPubSub).toHaveBeenCalledTimes(1)
+
     const { publisher, subscriber } = (RedisPubSub.mock.calls[0] as [Record<string, unknown>])[0]
+
     expect(publisher).not.toBe(subscriber)
   })
 
   it('passes host, port and password through', async () => {
     const { pubsub, Redis } = await load()
     pubsub()
+
     expect(redisOptions(Redis)).toMatchObject({
       host: 'redis.example.test',
       port: 6379,
@@ -117,6 +126,7 @@ describe('with Redis configured', () => {
     const { pubsub, Redis } = await load()
     pubsub()
     const { retryStrategy } = redisOptions(Redis)
+
     expect(retryStrategy).toBeDefined()
     expect(retryStrategy?.(1)).toBe(50)
     expect(retryStrategy?.(10)).toBe(500)
@@ -126,6 +136,7 @@ describe('with Redis configured', () => {
 
   it('memoises across calls', async () => {
     const { pubsub, RedisPubSub } = await load()
+
     expect(pubsub()).toBe(pubsub())
     expect(RedisPubSub).toHaveBeenCalledTimes(1)
   })

--- a/backend/src/db/migration-roles-single-role-edges.spec.ts
+++ b/backend/src/db/migration-roles-single-role-edges.spec.ts
@@ -1,3 +1,5 @@
+import { describe, beforeEach, afterAll, it, expect } from 'vitest'
+
 import { cleanDatabase } from '@db/factories'
 import { getDriver } from '@db/neo4j'
 
@@ -55,6 +57,7 @@ describe('migration: single-role-edges', () => {
 
   it('gives every user exactly one role edge matching their tier', async () => {
     await up(noop)
+
     expect(await rolesOf('admin-id')).toEqual(['admin'])
     expect(await rolesOf('mod-id')).toEqual(['moderator'])
     expect(await rolesOf('member-id')).toEqual(['user']) // baseline gets an explicit edge
@@ -62,12 +65,14 @@ describe('migration: single-role-edges', () => {
 
   it('collapses multiple edges to a single deterministic role', async () => {
     await up(noop)
+
     // owner-first then alphabetical → admin wins over moderator
     expect(await rolesOf('multi-id')).toEqual(['admin'])
   })
 
   it('drops the legacy user.role property', async () => {
     await up(noop)
+
     expect(await legacyRole('admin-id')).toBeNull()
     expect(await legacyRole('member-id')).toBeNull()
   })

--- a/backend/src/db/migrations-specs/20260820140000-drop-article-secondary-label-constraints.spec.ts
+++ b/backend/src/db/migrations-specs/20260820140000-drop-article-secondary-label-constraints.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { isReversible } from '@db/migrations/20260820140000-drop-article-secondary-label-constraints'
 
 import type { PresentConstraint } from '@db/migrations/20260820140000-drop-article-secondary-label-constraints'
@@ -17,7 +19,7 @@ const constraint = (over: Partial<PresentConstraint> = {}): PresentConstraint =>
   ...over,
 })
 
-describe('isReversible', () => {
+describe(isReversible, () => {
   it.each([['id'], ['slug']])('accepts the uniqueness constraint on Article(%s)', (property) => {
     // The closed set neode's `extend('Post', 'Article')` produced: Post's `id: primary` and
     // `slug: unique`, copied onto the secondary label.

--- a/backend/src/db/migrations-specs/20260821120000-repair-or-remove-unfollowable-social-media.spec.ts
+++ b/backend/src/db/migrations-specs/20260821120000-repair-or-remove-unfollowable-social-media.spec.ts
@@ -1,9 +1,10 @@
-import { jest } from '@jest/globals'
-// ESM has no automock: unstable_mockModule requires an explicit factory.
-jest.unstable_mockModule('@db/neo4j', () => ({ getDriver: jest.fn() }))
+// ESM has no automock: `vi.mock` requires an explicit factory.
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+vi.mock('@db/neo4j', () => ({ getDriver: vi.fn() }))
+
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { forLog, repair, up } =
   await import('@db/migrations/20260821120000-repair-or-remove-unfollowable-social-media')
 const { getDriver } = await import('@db/neo4j')
@@ -14,7 +15,7 @@ const { getDriver } = await import('@db/neo4j')
 //
 // NOT beside its subject, which is the convention everywhere else in this repository, because
 // `node-migrate` requires EVERY entry that `readdir` returns for --migrations-dir. A spec left
-// in there is loaded by the runner, `describe` is not defined outside jest, and `db:migrate up`
+// in there is loaded by the runner, `describe` is not defined outside it, and `db:migrate up`
 // dies before it reaches the first real migration — in the init container, on every deploy.
 // Measured, not assumed: `yarn db:migrate list` reproduces it, and a `__tests__/` subdirectory
 // does not help, because the loader `require`s the directory entry too. The only fix is to be
@@ -170,6 +171,7 @@ describe('repair', () => {
     // result against the stored value to decide whether to write at all.
     for (const url of ['mastodon.social/@user', 'someone@example.org', 'mailto:a@b.org?x=1']) {
       const once = repair(url)
+
       expect(once).not.toBeNull()
       expect(repair(once as string)).toBe(once)
     }
@@ -263,15 +265,15 @@ describe('up', () => {
         ),
       close: async () => Promise.resolve(),
     }
-    jest.mocked(getDriver).mockReturnValue({ session: () => session } as never)
-    jest.spyOn(console, 'log').mockImplementation((line: string) => {
+    vi.mocked(getDriver).mockReturnValue({ session: () => session } as never)
+    vi.spyOn(console, 'log').mockImplementation((line: string) => {
       events.push(`log ${line.trim()}`)
     })
     await up(undefined)
   })
 
   afterEach(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
   })
 
   it('names a url before the write that destroys it', () => {
@@ -280,6 +282,7 @@ describe('up', () => {
     // names nothing. The order is the promise.
     const removal = events.indexOf('write s2')
     const naming = events.findIndex((event) => event.includes('example.org/pub'))
+
     expect(naming).toBeGreaterThanOrEqual(0)
     expect(naming).toBeLessThan(removal)
   })
@@ -288,6 +291,7 @@ describe('up', () => {
     // The quieter half of the same problem: `SET s.url = $url` overwrites the only copy.
     const write = events.indexOf('write s1')
     const naming = events.findIndex((event) => event.includes('mailto:a@example.org'))
+
     expect(naming).toBeGreaterThanOrEqual(0)
     expect(naming).toBeLessThan(write)
   })
@@ -296,6 +300,7 @@ describe('up', () => {
     // Logging the old value redacted and the new one raw put the token in the log anyway, by
     // the other half of the same line.
     const line = events.find((event) => event.includes('example.org/x'))
+
     expect(line).toBeDefined()
     expect(line).not.toContain('token=abc')
     expect(line).toContain('https://example.org/x (query removed)')
@@ -306,6 +311,7 @@ describe('up', () => {
     // password or someone else's address into it would leave the migration undoing itself —
     // removing the value from the public profile and keeping it somewhere less guarded.
     const log = events.filter((event) => event.startsWith('log ')).join('\n')
+
     expect(log).not.toContain('secret')
     expect(log).not.toContain('evil@example.tld')
     // Still enough to act on: the owner and the link they lost.
@@ -322,3 +328,6 @@ describe('up', () => {
     expect(events[0]).toBe('log SocialMedia urls: 3 checked, 2 to repair, 1 to remove')
   })
 })
+
+// No imports left after the vitest switch — without this the file is a script, not a
+// module: its top-level consts would collide across specs and `await` would be illegal.

--- a/backend/src/db/schema/derive/apply.spec.ts
+++ b/backend/src/db/schema/derive/apply.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { entities, relationships } from '@db/schema/index'
 
 import { applyPlan, enforce, planConstraints, SchemaEnforcementError } from './apply'
@@ -93,11 +95,12 @@ const presentIndex = (
   uniqueness: 'UNIQUE' | 'NONUNIQUE' = 'NONUNIQUE',
 ) => ({ name, labelsOrTypes: [label], properties, uniqueness, type: 'BTREE' as const })
 
-describe('planConstraints', () => {
+describe(planConstraints, () => {
   const items = planConstraints(entities, relationships, 'neo4j-community')
 
   it('plans one statement per enforceable rule', () => {
     expect(items.length).toBeGreaterThan(0)
+
     for (const item of items) {
       expect(item.statement).toContain('CREATE CONSTRAINT')
     }
@@ -119,16 +122,18 @@ describe('planConstraints', () => {
   })
 })
 
-describe('applyPlan', () => {
+describe(applyPlan, () => {
   it('creates indices before constraints, so a rejected constraint costs no index', async () => {
     const { runner, calls } = stubRunner()
     await applyPlan(runner, plan, ['CREATE INDEX Role_name_index'])
+
     expect(calls[0]).toBe('execute CREATE INDEX Role_name_index')
   })
 
   it('applies a statement whose audit is clean', async () => {
     const { runner, calls } = stubRunner()
     const report = await applyPlan(runner, plan)
+
     expect(report.applied).toContain(CONSTRAINT)
     expect(calls).toContain(`count ${AUDIT}`)
     expect(calls.indexOf(`count ${AUDIT}`)).toBeLessThan(calls.indexOf(`execute ${CONSTRAINT}`))
@@ -137,6 +142,7 @@ describe('applyPlan', () => {
   it('skips a statement whose audit finds violations, and never sends it', async () => {
     const { runner, calls } = stubRunner({ violations: new Map([[AUDIT, 3]]) })
     const report = await applyPlan(runner, plan)
+
     expect(report.skipped).toEqual([
       {
         statement: CONSTRAINT,
@@ -156,10 +162,12 @@ describe('applyPlan', () => {
     // notice — the report would look identical.
     const clean = stubRunner()
     await applyPlan(clean.runner, plan)
+
     expect(clean.calls.filter((call) => call.startsWith('sample'))).toEqual([])
 
     const violating = stubRunner({ violations: new Map([[AUDIT, 3]]) })
     await applyPlan(violating.runner, plan)
+
     expect(violating.calls.filter((call) => call.startsWith('sample'))).toEqual([
       'sample SAMPLE User.slug',
     ])
@@ -168,12 +176,14 @@ describe('applyPlan', () => {
   it('carries on with the remaining statements after a skip', async () => {
     const { runner } = stubRunner({ violations: new Map([[AUDIT, 1]]) })
     const report = await applyPlan(runner, plan)
+
     expect(report.applied).toEqual(['CREATE CONSTRAINT Role_id_unique'])
   })
 
   it('records a rejected statement with its Neo4j code and carries on', async () => {
     const { runner } = stubRunner({ rejects: ['User_slug_unique'] })
     const report = await applyPlan(runner, plan)
+
     expect(report.failed).toEqual([
       {
         statement: CONSTRAINT,
@@ -187,6 +197,7 @@ describe('applyPlan', () => {
   it('does not stop the run when an index cannot be created', async () => {
     const { runner } = stubRunner({ rejects: ['INDEX'] })
     const report = await applyPlan(runner, plan, ['CREATE INDEX broken'])
+
     expect(report.failed).toHaveLength(1)
     expect(report.applied).toContain(CONSTRAINT)
   })
@@ -197,6 +208,7 @@ describe('applyPlan', () => {
     // must not turn a repeated deployment into a red one.
     const { runner } = stubRunner({ alreadyThere: ['fulltext'] })
     const report = await applyPlan(runner, [], ['CALL db.index.fulltext.createNodeIndex("x")'])
+
     expect(report.unchanged).toEqual(['CALL db.index.fulltext.createNodeIndex("x")'])
     expect(report.failed).toEqual([])
   })
@@ -204,6 +216,7 @@ describe('applyPlan', () => {
   it('keeps unchanged out of applied, so a no-op run does not claim work', async () => {
     const { runner } = stubRunner({ alreadyThere: ['fulltext'] })
     const report = await applyPlan(runner, [], ['CALL db.index.fulltext.createNodeIndex("x")'])
+
     expect(report.applied).toEqual([])
   })
 
@@ -217,6 +230,7 @@ describe('applyPlan', () => {
         indices: [presentIndex('User_slug_index', 'User', ['slug'])],
       })
       const report = await applyPlan(runner, supersedingPlan)
+
       expect(calls).toEqual([
         `count ${AUDIT}`,
         'sample SHOW INDEXES',
@@ -238,6 +252,7 @@ describe('applyPlan', () => {
         rejects: [CONSTRAINT, 'CREATE INDEX'],
       })
       const report = await applyPlan(runner, supersedingPlan)
+
       // Still in `superseded`, because that is the truth: dropped, and not back.
       expect(report.superseded).toEqual(['User_slug_index'])
       expect(report.failed.map((item) => item.message)).toEqual([
@@ -254,6 +269,7 @@ describe('applyPlan', () => {
         rejects: [CONSTRAINT, 'CREATE INDEX'],
       })
       const report = await applyPlan(runner, supersedingPlan)
+
       expect(() => {
         enforce(report, 'report')
       }).toThrow(SchemaEnforcementError)
@@ -267,6 +283,7 @@ describe('applyPlan', () => {
         indices: [presentIndex('User_slug_index', 'User', ['slug'])],
       })
       const report = await applyPlan(runner, supersedingPlan)
+
       expect(calls).not.toContain('sample SHOW INDEXES')
       expect(calls.filter((call) => call.startsWith('execute DROP'))).toEqual([])
       expect(report.superseded).toEqual([])
@@ -279,6 +296,7 @@ describe('applyPlan', () => {
         indices: [presentIndex('User_slug_unique', 'User', ['slug'], 'UNIQUE')],
       })
       const report = await applyPlan(runner, supersedingPlan)
+
       expect(calls.filter((call) => call.startsWith('execute DROP'))).toEqual([])
       expect(report.superseded).toEqual([])
     })
@@ -294,6 +312,7 @@ describe('applyPlan', () => {
         ],
       })
       const report = await applyPlan(runner, supersedingPlan)
+
       expect(calls.filter((call) => call.startsWith('execute DROP'))).toEqual([])
       expect(report.superseded).toEqual([])
     })
@@ -307,6 +326,7 @@ describe('applyPlan', () => {
         ],
       })
       await applyPlan(runner, supersedingPlan)
+
       expect(calls.filter((call) => call.startsWith('execute DROP'))).toEqual([])
     })
 
@@ -319,6 +339,7 @@ describe('applyPlan', () => {
         indices: [presentIndex('User_slug_index', 'User', ['slug'])],
       })
       const report = await applyPlan(runner, supersedingPlan)
+
       expect(calls).toContain(
         'execute CREATE INDEX `User_slug_index` IF NOT EXISTS FOR (n:User) ON (n.slug)',
       )
@@ -329,6 +350,7 @@ describe('applyPlan', () => {
     it('costs one read and nothing else on a database that has no such index', async () => {
       const { runner, calls } = stubRunner({ indices: [] })
       const report = await applyPlan(runner, supersedingPlan)
+
       expect(calls.filter((call) => call.startsWith('execute'))).toEqual([`execute ${CONSTRAINT}`])
       expect(report.superseded).toEqual([])
     })
@@ -337,11 +359,12 @@ describe('applyPlan', () => {
   it('passes unsupported objects through instead of dropping them silently', async () => {
     const { runner } = stubRunner()
     const report = await applyPlan(runner, [], [], ['fulltext index x on Y(z)'])
+
     expect(report.unsupported).toEqual(['fulltext index x on Y(z)'])
   })
 })
 
-describe('enforce', () => {
+describe(enforce, () => {
   const clean: ApplyReport = {
     applied: ['x'],
     unchanged: [],

--- a/backend/src/db/schema/derive/audit.spec.ts
+++ b/backend/src/db/schema/derive/audit.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { entities, Post, relationships, Role, User } from '@db/schema/index'
 
 import { auditFor, auditQueryFor, auditsFor } from './audit'
@@ -21,12 +23,14 @@ describe('the enforced/audited partition', () => {
     for (const rule of RULES) {
       const enforced = statementFor(rule, profile) !== null
       const audited = auditFor(rule, profile) !== null
+
       expect({ rule, enforced, audited }).toMatchObject({ enforced: !audited, audited: !enforced })
     }
   })
 
   it('shifts rules from audited to enforced as the backend gains capability', () => {
     const audited = PROFILES.map((profile) => auditsFor(RULES, profile).length)
+
     expect(audited).toEqual([...audited].sort((a, b) => b - a))
     // Memgraph enforces strictly more of the same declaration than Neo4j Community does.
     expect(audited[audited.length - 1]).toBeLessThan(audited[0])
@@ -223,6 +227,7 @@ describe('generated queries', () => {
 describe('coverage of the pilot registry', () => {
   it.each([User.label, Role.label, Post.label])('produces node audits for %s', (label) => {
     const violations = auditsFor(RULES, 'neo4j-community').map((query) => query.violation)
+
     expect(violations.some((violation) => violation.startsWith(`${label}.`))).toBe(true)
   })
 
@@ -235,6 +240,7 @@ describe('coverage of the pilot registry', () => {
 
   it('gives every audit a stable, unique identifier', () => {
     const violations = auditsFor(RULES, 'neo4j-community').map((query) => query.violation)
+
     expect(new Set(violations).size).toBe(violations.length)
   })
 })

--- a/backend/src/db/schema/derive/ddl.spec.ts
+++ b/backend/src/db/schema/derive/ddl.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+
 import { Post, Role, User } from '@db/schema/index'
 import { defineEntity } from '@db/schema/types'
 
@@ -15,7 +17,7 @@ const statements = (entity: Parameters<typeof rulesForEntity>[0], profile: Backe
     .map((rule) => statementFor(rule, profile))
     .filter((statement): statement is string => statement !== null)
 
-describe('statementFor', () => {
+describe(statementFor, () => {
   describe('neo4j-community', () => {
     it('emits uniqueness constraints and nothing else', () => {
       expect(statements(User, 'neo4j-community')).toEqual([
@@ -60,6 +62,7 @@ describe('statementFor', () => {
   describe('memgraph', () => {
     it('emits existence and data type constraints in memgraph dialect', () => {
       const emitted = statements(Role, 'memgraph')
+
       expect(emitted).toContainEqual('CREATE CONSTRAINT ON (n:Role) ASSERT EXISTS (n.id)')
       expect(emitted).toContainEqual('CREATE CONSTRAINT ON (n:Role) ASSERT n.id IS TYPED STRING')
       expect(emitted).toContainEqual(
@@ -83,6 +86,7 @@ describe('statementFor', () => {
         properties: { value: { type: 'number' } },
         required: [],
       })
+
       expect(statements(Measured, 'memgraph')).toEqual([])
     })
 
@@ -92,6 +96,7 @@ describe('statementFor', () => {
         properties: { value: { type: ['string', 'integer'] } },
         required: [],
       })
+
       expect(statements(Widened, 'memgraph')).toEqual([])
     })
   })
@@ -122,9 +127,10 @@ describe('statementFor', () => {
   })
 })
 
-describe('indexStatementsFor', () => {
+describe(indexStatementsFor, () => {
   it('emits the 4.4 procedure form for fulltext indices', () => {
     const { statements: emitted } = indexStatementsFor(Post, 'neo4j-community')
+
     expect(emitted).toContainEqual(
       'CALL db.index.fulltext.createNodeIndex("post_fulltext_search",["Post"],["title","content"])',
     )
@@ -142,6 +148,7 @@ describe('indexStatementsFor', () => {
   // A dropped index would read as "covered" while search silently degrades. It is reported.
   it('reports fulltext indices as unsupported on memgraph rather than approximating them', () => {
     const { statements: emitted, unsupported } = indexStatementsFor(Post, 'memgraph')
+
     expect(emitted).not.toContainEqual(expect.stringContaining('fulltext'))
     expect(unsupported).toEqual(['fulltext index post_fulltext_search on Post(title, content)'])
   })
@@ -150,6 +157,7 @@ describe('indexStatementsFor', () => {
 describe('every profile', () => {
   it('produces syntactically distinct DDL for the same declaration', () => {
     const perProfile = PROFILES.map((profile) => statements(User, profile).length)
+
     // community < enterprise < memgraph: more capability, more enforcement, same declaration.
     expect(perProfile).toEqual([...perProfile].sort((a, b) => a - b))
     expect(new Set(perProfile).size).toBeGreaterThan(1)
@@ -160,6 +168,7 @@ describe('every profile', () => {
       const emitted = allRules([User, Role, Post], [])
         .map((rule) => statementFor(rule, profile))
         .filter((statement): statement is string => statement !== null)
+
       expect(emitted).not.toContainEqual('')
       expect(new Set(emitted).size).toBe(emitted.length)
     }
@@ -194,6 +203,7 @@ describe('a capability the table denies is not emitted', () => {
     const rule = rulesForEntity(User).find(
       (entry) => entry.kind === 'unique' && entry.properties.join() === 'id',
     )
+
     expect(rule).toBeDefined()
     expect(auditFor(rule as Rule, WITHOUT_UNIQUE)).not.toBeNull()
   })

--- a/backend/src/db/schema/derive/drift.spec.ts
+++ b/backend/src/db/schema/derive/drift.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { entities, Role, User } from '@db/schema/index'
 import { defineEntity } from '@db/schema/types'
 
@@ -24,9 +26,10 @@ const existence = (label: string, property: string): SchemaObject => ({
   properties: [property],
 })
 
-describe('declaredObjects', () => {
+describe(declaredObjects, () => {
   it('lists the uniqueness constraints a community backend can hold', () => {
     const objects = declaredObjects([User], 'neo4j-community')
+
     expect(objects).toContainEqual(constraint('User', 'id'))
     expect(objects).toContainEqual(constraint('User', 'slug'))
   })
@@ -57,6 +60,7 @@ describe('declaredObjects', () => {
     // AND unsupported in the apply report, from the same run; and since `missing` feeds the
     // exit code, `check memgraph` against a database without it could never come back clean.
     const declared = declaredObjects([User], 'memgraph')
+
     expect(declared).not.toContainEqual({
       kind: 'fulltext',
       label: 'User',
@@ -71,7 +75,9 @@ describe('declaredObjects', () => {
     // creatable on it, or `check` reports work that no `apply` can ever do.
     const { missing } = compareSchemaObjects(declaredObjects([User], 'memgraph'), [])
     const { unsupported } = declaredIndexStatements([User], 'memgraph')
+
     expect(unsupported).toHaveLength(1)
+
     for (const object of missing) {
       expect(describeSchemaObject(object)).not.toContain('name, slug')
     }
@@ -85,7 +91,7 @@ describe('declaredObjects', () => {
   })
 })
 
-describe('inexpressibleObjects', () => {
+describe(inexpressibleObjects, () => {
   const userFulltext = { kind: 'fulltext' as const, label: 'User', properties: ['name', 'slug'] }
 
   it('names what a profile cannot create, so it is not read as surplus either', () => {
@@ -94,7 +100,9 @@ describe('inexpressibleObjects', () => {
     // present. Undeclared for that profile, it would come back as SURPLUS "declared nowhere":
     // untrue, and an invitation to drop an index the current backend needs.
     expect(inexpressibleObjects([User], 'memgraph')).toEqual([userFulltext])
+
     const { surplus } = compareSchemaObjects(declaredObjects([User], 'memgraph'), [userFulltext])
+
     expect(surplus).toEqual([userFulltext])
     // …which is why run-audit subtracts exactly this set before printing and counting.
   })
@@ -106,9 +114,10 @@ describe('inexpressibleObjects', () => {
   })
 })
 
-describe('compareSchemaObjects', () => {
+describe(compareSchemaObjects, () => {
   it('reports what the declaration wants and the database lacks', () => {
     const report = compareSchemaObjects([constraint('User', 'slug')], [])
+
     expect(report.missing).toEqual([constraint('User', 'slug')])
     expect(report.surplus).toEqual([])
   })
@@ -118,6 +127,7 @@ describe('compareSchemaObjects', () => {
     // is dropped any more, so an undeclared constraint would otherwise live forever and keep
     // rejecting writes no one expects it to reject.
     const report = compareSchemaObjects([], [constraint('Ghost', 'id')])
+
     expect(report.surplus).toEqual([constraint('Ghost', 'id')])
     expect(report.missing).toEqual([])
   })
@@ -127,6 +137,7 @@ describe('compareSchemaObjects', () => {
       [constraint('User', 'slug')],
       [{ kind: 'index', label: 'User', properties: ['slug'] }],
     )
+
     // Same label and property, different kind: an index does not satisfy a constraint.
     expect(report.missing).toEqual([constraint('User', 'slug')])
     expect(report.surplus).toEqual([{ kind: 'index', label: 'User', properties: ['slug'] }])
@@ -134,6 +145,7 @@ describe('compareSchemaObjects', () => {
 
   it('treats a composite key as one object, not as two', () => {
     const composite = constraint('X', 'a', 'b')
+
     expect(compareSchemaObjects([composite], [composite]).missing).toEqual([])
     expect(compareSchemaObjects([composite], [constraint('X', 'a')]).missing).toEqual([composite])
   })
@@ -143,11 +155,12 @@ describe('compareSchemaObjects', () => {
       constraint('User', 'id'),
       { kind: 'index' as const, label: 'Role', properties: ['name'] },
     ]
+
     expect(compareSchemaObjects(objects, objects)).toEqual({ missing: [], surplus: [] })
   })
 })
 
-describe('describeSchemaObject', () => {
+describe(describeSchemaObject, () => {
   it('reads as the operator would say it', () => {
     expect(describeSchemaObject(constraint('User', 'slug'))).toBe('unique constraint User(slug)')
     expect(describeSchemaObject(constraint('X', 'a', 'b'))).toBe('unique constraint X(a, b)')
@@ -157,7 +170,7 @@ describe('describeSchemaObject', () => {
   })
 })
 
-describe('isKnownProfile', () => {
+describe(isKnownProfile, () => {
   it('accepts the three profiles and rejects a typo', () => {
     expect(isKnownProfile('neo4j-community')).toBe(true)
     expect(isKnownProfile('memgraph')).toBe(true)
@@ -174,6 +187,7 @@ describe('the two constraint kinds are told apart', () => {
 
   it('wants both where the backend can hold both', () => {
     const declared = declaredObjects([User], 'neo4j-enterprise')
+
     expect(declared).toContainEqual(constraint('User', 'id'))
     expect(declared).toContainEqual(existence('User', 'id'))
   })
@@ -183,6 +197,7 @@ describe('the two constraint kinds are told apart', () => {
       [constraint('User', 'id'), existence('User', 'id')],
       [constraint('User', 'id')],
     )
+
     expect(report.missing).toEqual([existence('User', 'id')])
   })
 
@@ -194,6 +209,7 @@ describe('the two constraint kinds are told apart', () => {
       [constraint('User', 'id'), constraint('User', 'id')],
       [],
     )
+
     expect(wantedTwice.missing).toEqual([constraint('User', 'id')])
 
     // The present side is the harder one to reach — Neo4j will not hold two constraints over
@@ -203,6 +219,7 @@ describe('the two constraint kinds are told apart', () => {
       [],
       [constraint('User', 'id'), constraint('User', 'id')],
     )
+
     expect(presentTwice.surplus).toEqual([constraint('User', 'id')])
   })
 })
@@ -230,6 +247,7 @@ describe('the two index kinds are told apart', () => {
     const report = compareSchemaObjects(declaredObjects([Both], 'neo4j-community'), [
       { kind: 'fulltext', label: 'Both', properties: ['id'] },
     ])
+
     expect(report.missing).toEqual([{ kind: 'index', label: 'Both', properties: ['id'] }])
     expect(report.surplus).toEqual([])
   })

--- a/backend/src/db/schema/patternParity.spec.ts
+++ b/backend/src/db/schema/patternParity.spec.ts
@@ -1,3 +1,5 @@
+import { afterAll, describe, expect } from 'vitest'
+
 import { closeDriver, getDriver } from '@db/neo4j'
 import { cypherString } from '@db/schema/derive/audit'
 import { EMAIL, FOLLOWABLE_URL, ISO_DATE_TIME, SLUG } from '@db/schema/entities/patterns'
@@ -153,8 +155,8 @@ const patterns = (): { pattern: string; used: string }[] => {
  *
  * A test here asks up to 180 of them, and the wrapping is what they cost: measured against a
  * local Neo4j, 180 round trips take 664 ms as a session-and-transaction each, 548 ms sharing
- * the session, and 222 ms inside a single transaction. Jest's default timeout is 5 s and this
- * file sets none, so the margin was about sevenfold locally and correspondingly thinner
+ * the session, and 222 ms inside a single transaction. The runner's timeout is 10 s (set in
+ * vitest.config.ts), so the margin was about fortyfold locally and correspondingly thinner
  * wherever the database is a network hop further away.
  */
 const inReadTransaction = async (work: (transaction: Transaction) => Promise<void>) => {
@@ -237,6 +239,7 @@ describe('every declared pattern reads the same in ajv and in Cypher', () => {
           // comparison below trivially "false === false" — and so would an injection point that
           // lands outside the class under test, which is why `variantsOf` declares where it goes.
           const { value: sample } = placed(marked)
+
           expect({ sample, ajv: inJavaScript.test(sample) }).toEqual({ sample, ajv: true })
           expect({ sample, cypher: await matchesInJava(transaction, sample, pattern) }).toEqual({
             sample,

--- a/backend/src/db/schema/schema.spec.ts
+++ b/backend/src/db/schema/schema.spec.ts
@@ -1,4 +1,5 @@
 import { Ajv } from 'ajv'
+import { describe, expect, it } from 'vitest'
 
 import { sourcesOf, targetsOf } from './derive/rules'
 import { jsonSchemaFor, relationshipJsonSchemaFor } from './types'
@@ -30,6 +31,7 @@ describe('the declaration', () => {
         ...(entity.indexed ?? []),
         ...(entity.fulltext ?? []).flatMap((index) => index.properties),
       ]
+
       expect(declared).toEqual(expect.arrayContaining(referenced))
     }
   })
@@ -49,6 +51,7 @@ describe('the declaration', () => {
     // WROTE points at both Post and Comment; a single-target declaration would report every
     // comment edge as an endpoint violation.
     const wrote = relationships.find((relationship) => relationship.type === 'WROTE')
+
     expect(wrote).toBeDefined()
     expect(targetsOf(wrote as RelationshipDefinition).map((entity) => entity.label)).toEqual([
       'Post',
@@ -116,12 +119,13 @@ describe('validation', () => {
   it('validates edge properties against the edge declaration', () => {
     const [observes] = relationships.filter((relationship) => relationship.type === 'OBSERVES')
     const validate = ajv.compile(relationshipJsonSchemaFor(observes))
+
     expect(validate({ createdAt: '2026-08-19T10:00:00.000Z', active: true })).toBe(true)
     expect(validate({ createdAt: 'yesterday', active: true })).toBe(false)
   })
 })
 
-describe('validateProperty', () => {
+describe(validateProperty, () => {
   // The single-property path exists for resolvers that check an input before there is a node
   // to write — AddEmailAddress validates the address the user typed, while the node it will
   // eventually create also carries a nonce and a timestamp that do not exist yet.
@@ -230,16 +234,19 @@ describe('derived types', () => {
       updatedAt: '2026-08-19T10:00:00.000Z',
       about: null,
     }
+
     expect(user.about).toBeNull()
   })
 
   it('narrows an enum property to its literal values', () => {
     const post: Pick<EntityProperties<typeof Post>, 'postType'> = { postType: 'Article' }
+
     expect(post.postType).toBe('Article')
   })
 
   it('types a boolean property as boolean', () => {
     const role: Pick<EntityProperties<typeof Role>, 'protected'> = { protected: true }
+
     expect(role.protected).toBe(true)
   })
 })

--- a/backend/src/db/testing/aliases.spec.ts
+++ b/backend/src/db/testing/aliases.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { branchesOf } from '@db/schema/derive/rules'
 import { relationships } from '@db/schema/relationships'
 
@@ -38,7 +40,7 @@ describe('the alias table against the declaration', () => {
   )
 })
 
-describe('resolveAlias', () => {
+describe(resolveAlias, () => {
   it('resolves a declared alias', () => {
     expect(resolveAlias('User', 'following')).toEqual({ type: 'FOLLOWS', direction: 'out' })
   })

--- a/backend/src/db/testing/create.spec.ts
+++ b/backend/src/db/testing/create.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { Post, User } from '@db/schema/index'
 
 import { findNode } from './create'
@@ -6,7 +8,7 @@ import { declaredProperty } from './defaults'
 // No database: the guard runs before the session is opened, which is the point of it — a typo
 // should cost nothing and be reported where it was made, not turn into an empty result.
 
-describe('declaredProperty', () => {
+describe(declaredProperty, () => {
   it('passes a name the entity declares', () => {
     expect(declaredProperty(User, 'slug')).toBe('slug')
     expect(declaredProperty(Post, 'title')).toBe('title')
@@ -32,7 +34,7 @@ describe('declaredProperty', () => {
   })
 })
 
-describe('findNode', () => {
+describe(findNode, () => {
   it('rejects an undeclared property before it reaches the database', async () => {
     // Without this it was a `MATCH (node:User {slugg: $value})` — valid Cypher, no match, and
     // a `null` indistinguishable from "no such user". The factory then built half a fixture

--- a/backend/src/db/testing/defaults.spec.ts
+++ b/backend/src/db/testing/defaults.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { User } from '@db/schema/index'
 
 import { normalised, timestamp, withDefaults } from './defaults'
@@ -5,7 +7,7 @@ import { normalised, timestamp, withDefaults } from './defaults'
 // No database: the point of this helper is what it guarantees in-process, and a round trip
 // would hide it — two writes 40ms apart differ even with `new Date()`.
 
-describe('timestamp', () => {
+describe(timestamp, () => {
   const stamps = Array.from({ length: 200 }, () => timestamp())
 
   it('hands out a distinct value every time', () => {
@@ -31,7 +33,7 @@ describe('timestamp', () => {
   })
 })
 
-describe('normalised', () => {
+describe(normalised, () => {
   it('drops an undefined value, so a default can still apply', () => {
     // A spread copies the key either way: `{ ...defaults, ...{ name: undefined } }` overwrites
     // the default with nothing, and `Factory.build('user', { name: someVar })` with an unset
@@ -51,7 +53,7 @@ describe('normalised', () => {
   })
 })
 
-describe('withDefaults', () => {
+describe(withDefaults, () => {
   it('fills in the default for a property passed as undefined', () => {
     expect(withDefaults(User, { name: undefined }).name).toBe('Test User')
   })

--- a/backend/src/db/testing/fixtures.spec.ts
+++ b/backend/src/db/testing/fixtures.spec.ts
@@ -1,3 +1,5 @@
+import { beforeAll, afterAll, describe, it, expect } from 'vitest'
+
 import { cleanDatabase } from '@db/factories'
 import { getDriver } from '@db/neo4j'
 
@@ -47,6 +49,7 @@ describe('fixtures.first', () => {
 
   it('still matches when every condition holds', async () => {
     const user = await fixtures.first('User', { id: 'gone', deleted: true, name: 'Gone' })
+
     expect(user.get('id')).toBe('gone')
   })
 
@@ -79,6 +82,7 @@ describe('TestNode.update against a real node', () => {
     // properties — what is checked is the stored node with the patch applied.
     const node = await fixtures.first('User', { id: 'live' })
     await node.update({ deleted: true })
+
     expect(node.get('deleted')).toBe(true)
     expect(node.get('name')).toBe('Live')
   })
@@ -99,6 +103,7 @@ describe('TestNode.update against a real node', () => {
     )
     const node = await fixtures.first('User', { id: 'doomed' })
     await run(`MATCH (n:User {id: 'doomed'}) DETACH DELETE n`)
+
     await expect(node.update({ name: 'Renamed' })).rejects.toThrow('the node does not exist')
   })
 
@@ -115,6 +120,7 @@ describe('TestNode.update against a real node', () => {
     )
     const node = await fixtures.first('User', { id: 'arrow' })
     await run(`MATCH (n:User {id: 'arrow'}) DETACH DELETE n`)
+
     await expect(node.relateTo(node, alias)).rejects.toThrow(arrow)
   })
 
@@ -132,6 +138,7 @@ describe('TestNode.update against a real node', () => {
     )
     const a = await fixtures.first('User', { id: 'edge-a' })
     const b = await fixtures.first('User', { id: 'edge-b' })
+
     await expect(a.relateTo(b, 'following', { createdAtd: now })).rejects.toThrow(
       '[:FOLLOWS] declares no property createdAtd',
     )
@@ -146,6 +153,7 @@ describe('TestNode.update against a real node', () => {
     // written: the query stores the normalised patch, not the raw one.
     const node = await fixtures.first('User', { id: 'live' })
     await node.update({ slug: 'Peter Pan' })
+
     expect(node.get('slug')).toBe('peter-pan')
   })
 
@@ -155,6 +163,7 @@ describe('TestNode.update against a real node', () => {
     await run(`MATCH (n:User {id: 'gone'}) SET n.myRole = 'owner'`)
     const node = await fixtures.first('User', { id: 'gone' })
     await node.update({ name: 'Gone Away' })
+
     expect(node.get('name')).toBe('Gone Away')
     expect(node.get('myRole')).toBe('owner')
   })

--- a/backend/src/db/testing/fixtures.ts
+++ b/backend/src/db/testing/fixtures.ts
@@ -67,7 +67,7 @@ export interface FixtureApi {
    * tell a read from a write, and the caller that names the wrong door gets a failure — an
    * `ON CREATE SET` sent through a read transaction does not warn, it errors. Routing is the
    * only thing the split would buy, and it buys nothing here: this runs against a single
-   * instance in jest and in the Cypress support process, never against a cluster with read
+   * instance in the test runner and in the Cypress support process, never against a cluster with read
    * replicas.
    *
    * Where the distinction does matter, it is already made: `context.database` exposes `query`

--- a/backend/src/db/testing/node.spec.ts
+++ b/backend/src/db/testing/node.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { User } from '@db/schema/index'
 
 import { TestNode } from './node'
@@ -18,6 +20,7 @@ describe('TestNode.get', () => {
 
   it('keeps a stored falsy value distinguishable from an absent one', () => {
     const user = node({ deleted: false, about: null, name: '' })
+
     expect(user.get('deleted')).toBe(false)
     expect(user.get('about')).toBeNull()
     expect(user.get('name')).toBe('')
@@ -38,6 +41,7 @@ describe('TestNode.properties', () => {
     const user = node({ slug: 'peter-pan' })
     const copy = user.properties()
     copy.slug = 'someone-else'
+
     expect(user.get('slug')).toBe('peter-pan')
   })
 })

--- a/backend/src/emails/__snapshots__/sendChatMessageMail.spec.ts.snap
+++ b/backend/src/emails/__snapshots__/sendChatMessageMail.spec.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sendChatMessageMail English chat_message template 1`] = `
+exports[`sendChatMessageMail > English > chat_message template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -144,7 +144,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendChatMessageMail German chat_message template 1`] = `
+exports[`sendChatMessageMail > German > chat_message template 1`] = `
 {
   "attachments": [],
   "from": {

--- a/backend/src/emails/__snapshots__/sendEmailVerification.spec.ts.snap
+++ b/backend/src/emails/__snapshots__/sendEmailVerification.spec.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sendEmailVerification English renders correctly 1`] = `
+exports[`sendEmailVerification > English > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -147,7 +147,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendEmailVerification German renders correctly 1`] = `
+exports[`sendEmailVerification > German > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {

--- a/backend/src/emails/__snapshots__/sendNotificationMail.spec.ts.snap
+++ b/backend/src/emails/__snapshots__/sendNotificationMail.spec.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sendNotificationMail English changed_group_member_role template 1`] = `
+exports[`sendNotificationMail > English > changed_group_member_role template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -143,7 +143,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English commented_on_post template 1`] = `
+exports[`sendNotificationMail > English > commented_on_post template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -288,7 +288,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English followed_user_posted template 1`] = `
+exports[`sendNotificationMail > English > followed_user_posted template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -433,7 +433,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English mentioned_in_comment template 1`] = `
+exports[`sendNotificationMail > English > mentioned_in_comment template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -578,7 +578,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English mentioned_in_post template 1`] = `
+exports[`sendNotificationMail > English > mentioned_in_post template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -722,7 +722,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English post_in_group template 1`] = `
+exports[`sendNotificationMail > English > post_in_group template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -865,7 +865,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English removed_user_from_group template 1`] = `
+exports[`sendNotificationMail > English > removed_user_from_group template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -1005,7 +1005,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English user_joined_group template 1`] = `
+exports[`sendNotificationMail > English > user_joined_group template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -1149,7 +1149,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail English user_left_group template 1`] = `
+exports[`sendNotificationMail > English > user_left_group template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -1293,7 +1293,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German changed_group_member_role template 1`] = `
+exports[`sendNotificationMail > German > changed_group_member_role template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -1436,7 +1436,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German commented_on_post template 1`] = `
+exports[`sendNotificationMail > German > commented_on_post template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -1581,7 +1581,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German followed_user_posted template 1`] = `
+exports[`sendNotificationMail > German > followed_user_posted template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -1726,7 +1726,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German mentioned_in_comment template 1`] = `
+exports[`sendNotificationMail > German > mentioned_in_comment template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -1871,7 +1871,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German mentioned_in_post template 1`] = `
+exports[`sendNotificationMail > German > mentioned_in_post template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -2016,7 +2016,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German post_in_group template 1`] = `
+exports[`sendNotificationMail > German > post_in_group template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -2159,7 +2159,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German removed_user_from_group template 1`] = `
+exports[`sendNotificationMail > German > removed_user_from_group template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -2299,7 +2299,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German user_joined_group template 1`] = `
+exports[`sendNotificationMail > German > user_joined_group template 1`] = `
 {
   "attachments": [],
   "from": {
@@ -2443,7 +2443,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendNotificationMail German user_left_group template 1`] = `
+exports[`sendNotificationMail > German > user_left_group template 1`] = `
 {
   "attachments": [],
   "from": {

--- a/backend/src/emails/__snapshots__/sendRegistrationMail.spec.ts.snap
+++ b/backend/src/emails/__snapshots__/sendRegistrationMail.spec.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sendRegistrationMail with invite code English renders correctly 1`] = `
+exports[`sendRegistrationMail > with invite code > English > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -156,7 +156,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendRegistrationMail with invite code German renders correctly 1`] = `
+exports[`sendRegistrationMail > with invite code > German > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -313,7 +313,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendRegistrationMail without invite code English renders correctly 1`] = `
+exports[`sendRegistrationMail > without invite code > English > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -469,7 +469,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendRegistrationMail without invite code German renders correctly 1`] = `
+exports[`sendRegistrationMail > without invite code > German > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {

--- a/backend/src/emails/__snapshots__/sendResetPasswordMail.spec.ts.snap
+++ b/backend/src/emails/__snapshots__/sendResetPasswordMail.spec.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sendResetPasswordMail English renders correctly 1`] = `
+exports[`sendResetPasswordMail > English > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -146,7 +146,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendResetPasswordMail German renders correctly 1`] = `
+exports[`sendResetPasswordMail > German > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {

--- a/backend/src/emails/__snapshots__/sendWrongEmail.spec.ts.snap
+++ b/backend/src/emails/__snapshots__/sendWrongEmail.spec.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sendWrongEmail English renders correctly 1`] = `
+exports[`sendWrongEmail > English > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -144,7 +144,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendWrongEmail German renders correctly 1`] = `
+exports[`sendWrongEmail > German > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {

--- a/backend/src/emails/__snapshots__/supportLine.spec.ts.snap
+++ b/backend/src/emails/__snapshots__/supportLine.spec.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`sendResetPasswordMail with support English renders correctly 1`] = `
+exports[`sendResetPasswordMail > with support > English > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -146,7 +146,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendResetPasswordMail with support German renders correctly 1`] = `
+exports[`sendResetPasswordMail > with support > German > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -293,7 +293,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendResetPasswordMail without support English renders correctly 1`] = `
+exports[`sendResetPasswordMail > without support > English > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {
@@ -433,7 +433,7 @@ ocelot.social Community [https://ocelot.social]",
 }
 `;
 
-exports[`sendResetPasswordMail without support German renders correctly 1`] = `
+exports[`sendResetPasswordMail > without support > German > renders correctly 1`] = `
 {
   "attachments": [],
   "from": {

--- a/backend/src/emails/branding.spec.ts
+++ b/backend/src/emails/branding.spec.ts
@@ -7,6 +7,8 @@
 // combination can only arise when the two are read at DIFFERENT times — which is what a module-scope
 // read of `branding` does. Snapshot tests cannot catch it: they run unbranded, where the default IS
 // the expected value.
+import { describe, afterEach, beforeEach, it, expect } from 'vitest'
+
 import CONFIG from '@config/index'
 import { setBranding, brandingDefaults } from '@src/branding'
 
@@ -82,9 +84,11 @@ describe('branding in rendered mails', () => {
     const original = defaultParams.SUPPORT_EMAIL
 
     defaultParams.SUPPORT_EMAIL = 'support@example.org'
+
     expect(defaultParams.SUPPORT_EMAIL).toBe('support@example.org')
 
     delete defaultParams.SUPPORT_EMAIL
+
     expect(defaultParams.SUPPORT_EMAIL).toBeUndefined()
 
     defaultParams.SUPPORT_EMAIL = original

--- a/backend/src/emails/sendChatMessageMail.spec.ts
+++ b/backend/src/emails/sendChatMessageMail.spec.ts
@@ -1,3 +1,5 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import CONFIG from '@config/index'
 
 CONFIG.SUPPORT_EMAIL = 'devops@ocelot.social'

--- a/backend/src/emails/sendEmailVerification.spec.ts
+++ b/backend/src/emails/sendEmailVerification.spec.ts
@@ -1,3 +1,5 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import CONFIG from '@config/index'
 
 CONFIG.SUPPORT_EMAIL = 'devops@ocelot.social'

--- a/backend/src/emails/sendNotificationMail.spec.ts
+++ b/backend/src/emails/sendNotificationMail.spec.ts
@@ -1,3 +1,5 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import CONFIG from '@config/index'
 
 CONFIG.SUPPORT_EMAIL = 'devops@ocelot.social'

--- a/backend/src/emails/sendRegistrationMail.spec.ts
+++ b/backend/src/emails/sendRegistrationMail.spec.ts
@@ -1,3 +1,5 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import CONFIG from '@config/index'
 
 CONFIG.SUPPORT_EMAIL = 'devops@ocelot.social'

--- a/backend/src/emails/sendResetPasswordMail.spec.ts
+++ b/backend/src/emails/sendResetPasswordMail.spec.ts
@@ -1,3 +1,5 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import CONFIG from '@config/index'
 
 CONFIG.SUPPORT_EMAIL = 'devops@ocelot.social'

--- a/backend/src/emails/sendWrongEmail.spec.ts
+++ b/backend/src/emails/sendWrongEmail.spec.ts
@@ -1,3 +1,5 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import CONFIG from '@config/index'
 
 CONFIG.SUPPORT_EMAIL = 'devops@ocelot.social'

--- a/backend/src/emails/supportLine.spec.ts
+++ b/backend/src/emails/supportLine.spec.ts
@@ -1,6 +1,8 @@
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import { sendResetPasswordMail, defaultParams } from './sendEmail'
 
-describe('sendResetPasswordMail', () => {
+describe(sendResetPasswordMail, () => {
   const data: {
     email: string
     nonce: string

--- a/backend/src/jwt/decode.spec.ts
+++ b/backend/src/jwt/decode.spec.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable jest/expect-expect */
+/* eslint-disable vitest/expect-expect */
 /* eslint-disable @typescript-eslint/no-shadow */
 import { createHash } from 'node:crypto'
 import { setTimeout as delay } from 'node:timers/promises'
+
+import { beforeAll, afterAll, afterEach, describe, expect, beforeEach, it } from 'vitest'
 
 import Factory, { cleanDatabase } from '@db/factories'
 import { getDriver } from '@db/neo4j'
@@ -40,7 +42,7 @@ afterEach(async () => {
   await cleanDatabase()
 })
 
-describe('decode', () => {
+describe(decode, () => {
   let authorizationHeader: string | undefined | null
   const returnsNull = async () => {
     await expect(decode(context)(authorizationHeader)).resolves.toBeNull()
@@ -94,6 +96,7 @@ describe('decode', () => {
           return tx.run(`MATCH (k:ApiKey { id: 'ak1' }) RETURN k.lastUsedAt AS lastUsedAt`)
         })
         await session.close()
+
         expect(result.records[0].get('lastUsedAt')).toBeTruthy()
       })
     })
@@ -262,6 +265,7 @@ describe('decode', () => {
     describe('and corresponding user in the database', () => {
       let user
       let validAuthorizationHeader: string
+
       beforeEach(async () => {
         user = await Factory.build(
           'user',
@@ -292,9 +296,12 @@ describe('decode', () => {
 
       it('does not set `lastActiveAt`', async () => {
         let user = await neode.first('User', { id: 'u3' }, undefined)
+
         await expect(user.toJson()).resolves.not.toHaveProperty('lastActiveAt')
+
         await decode(context)(validAuthorizationHeader)
         user = await neode.first('User', { id: 'u3' }, undefined)
+
         await expect(user.toJson()).resolves.not.toHaveProperty('lastActiveAt')
       })
 
@@ -305,11 +312,14 @@ describe('decode', () => {
 
           lastActiveAt: '2019-10-03T23:33:08.598Z',
         })
+
         await expect(user.toJson()).resolves.toMatchObject({
           lastActiveAt: '2019-10-03T23:33:08.598Z',
         })
+
         await decode(context)(validAuthorizationHeader)
         user = await neode.first('User', { id: 'u3' }, undefined)
+
         await expect(user.toJson()).resolves.toMatchObject({
           lastActiveAt: '2019-10-03T23:33:08.598Z',
         })

--- a/backend/src/jwt/encode.spec.ts
+++ b/backend/src/jwt/encode.spec.ts
@@ -4,6 +4,7 @@
    Reaching through the default import is the only form that works at runtime. */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import jwt from 'jsonwebtoken'
+import { describe, beforeEach, it, expect } from 'vitest'
 
 import { TEST_CONFIG } from '@root/test/helpers'
 
@@ -17,8 +18,9 @@ const config = {
 }
 const context = { config }
 
-describe('encode', () => {
+describe(encode, () => {
   let payload
+
   beforeEach(() => {
     payload = {
       name: 'Some body',
@@ -29,8 +31,11 @@ describe('encode', () => {
 
   it('encodes a valided JWT bearer token', () => {
     const token = encode(context)(payload)
+
     expect(token.split('.')).toHaveLength(3)
+
     const decoded = jwt.verify(token, context.config.JWT_SECRET)
+
     expect(decoded).toEqual({
       name: 'Some body',
       slug: 'some-body',
@@ -54,6 +59,7 @@ describe('encode', () => {
 
     it('does not encode sensitive data', () => {
       const token = encode(context)(payload)
+
       expect(payload).toEqual({
         email: 'none-of-your-business@example.org',
         password: 'topsecret',
@@ -61,7 +67,9 @@ describe('encode', () => {
         slug: 'some-body',
         id: 'some-id',
       })
+
       const decoded = jwt.verify(token, context.config.JWT_SECRET)
+
       expect(decoded).toEqual({
         name: 'Some body',
         slug: 'some-body',

--- a/backend/src/livekit/poller.spec.ts
+++ b/backend/src/livekit/poller.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import { jest } from '@jest/globals'
+import { beforeEach, afterEach, describe, it, expect } from 'vitest'
 
 const mockConfig: {
   LIVEKIT_ENABLED: boolean
@@ -9,11 +9,14 @@ const mockConfig: {
   LIVEKIT_API_SECRET?: string
 } = { LIVEKIT_ENABLED: false }
 
-const mockListRooms = jest.fn<(...args: unknown[]) => Promise<unknown>>()
-const mockRoomServiceCtor = jest.fn()
+const mockListRooms = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const mockRoomServiceCtor = vi.fn()
 
-jest.unstable_mockModule('livekit-server-sdk', () => ({
-  RoomServiceClient: jest.fn().mockImplementation((...args: unknown[]) => {
+// `function`, not an arrow: this stands in for a CLASS and the code under test calls it with
+// `new`. Vitest constructs the mock's implementation via Reflect.construct, and an arrow is
+// not a constructor — Jest applied the implementation instead, so arrows worked there.
+vi.mock('livekit-server-sdk', () => ({
+  RoomServiceClient: vi.fn().mockImplementation(function (...args: unknown[]) {
     mockRoomServiceCtor(...args)
     return {
       listRooms: (...inner: unknown[]): unknown => mockListRooms(...inner),
@@ -21,46 +24,46 @@ jest.unstable_mockModule('livekit-server-sdk', () => ({
   }),
 }))
 
-const mockPublish = jest.fn<(...args: unknown[]) => Promise<unknown>>()
-jest.unstable_mockModule('@src/context', () => ({
+const mockPublish = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+vi.mock('@src/context', () => ({
   __esModule: true,
   serverPubsub: {
     publish: (...args: unknown[]): unknown => mockPublish(...args),
   },
 }))
 
-jest.unstable_mockModule('@src/graphql/resolvers/videoCalls', () => ({
+vi.mock('@src/graphql/resolvers/videoCalls', () => ({
   __esModule: true,
   groupIdFromRoomName: (roomName: string | null | undefined): string | null =>
     roomName?.startsWith('group-') ? roomName.slice('group-'.length) : null,
 }))
 
 const mockLogger = {
-  info: jest.fn<(...args: unknown[]) => void>(),
-  warn: jest.fn<(...args: unknown[]) => void>(),
-  error: jest.fn<(...args: unknown[]) => void>(),
+  info: vi.fn<(...args: unknown[]) => void>(),
+  warn: vi.fn<(...args: unknown[]) => void>(),
+  error: vi.fn<(...args: unknown[]) => void>(),
 }
-// jest.mock factories are hoisted above the const/let declarations they
+// vi.mock factories are hoisted above the const/let declarations they
 // reference, so `default: mockLogger` / `default: mockConfig` would read a
 // TDZ-locked binding when poller.ts is required. Expose them through getters
 // so the binding is only read when the consuming code actually touches the
 // imported default — by which time the test file has finished initializing.
-jest.unstable_mockModule('@src/logger', () => ({
+vi.mock('@src/logger', () => ({
   __esModule: true,
   get default() {
     return mockLogger
   },
 }))
 
-jest.unstable_mockModule('@src/config', () => ({
+vi.mock('@src/config', () => ({
   __esModule: true,
   get default() {
     return mockConfig
   },
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { startLiveKitPoller, stopLiveKitPoller } = await import('./poller')
 
 const setEnabled = () => {
@@ -71,7 +74,7 @@ const setEnabled = () => {
 }
 
 beforeEach(() => {
-  jest.useFakeTimers()
+  vi.useFakeTimers()
   mockConfig.LIVEKIT_ENABLED = false
   mockConfig.LIVEKIT_URL = undefined
   mockConfig.LIVEKIT_API_KEY = undefined
@@ -86,12 +89,13 @@ beforeEach(() => {
 
 afterEach(() => {
   stopLiveKitPoller()
-  jest.useRealTimers()
+  vi.useRealTimers()
 })
 
 describe('startLiveKitPoller', () => {
   it('does nothing when LiveKit is disabled', () => {
     startLiveKitPoller()
+
     expect(mockRoomServiceCtor).not.toHaveBeenCalled()
     expect(mockLogger.info).not.toHaveBeenCalled()
   })
@@ -101,12 +105,14 @@ describe('startLiveKitPoller', () => {
     mockConfig.LIVEKIT_URL = 'wss://lk.example.test'
     // missing key/secret
     startLiveKitPoller()
+
     expect(mockRoomServiceCtor).not.toHaveBeenCalled()
   })
 
   it('creates a RoomServiceClient with http url and starts the timers', () => {
     setEnabled()
     startLiveKitPoller()
+
     expect(mockRoomServiceCtor).toHaveBeenCalledWith('https://lk.example.test', 'key', 'secret')
     expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('LiveKit poller starting'))
   })
@@ -115,6 +121,7 @@ describe('startLiveKitPoller', () => {
     setEnabled()
     startLiveKitPoller()
     startLiveKitPoller()
+
     expect(mockRoomServiceCtor).toHaveBeenCalledTimes(1)
   })
 
@@ -124,6 +131,7 @@ describe('startLiveKitPoller', () => {
     mockConfig.LIVEKIT_API_KEY = 'k'
     mockConfig.LIVEKIT_API_SECRET = 's'
     startLiveKitPoller()
+
     expect(mockRoomServiceCtor).toHaveBeenCalledWith('http://plain.test', 'k', 's')
   })
 
@@ -133,6 +141,7 @@ describe('startLiveKitPoller', () => {
     mockConfig.LIVEKIT_API_KEY = 'k'
     mockConfig.LIVEKIT_API_SECRET = 's'
     startLiveKitPoller()
+
     expect(mockRoomServiceCtor).toHaveBeenCalledWith('https://already.test', 'k', 's')
   })
 })
@@ -149,7 +158,7 @@ describe('poll tick', () => {
       { name: 'other', numParticipants: 5 },
     ])
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
 
     expect(mockListRooms).toHaveBeenCalledTimes(1)
     expect(mockPublish).toHaveBeenCalledWith('VIDEO_CALL_PARTICIPANT_COUNT_CHANGED', {
@@ -171,18 +180,20 @@ describe('poll tick', () => {
       { name: 'group-a', numParticipants: 2 },
       { name: 'group-b', numParticipants: 0 },
     ])
-    await jest.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
+
     expect(mockPublish).not.toHaveBeenCalled()
   })
 
   it('publishes count: 0 for rooms that disappeared from the list', async () => {
     mockListRooms.mockResolvedValueOnce([{ name: 'group-a', numParticipants: 3 }])
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
     mockPublish.mockClear()
 
     mockListRooms.mockResolvedValueOnce([])
-    await jest.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
+
     expect(mockPublish).toHaveBeenCalledWith('VIDEO_CALL_PARTICIPANT_COUNT_CHANGED', {
       groupId: 'a',
       count: 0,
@@ -191,25 +202,28 @@ describe('poll tick', () => {
     // Third tick: the disappeared entry has been pruned, no further publish
     mockPublish.mockClear()
     mockListRooms.mockResolvedValueOnce([])
-    await jest.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
+
     expect(mockPublish).not.toHaveBeenCalled()
   })
 
   it('does not emit a duplicate zero when the disappeared room was already at 0', async () => {
     mockListRooms.mockResolvedValueOnce([{ name: 'group-a', numParticipants: 0 }])
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
     mockPublish.mockClear()
 
     mockListRooms.mockResolvedValueOnce([])
-    await jest.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
+
     expect(mockPublish).not.toHaveBeenCalled()
   })
 
   it('coerces undefined numParticipants to 0', async () => {
     mockListRooms.mockResolvedValueOnce([{ name: 'group-a' }])
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+
     expect(mockPublish).toHaveBeenCalledWith('VIDEO_CALL_PARTICIPANT_COUNT_CHANGED', {
       groupId: 'a',
       count: 0,
@@ -219,10 +233,11 @@ describe('poll tick', () => {
   it('warns on listRooms failures and goes quiet after 3 consecutive errors', async () => {
     mockListRooms.mockRejectedValue(new Error('lk unreachable'))
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
-    await jest.advanceTimersByTimeAsync(15_000)
-    await jest.advanceTimersByTimeAsync(15_000)
-    await jest.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
+
     expect(mockListRooms).toHaveBeenCalledTimes(4)
     // First 3 failures logged, 4th suppressed
     expect(mockLogger.warn).toHaveBeenCalledTimes(3)
@@ -231,18 +246,20 @@ describe('poll tick', () => {
   it('resets the failure counter once a poll succeeds again', async () => {
     mockListRooms.mockRejectedValueOnce(new Error('boom1'))
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+
     expect(mockLogger.warn).toHaveBeenCalledTimes(1)
     expect(mockLogger.warn.mock.calls[0][0]).toContain('#1')
 
     mockListRooms.mockResolvedValueOnce([])
-    await jest.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
 
     mockListRooms.mockRejectedValueOnce(new Error('boom2'))
-    await jest.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(15_000)
     // Should be back to "#1" after the success reset
     const calls = mockLogger.warn.mock.calls
     const lastWarn = calls[calls.length - 1]
+
     expect(lastWarn[0]).toContain('#1')
   })
 
@@ -251,7 +268,8 @@ describe('poll tick', () => {
     mockListRooms.mockResolvedValueOnce([{ name: 'group-a', numParticipants: 1 }])
     mockPublish.mockRejectedValueOnce(new Error('pubsub down'))
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+
     expect(mockLogger.warn).toHaveBeenCalledWith('LiveKit poll tick failed:', 'pubsub down')
   })
 })
@@ -261,17 +279,19 @@ describe('stopLiveKitPoller', () => {
     setEnabled()
     startLiveKitPoller()
     stopLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+
     expect(mockListRooms).not.toHaveBeenCalled()
   })
 
   it('cancels the recurring interval', async () => {
     setEnabled()
     startLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(5_000)
     mockListRooms.mockClear()
     stopLiveKitPoller()
-    await jest.advanceTimersByTimeAsync(60_000)
+    await vi.advanceTimersByTimeAsync(60_000)
+
     expect(mockListRooms).not.toHaveBeenCalled()
   })
 
@@ -281,3 +301,6 @@ describe('stopLiveKitPoller', () => {
     }).not.toThrow()
   })
 })
+
+// No imports left after the vitest switch — without this the file is a script, not a
+// module: its top-level consts would collide across specs and `await` would be illegal.

--- a/backend/src/livekit/utils.spec.ts
+++ b/backend/src/livekit/utils.spec.ts
@@ -1,10 +1,11 @@
-import { jest } from '@jest/globals'
+import { describe, it, expect } from 'vitest'
 
 import { withTimeout } from './utils'
 
-describe('withTimeout', () => {
+describe(withTimeout, () => {
   it('resolves with the inner promise value when it settles before the timeout', async () => {
     const value = await withTimeout(Promise.resolve(42), 1000, 'fast')
+
     expect(value).toBe(42)
   })
 
@@ -18,18 +19,22 @@ describe('withTimeout', () => {
         timer.unref()
       }
     })
+
     await expect(withTimeout(slow, 20, 'slow')).rejects.toThrow('slow timed out after 20ms')
   })
 
   it('clears the timeout handle on fast resolution', async () => {
-    const setSpy = jest.spyOn(global, 'setTimeout')
-    const clearSpy = jest.spyOn(global, 'clearTimeout')
+    const setSpy = vi.spyOn(global, 'setTimeout')
+    const clearSpy = vi.spyOn(global, 'clearTimeout')
     try {
       const value = await withTimeout(Promise.resolve('done'), 60_000, 'fast')
+
       expect(value).toBe('done')
+
       const ourTimer = setSpy.mock.results[setSpy.mock.results.length - 1].value as ReturnType<
         typeof setTimeout
       >
+
       expect(clearSpy).toHaveBeenCalledWith(ourTimer)
     } finally {
       setSpy.mockRestore()
@@ -38,15 +43,17 @@ describe('withTimeout', () => {
   })
 
   it('clears the timeout handle on fast rejection', async () => {
-    const setSpy = jest.spyOn(global, 'setTimeout')
-    const clearSpy = jest.spyOn(global, 'clearTimeout')
+    const setSpy = vi.spyOn(global, 'setTimeout')
+    const clearSpy = vi.spyOn(global, 'clearTimeout')
     try {
       await expect(withTimeout(Promise.reject(new Error('boom')), 60_000, 'fast')).rejects.toThrow(
         'boom',
       )
+
       const ourTimer = setSpy.mock.results[setSpy.mock.results.length - 1].value as ReturnType<
         typeof setTimeout
       >
+
       expect(clearSpy).toHaveBeenCalledWith(ourTimer)
     } finally {
       setSpy.mockRestore()

--- a/backend/src/livekit/webhook.spec.ts
+++ b/backend/src/livekit/webhook.spec.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { jest } from '@jest/globals'
+import { beforeEach, describe, it, expect } from 'vitest'
 
 const mockConfig: {
   LIVEKIT_ENABLED: boolean
@@ -13,60 +13,63 @@ const mockConfig: {
   LIVEKIT_API_SECRET?: string
 } = { LIVEKIT_ENABLED: false }
 
-const mockReceive = jest.fn<(...args: unknown[]) => Promise<unknown>>()
-const mockWebhookReceiverCtor = jest.fn()
+const mockReceive = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const mockWebhookReceiverCtor = vi.fn()
 
-jest.unstable_mockModule('livekit-server-sdk', () => ({
-  WebhookReceiver: jest.fn().mockImplementation((...args: unknown[]) => {
+// `function`, not an arrow: this stands in for a CLASS and the code under test calls it with
+// `new`. Vitest constructs the mock's implementation via Reflect.construct, and an arrow is
+// not a constructor — Jest applied the implementation instead, so arrows worked there.
+vi.mock('livekit-server-sdk', () => ({
+  WebhookReceiver: vi.fn().mockImplementation(function (...args: unknown[]) {
     mockWebhookReceiverCtor(...args)
     return { receive: async (...inner: unknown[]) => mockReceive(...inner) }
   }),
 }))
 
-const mockPublish = jest.fn()
-jest.unstable_mockModule('@src/context', () => ({
+const mockPublish = vi.fn()
+vi.mock('@src/context', () => ({
   __esModule: true,
   serverPubsub: { publish: (...args: unknown[]) => mockPublish(...args) },
 }))
 
-const mockGetCount = jest.fn<(...args: unknown[]) => Promise<unknown>>()
-jest.unstable_mockModule('@src/graphql/resolvers/videoCalls', () => ({
+const mockGetCount = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+vi.mock('@src/graphql/resolvers/videoCalls', () => ({
   __esModule: true,
   getLiveParticipantCount: async (...args: unknown[]) => mockGetCount(...args),
   groupIdFromRoomName: (roomName: string | null | undefined): string | null =>
     roomName?.startsWith('group-') ? roomName.slice('group-'.length) : null,
 }))
 
-const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
-// jest.mock factories are hoisted above the const/let declarations they
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+// vi.mock factories are hoisted above the const/let declarations they
 // reference, so `default: mockLogger` / `default: mockConfig` would read a
 // TDZ-locked binding when webhook.ts is required. Expose them through
 // getters so the binding is only read when the consuming code actually
 // touches the imported default — by which time the test file has finished
 // initializing.
-jest.unstable_mockModule('@src/logger', () => ({
+vi.mock('@src/logger', () => ({
   __esModule: true,
   get default() {
     return mockLogger
   },
 }))
 
-jest.unstable_mockModule('@src/config', () => ({
+vi.mock('@src/config', () => ({
   __esModule: true,
   get default() {
     return mockConfig
   },
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { registerLiveKitWebhook } = await import('./webhook')
 
 type CapturedHandler = (req: any, res: any) => void
 
 function makeApp() {
   const handlers: { path: string; handler: CapturedHandler }[] = []
-  const post = jest.fn((path: string, _parser: unknown, handler: CapturedHandler) => {
+  const post = vi.fn((path: string, _parser: unknown, handler: CapturedHandler) => {
     handlers.push({ path, handler })
   })
   return { post, handlers }
@@ -74,15 +77,17 @@ function makeApp() {
 
 function makeRes() {
   const res: any = { headersSent: false }
-  res.status = jest.fn(() => res)
-  res.send = jest.fn(() => res)
-  res.end = jest.fn(() => res)
+  // Direct assignment, not vi.spyOn: the fake starts out with `headersSent` only, so there is no
+  // status/send/end to intercept — these have to be created.
+  res.status = vi.fn(() => res)
+  res.send = vi.fn(() => res)
+  res.end = vi.fn(() => res)
   return res
 }
 
 function makeReq(opts: { authHeader?: string; body?: Buffer | string }) {
   return {
-    get: jest.fn((name: string) => (name === 'Authorization' ? opts.authHeader : undefined)),
+    get: vi.fn((name: string) => (name === 'Authorization' ? opts.authHeader : undefined)),
     body: opts.body,
   }
 }
@@ -113,7 +118,7 @@ beforeEach(() => {
   mockConfig.LIVEKIT_API_SECRET = undefined
   mockReceive.mockReset()
   mockWebhookReceiverCtor.mockReset()
-  mockPublish.mockReset().mockImplementation(async () => Promise.resolve(undefined))
+  mockPublish.mockReset().mockResolvedValue(undefined)
   mockGetCount.mockReset().mockResolvedValue(0)
   mockLogger.info.mockReset()
   mockLogger.warn.mockReset()
@@ -123,6 +128,7 @@ beforeEach(() => {
 describe('registerLiveKitWebhook', () => {
   it('does nothing when LiveKit is disabled', () => {
     const { app } = registerAndCapture()
+
     expect(app.post).not.toHaveBeenCalled()
     expect(mockLogger.info).not.toHaveBeenCalled()
   })
@@ -132,12 +138,14 @@ describe('registerLiveKitWebhook', () => {
     mockConfig.LIVEKIT_URL = 'wss://lk.example.test'
     // missing API key/secret
     const { app } = registerAndCapture()
+
     expect(app.post).not.toHaveBeenCalled()
   })
 
   it('registers the webhook route once LiveKit is configured', () => {
     setEnabledConfig()
     const { app } = registerAndCapture()
+
     expect(app.post).toHaveBeenCalledTimes(1)
     expect(app.post.mock.calls[0][0]).toBe('/livekit/webhook')
     expect(mockWebhookReceiverCtor).toHaveBeenCalledWith('key', 'secret')
@@ -146,6 +154,7 @@ describe('registerLiveKitWebhook', () => {
 
   describe('webhook handler', () => {
     let handler: CapturedHandler
+
     beforeEach(() => {
       setEnabledConfig()
       handler = registerAndCapture().handler
@@ -156,6 +165,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(res.status).toHaveBeenCalledWith(401)
       expect(res.send).toHaveBeenCalledWith('Missing Authorization header')
       expect(mockReceive).not.toHaveBeenCalled()
@@ -166,6 +176,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(res.status).toHaveBeenCalledWith(400)
       expect(res.send).toHaveBeenCalledWith('Missing body')
     })
@@ -176,6 +187,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(res.status).toHaveBeenCalledWith(401)
       expect(res.send).toHaveBeenCalledWith('Invalid signature')
       expect(mockLogger.warn).toHaveBeenCalled()
@@ -190,6 +202,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(res.status).toHaveBeenCalledWith(204)
       expect(res.end).toHaveBeenCalled()
       expect(mockPublish).not.toHaveBeenCalled()
@@ -201,6 +214,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(res.status).toHaveBeenCalledWith(204)
       expect(mockPublish).not.toHaveBeenCalled()
     })
@@ -215,6 +229,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(mockGetCount).toHaveBeenCalledWith(
         {
           LIVEKIT_URL: 'wss://lk.example.test',
@@ -242,6 +257,7 @@ describe('registerLiveKitWebhook', () => {
         const res = makeRes()
         handler(req, res)
         await flushPromises()
+
         expect(mockPublish).toHaveBeenCalledWith('VIDEO_CALL_PARTICIPANT_COUNT_CHANGED', {
           groupId: 'xyz',
           count: 1,
@@ -258,6 +274,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(mockGetCount).not.toHaveBeenCalled()
       expect(mockPublish).toHaveBeenCalledWith('VIDEO_CALL_PARTICIPANT_COUNT_CHANGED', {
         groupId: 'finished',
@@ -275,6 +292,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(mockPublish).not.toHaveBeenCalled()
       expect(mockGetCount).not.toHaveBeenCalled()
       expect(res.status).toHaveBeenCalledWith(204)
@@ -290,6 +308,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to publish'),
         expect.any(Error),
@@ -299,7 +318,7 @@ describe('registerLiveKitWebhook', () => {
 
     it('returns 500 when the handler hits an unexpected error', async () => {
       const req: any = {
-        get: jest.fn(() => {
+        get: vi.fn(() => {
           throw new Error('unexpected')
         }),
         body: Buffer.from('p'),
@@ -307,6 +326,7 @@ describe('registerLiveKitWebhook', () => {
       const res = makeRes()
       handler(req, res)
       await flushPromises()
+
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected LiveKit webhook handler error'),
         expect.any(Error),
@@ -317,7 +337,7 @@ describe('registerLiveKitWebhook', () => {
 
     it('does not write a second response when headers were already sent', async () => {
       const req: any = {
-        get: jest.fn(() => {
+        get: vi.fn(() => {
           throw new Error('unexpected')
         }),
         body: Buffer.from('p'),
@@ -326,8 +346,12 @@ describe('registerLiveKitWebhook', () => {
       res.headersSent = true
       handler(req, res)
       await flushPromises()
+
       expect(res.status).not.toHaveBeenCalled()
       expect(mockLogger.error).toHaveBeenCalled()
     })
   })
 })
+
+// No imports left after the vitest switch — without this the file is a script, not a
+// module: its top-level consts would collide across specs and `await` would be illegal.

--- a/backend/src/middleware/categories.spec.ts
+++ b/backend/src/middleware/categories.spec.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+import { beforeEach, beforeAll, afterAll, describe, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import Category from '@graphql/queries/Category.gql'
 import { createApolloTestSetup } from '@root/test/helpers'

--- a/backend/src/middleware/hashtags/extractHashtags.spec.ts
+++ b/backend/src/middleware/hashtags/extractHashtags.spec.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { describe, it, expect } from 'vitest'
+
 import extractHashtags from './extractHashtags'
 
-describe('extractHashtags', () => {
+describe(extractHashtags, () => {
   describe('content undefined', () => {
     it('returns empty array', () => {
       expect(extractHashtags()).toEqual([])
@@ -28,12 +30,14 @@ describe('extractHashtags', () => {
           </a>
         </p>
       `
+
       expect(extractHashtags(content)).toEqual(['Elections', 'Democracy'])
     })
 
     it('ignores mentions', () => {
       const content =
         '<p>Something inspirational about <a href="/profile/u2" target="_blank">@bob-der-baumeister</a> and <a href="/profile/u3/jenny-rostock" class="mention" target="_blank">@jenny-rostock</a>.</p>'
+
       expect(extractHashtags(content)).toEqual([])
     })
 
@@ -83,6 +87,7 @@ describe('extractHashtags', () => {
         </a>.
       </p>
       `
+
       expect(extractHashtags(content).sort()).toEqual([
         '0123456789a',
         'AbcDefXyz0123456789',
@@ -94,18 +99,21 @@ describe('extractHashtags', () => {
       it('`href` contains no Hashtag name', () => {
         const content =
           '<p>Something inspirational about <a href="/search/hashtag/" target="_blank">#Democracy</a> and <a href="/search/hashtag" target="_blank">#liberty</a>.</p>'
+
         expect(extractHashtags(content)).toEqual([])
       })
 
       it('`href` contains Hashtag as page anchor', () => {
         const content =
           '<p>Something inspirational about <a href="https://www.example.org/#anchor" target="_blank">#anchor</a>.</p>'
+
         expect(extractHashtags(content)).toEqual([])
       })
 
       it('`href` is empty or invalid', () => {
         const content =
           '<p>Something inspirational about <a href="" class="hashtag" target="_blank">@bob-der-baumeister</a> and <a href="not-a-url" target="_blank">@jenny-rostock</a>.</p>'
+
         expect(extractHashtags(content)).toEqual([])
       })
     })

--- a/backend/src/middleware/hashtags/hashtagsMiddleware.spec.ts
+++ b/backend/src/middleware/hashtags/hashtagsMiddleware.spec.ts
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-shadow */
+import { beforeAll, afterAll, beforeEach, afterEach, describe, it, expect } from 'vitest'
+
 import { cleanDatabase } from '@db/factories'
 import CreatePost from '@graphql/queries/posts/CreatePost.gql'
 import Post from '@graphql/queries/posts/Post.gql'

--- a/backend/src/middleware/helpers/isUserOnline.spec.ts
+++ b/backend/src/middleware/helpers/isUserOnline.spec.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { describe, beforeEach, it, expect } from 'vitest'
+
 import { isUserOnline } from './isUserOnline'
 
 let user
 
-describe('isUserOnline', () => {
+describe(isUserOnline, () => {
   beforeEach(() => {
     user = {
       lastActiveAt: null,
@@ -11,15 +13,19 @@ describe('isUserOnline', () => {
       lastOnlineStatus: null,
     }
   })
+
   describe('user has lastOnlineStatus `online`', () => {
     it('returns true if he was active within the last 90 seconds', () => {
       user.lastOnlineStatus = 'online'
       user.lastActiveAt = new Date()
+
       expect(isUserOnline(user)).toBe(true)
     })
+
     it('returns false if he was not active within the last 90 seconds', () => {
       user.lastOnlineStatus = 'online'
       user.lastActiveAt = new Date().getTime() - 90001
+
       expect(isUserOnline(user)).toBe(false)
     })
   })
@@ -28,11 +34,14 @@ describe('isUserOnline', () => {
     it('returns true if he went away less then 180 seconds ago', () => {
       user.lastOnlineStatus = 'away'
       user.awaySince = new Date()
+
       expect(isUserOnline(user)).toBe(true)
     })
+
     it('returns false if he went away more then 180 seconds ago', () => {
       user.lastOnlineStatus = 'away'
       user.awaySince = new Date().getTime() - 180001
+
       expect(isUserOnline(user)).toBe(false)
     })
   })

--- a/backend/src/middleware/index.spec.ts
+++ b/backend/src/middleware/index.spec.ts
@@ -1,7 +1,16 @@
-// Unit tests for addMiddleware – testing append, prepend, before, after, and error cases.
-// Each test uses jest.isolateModules + jest.doMock to get a fresh ocelotMiddlewares array.
+import { beforeEach, describe, it, expect } from 'vitest'
 
-import { jest } from '@jest/globals'
+import type { Mock } from 'vitest'
+
+// vitest has no `isolateModulesAsync`: resetting the registry before the dynamic import does the
+// same job, since a module graph is only shared within a file. Wrapped so the call sites keep
+// reading as "load this in isolation".
+const isolateModules = async (run: () => Promise<void>): Promise<void> => {
+  vi.resetModules()
+  await run()
+}
+// Unit tests for addMiddleware – testing append, prepend, before, after, and error cases.
+// Each test uses the isolateModules helper + vi.doMock to get a fresh ocelotMiddlewares array.
 
 interface MiddlewareModule {
   addMiddleware: (mw: { name: string; middleware: unknown; position: unknown }) => void
@@ -32,17 +41,17 @@ const middlewareModules = [
 ]
 
 const setupMocks = ({ extraMocks, disabledMiddlewares = [] }: MockOptions = {}) => {
-  jest.unstable_mockModule('./branding/brandingMiddlewares', () => ({ default: jest.fn() }))
+  vi.doMock('./branding/brandingMiddlewares', () => ({ default: vi.fn() }))
   // ESM mock factories must expose `default` themselves — there is no CommonJS interop layer
   // to synthesise one from the object.
-  jest.unstable_mockModule('@config/index', () => ({
+  vi.doMock('@config/index', () => ({
     default: { DISABLED_MIDDLEWARES: disabledMiddlewares },
   }))
 
   // Mock all middlewares and allow to override its mock
   for (const mod of middlewareModules) {
     // eslint-disable-next-line security/detect-object-injection
-    jest.unstable_mockModule(mod, () => ({ default: extraMocks?.[mod] ?? {} }))
+    vi.doMock(mod, () => ({ default: extraMocks?.[mod] ?? {} }))
   }
 }
 
@@ -51,11 +60,11 @@ const loadModule = async (
 ): Promise<{ mod: MiddlewareModule; getCapturedMiddlewares: () => unknown[] }> => {
   // The registry must be dropped BEFORE registering: an already-instantiated ./applyMiddleware
   // keeps the previous factory's closure, and this run's capturedArgs would never be written.
-  jest.resetModules()
+  vi.resetModules()
   let capturedArgs: unknown[] = []
   // ./applyMiddleware, not the package: graphql-middleware is reached through createRequire
-  // there (see that file), which bypasses Jest's registry entirely.
-  jest.unstable_mockModule('./applyMiddleware', () => ({
+  // there (see that file), which bypasses the runner's registry entirely.
+  vi.doMock('./applyMiddleware', () => ({
     applyMiddleware: (_schema: unknown, ...middlewares: unknown[]) => {
       capturedArgs = middlewares
       return _schema
@@ -73,34 +82,36 @@ const loadModule = async (
   }
 }
 
-// Under ESM the mock instances produced by an unstable_mockModule factory survive
-// isolateModulesAsync — only the module registry is isolated, not the mocks — so call counts
+// The mock instances produced by a `vi.mock` factory survive the registry reset in
+// isolateModules — only the module registry is isolated, not the mocks — so call counts
 // would otherwise accumulate across tests.
 beforeEach(() => {
-  jest.clearAllMocks()
+  vi.clearAllMocks()
 })
 
 describe('default', () => {
   it('registers the 15 default middlewares', async () => {
-    await jest.isolateModulesAsync(async () => {
+    await isolateModules(async () => {
       const { getCapturedMiddlewares } = await loadModule()
+
       expect(getCapturedMiddlewares()).toHaveLength(15)
     })
   })
 
   it('calls brandingMiddlewares', async () => {
-    await jest.isolateModulesAsync(async () => {
+    await isolateModules(async () => {
       const { mod } = await loadModule()
 
       const { default: brandingMiddlewares } =
-        (await import('./branding/brandingMiddlewares')) as unknown as { default: jest.Mock }
+        (await import('./branding/brandingMiddlewares')) as unknown as { default: Mock }
       mod.default({})
+
       expect(brandingMiddlewares).toHaveBeenCalledTimes(1)
     })
   })
 
   it('filters out disabled middlewares', async () => {
-    await jest.isolateModulesAsync(async () => {
+    await isolateModules(async () => {
       const sentryMarker = { __test: 'sentry' }
       const xssMarker = { __test: 'xss' }
       const { getCapturedMiddlewares } = await loadModule({
@@ -110,12 +121,14 @@ describe('default', () => {
         },
         disabledMiddlewares: ['sentry', 'xss'],
       })
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const middlewares = getCapturedMiddlewares()
+
       expect(middlewares).toHaveLength(13)
       expect(middlewares).not.toContain(sentryMarker)
       expect(middlewares).not.toContain(xssMarker)
       expect(consoleSpy).toHaveBeenCalledWith('Warning: Disabled "sentry, xss" middleware.')
+
       consoleSpy.mockRestore()
     })
   })
@@ -124,11 +137,12 @@ describe('default', () => {
 describe('addMiddleware', () => {
   describe('append', () => {
     it('adds middleware at the end', async () => {
-      await jest.isolateModulesAsync(async () => {
+      await isolateModules(async () => {
         const { mod, getCapturedMiddlewares } = await loadModule()
         const m = { __test: 'appended' }
         mod.addMiddleware({ name: 'test-append', middleware: m, position: 'append' })
         const middlewares = getCapturedMiddlewares()
+
         expect(middlewares).toHaveLength(16)
         expect(middlewares[15]).toBe(m)
       })
@@ -137,11 +151,12 @@ describe('addMiddleware', () => {
 
   describe('prepend', () => {
     it('adds middleware at the beginning', async () => {
-      await jest.isolateModulesAsync(async () => {
+      await isolateModules(async () => {
         const { mod, getCapturedMiddlewares } = await loadModule()
         const m = { __test: 'prepended' }
         mod.addMiddleware({ name: 'test-prepend', middleware: m, position: 'prepend' })
         const middlewares = getCapturedMiddlewares()
+
         expect(middlewares).toHaveLength(16)
         expect(middlewares[0]).toBe(m)
       })
@@ -150,7 +165,7 @@ describe('addMiddleware', () => {
 
   describe('before', () => {
     it('inserts middleware directly before the named anchor', async () => {
-      await jest.isolateModulesAsync(async () => {
+      await isolateModules(async () => {
         const sentryMarker = { __test: 'sentry' }
         const permissionsMarker = { __test: 'permissions' }
         const { mod, getCapturedMiddlewares } = await loadModule({
@@ -180,7 +195,7 @@ describe('addMiddleware', () => {
 
   describe('after', () => {
     it('inserts middleware directly after the named anchor', async () => {
-      await jest.isolateModulesAsync(async () => {
+      await isolateModules(async () => {
         const sentryMarker = { __test: 'sentry' }
         const permissionsMarker = { __test: 'permissions' }
         const { mod, getCapturedMiddlewares } = await loadModule({
@@ -210,8 +225,9 @@ describe('addMiddleware', () => {
 
   describe('unknown anchor', () => {
     it('throws when "before" anchor does not exist', async () => {
-      await jest.isolateModulesAsync(async () => {
+      await isolateModules(async () => {
         const { mod } = await loadModule()
+
         expect(() => {
           mod.addMiddleware({
             name: 'failure',
@@ -223,8 +239,9 @@ describe('addMiddleware', () => {
     })
 
     it('throws when "after" anchor does not exist', async () => {
-      await jest.isolateModulesAsync(async () => {
+      await isolateModules(async () => {
         const { mod } = await loadModule()
+
         expect(() => {
           mod.addMiddleware({
             name: 'failure',

--- a/backend/src/middleware/languages/languages.spec.ts
+++ b/backend/src/middleware/languages/languages.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { beforeAll, afterAll, describe, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import CreatePost from '@graphql/queries/posts/CreatePost.gql'
 import { createApolloTestSetup } from '@root/test/helpers'
@@ -51,6 +53,7 @@ describe('languagesMiddleware', () => {
       ...variables,
       content: 'Jeder sollte vor seiner eigenen Tür kehren.',
     }
+
     await expect(
       mutate({
         mutation: CreatePost,
@@ -70,6 +73,7 @@ describe('languagesMiddleware', () => {
       ...variables,
       content: 'A journey of a thousand miles begins with a single step.',
     }
+
     await expect(
       mutate({
         mutation: CreatePost,
@@ -89,6 +93,7 @@ describe('languagesMiddleware', () => {
       ...variables,
       content: 'A caballo regalado, no le mires el diente.',
     }
+
     await expect(
       mutate({
         mutation: CreatePost,
@@ -109,6 +114,7 @@ describe('languagesMiddleware', () => {
       content:
         '<strong>Jeder</strong> <strike>sollte</strike> <strong>vor</strong> <span>seiner</span> eigenen <blockquote>Tür</blockquote> kehren.',
     }
+
     await expect(
       mutate({
         mutation: CreatePost,
@@ -129,6 +135,7 @@ describe('languagesMiddleware', () => {
         ...variables,
         content: '',
       }
+
       await expect(
         mutate({
           mutation: CreatePost,

--- a/backend/src/middleware/notifications/mentions/extractMentionedUsers.spec.ts
+++ b/backend/src/middleware/notifications/mentions/extractMentionedUsers.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import extractMentionedUsers from './extractMentionedUsers'
 
 const contentWithMentions =
@@ -9,7 +11,7 @@ const contentWithPlainLinks =
 const contentWithDuplicateIds =
   'One more mention to <a data-mention-id="you" class="mention" href="/profile/you"> @al-capone </a> and again: <a data-mention-id="you" class="mention" href="/profile/you"> @al-capone </a> and again <a data-mention-id="you" class="mention" href="/profile/you"> @al-capone </a>'
 
-describe('extractMentionedUsers', () => {
+describe(extractMentionedUsers, () => {
   describe('content undefined', () => {
     it('returns empty array', () => {
       expect(extractMentionedUsers()).toEqual([])

--- a/backend/src/middleware/notifications/notificationsMiddleware.emails.spec.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.emails.spec.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { jest } from '@jest/globals'
+
+import { beforeAll, afterAll, describe, beforeEach, afterEach, it, expect } from 'vitest'
 
 import type { ApolloTestSetup } from '@root/test/helpers'
 import type { Context } from '@src/context'
 
-const sendNotificationMailMock: (notification) => void = jest.fn()
-jest.unstable_mockModule('@src/emails/sendEmail', () => ({
+const sendNotificationMailMock: (notification) => void = vi.fn()
+vi.mock('@src/emails/sendEmail', () => ({
   sendNotificationMail: (notification) => {
     sendNotificationMailMock(notification)
   },
@@ -16,16 +17,16 @@ jest.unstable_mockModule('@src/emails/sendEmail', () => ({
   // registration/verification mails in transitively). Under CommonJS a missing key was
   // simply undefined and only mattered if it was called. The stubs below carry no
   // behaviour — only the two above are asserted on.
-  defaultParams: jest.fn(),
-  sendChatMessageMail: jest.fn(),
-  sendRegistrationMail: jest.fn(),
-  sendEmailVerification: jest.fn(),
-  sendResetPasswordMail: jest.fn(),
-  sendWrongEmail: jest.fn(),
+  defaultParams: vi.fn(),
+  sendChatMessageMail: vi.fn(),
+  sendRegistrationMail: vi.fn(),
+  sendEmailVerification: vi.fn(),
+  sendResetPasswordMail: vi.fn(),
+  sendWrongEmail: vi.fn(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { default: Factory, cleanDatabase } = await import('@db/factories')
 const { default: CreateComment } = await import('@graphql/queries/comments/CreateComment.gql')
 const { default: CreateGroup } = await import('@graphql/queries/groups/CreateGroup.gql')
@@ -143,7 +144,7 @@ describe('emails sent for notifications', () => {
     describe('post-author posts into group and mentions following group-member', () => {
       describe('all email notification settings are true', () => {
         beforeEach(async () => {
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           authenticatedUser = await postAuthor.toJson()
           await mutate({
             mutation: CreatePost,
@@ -168,6 +169,7 @@ describe('emails sent for notifications', () => {
 
         it('sends 3 notifications', async () => {
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,
@@ -224,7 +226,7 @@ describe('emails sent for notifications', () => {
 
       describe('email notification for mention in post is false', () => {
         beforeEach(async () => {
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           await groupMember.update({ emailNotificationsMention: false })
           authenticatedUser = await postAuthor.toJson()
           await mutate({
@@ -250,6 +252,7 @@ describe('emails sent for notifications', () => {
 
         it('sends 3 notifications', async () => {
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,
@@ -306,7 +309,7 @@ describe('emails sent for notifications', () => {
 
       describe('email notification for mention in post and followed users is false', () => {
         beforeEach(async () => {
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           await groupMember.update({ emailNotificationsMention: false })
           await groupMember.update({ emailNotificationsFollowingUsers: false })
           authenticatedUser = await postAuthor.toJson()
@@ -333,6 +336,7 @@ describe('emails sent for notifications', () => {
 
         it('sends 3 notifications', async () => {
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,
@@ -389,7 +393,7 @@ describe('emails sent for notifications', () => {
 
       describe('all relevant email notifications are false', () => {
         beforeEach(async () => {
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           await groupMember.update({ emailNotificationsMention: false })
           await groupMember.update({ emailNotificationsFollowingUsers: false })
           await groupMember.update({ emailNotificationsPostInGroup: false })
@@ -411,6 +415,7 @@ describe('emails sent for notifications', () => {
 
         it('sends 3 notifications', async () => {
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,
@@ -493,7 +498,7 @@ describe('emails sent for notifications', () => {
           await mutate({
             mutation: markAllAsRead,
           })
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           authenticatedUser = await postAuthor.toJson()
           await mutate({
             mutation: CreateComment,
@@ -517,6 +522,7 @@ describe('emails sent for notifications', () => {
 
         it('sends 2 notifications', async () => {
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,
@@ -586,7 +592,7 @@ describe('emails sent for notifications', () => {
           await mutate({
             mutation: markAllAsRead,
           })
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           authenticatedUser = await postAuthor.toJson()
           await mutate({
             mutation: CreateComment,
@@ -610,6 +616,7 @@ describe('emails sent for notifications', () => {
 
         it('sends 2 notifications', async () => {
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,
@@ -680,7 +687,7 @@ describe('emails sent for notifications', () => {
           await mutate({
             mutation: markAllAsRead,
           })
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           authenticatedUser = await postAuthor.toJson()
           await mutate({
             mutation: CreateComment,
@@ -698,6 +705,7 @@ describe('emails sent for notifications', () => {
 
         it('sends 2 notifications', async () => {
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,

--- a/backend/src/middleware/notifications/notificationsMiddleware.followed-users.spec.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.followed-users.spec.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { jest } from '@jest/globals'
+
+import { beforeAll, afterAll, describe, it, expect } from 'vitest'
 
 import type { ApolloTestSetup } from '@root/test/helpers'
 import type { Context } from '@src/context'
 
-const sendNotificationMailMock: (notification) => void = jest.fn()
-jest.unstable_mockModule('@src/emails/sendEmail', () => ({
+const sendNotificationMailMock: (notification) => void = vi.fn()
+vi.mock('@src/emails/sendEmail', () => ({
   sendNotificationMail: (notification) => {
     sendNotificationMailMock(notification)
   },
@@ -16,16 +17,16 @@ jest.unstable_mockModule('@src/emails/sendEmail', () => ({
   // registration/verification mails in transitively). Under CommonJS a missing key was
   // simply undefined and only mattered if it was called. The stubs below carry no
   // behaviour — only the two above are asserted on.
-  defaultParams: jest.fn(),
-  sendChatMessageMail: jest.fn(),
-  sendRegistrationMail: jest.fn(),
-  sendEmailVerification: jest.fn(),
-  sendResetPasswordMail: jest.fn(),
-  sendWrongEmail: jest.fn(),
+  defaultParams: vi.fn(),
+  sendChatMessageMail: vi.fn(),
+  sendRegistrationMail: vi.fn(),
+  sendEmailVerification: vi.fn(),
+  sendResetPasswordMail: vi.fn(),
+  sendWrongEmail: vi.fn(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { default: Factory, cleanDatabase } = await import('@db/factories')
 const { default: CreateGroup } = await import('@graphql/queries/groups/CreateGroup.gql')
 const { default: followUser } = await import('@graphql/queries/interactions/followUser.gql')
@@ -135,7 +136,7 @@ describe('following users notifications', () => {
       mutation: followUser,
       variables: { id: 'post-author' },
     })
-    jest.clearAllMocks()
+    vi.clearAllMocks()
   })
 
   describe('the followed user writes a post', () => {
@@ -167,6 +168,7 @@ describe('following users notifications', () => {
 
     it('sends notification to the first follower', async () => {
       authenticatedUser = await firstFollower.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -191,6 +193,7 @@ describe('following users notifications', () => {
 
     it('sends notification to the second follower', async () => {
       authenticatedUser = await secondFollower.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -215,6 +218,7 @@ describe('following users notifications', () => {
 
     it('sends notification to the email-less follower', async () => {
       authenticatedUser = await emaillessFollower.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -294,6 +298,7 @@ describe('following users notifications', () => {
 
     it('sends a notification to the first follower', async () => {
       authenticatedUser = await firstFollower.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -365,6 +370,7 @@ describe('following users notifications', () => {
 
     it('sends NO notification to the first follower', async () => {
       authenticatedUser = await firstFollower.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -436,6 +442,7 @@ describe('following users notifications', () => {
 
     it('sends NO notification to the first follower', async () => {
       authenticatedUser = await firstFollower.toJson()
+
       await expect(
         query({
           query: notifications,

--- a/backend/src/middleware/notifications/notificationsMiddleware.mentions-in-groups.spec.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.mentions-in-groups.spec.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { jest } from '@jest/globals'
+
+import { beforeAll, afterAll, describe, beforeEach, afterEach, it, expect } from 'vitest'
 
 import type { ApolloTestSetup } from '@root/test/helpers'
 import type { Context } from '@src/context'
 
-const sendNotificationMailMock: (notification) => void = jest.fn()
-jest.unstable_mockModule('@src/emails/sendEmail', () => ({
+const sendNotificationMailMock: (notification) => void = vi.fn()
+vi.mock('@src/emails/sendEmail', () => ({
   sendNotificationMail: (notification) => {
     sendNotificationMailMock(notification)
   },
@@ -16,16 +17,16 @@ jest.unstable_mockModule('@src/emails/sendEmail', () => ({
   // registration/verification mails in transitively). Under CommonJS a missing key was
   // simply undefined and only mattered if it was called. The stubs below carry no
   // behaviour — only the two above are asserted on.
-  defaultParams: jest.fn(),
-  sendChatMessageMail: jest.fn(),
-  sendRegistrationMail: jest.fn(),
-  sendEmailVerification: jest.fn(),
-  sendResetPasswordMail: jest.fn(),
-  sendWrongEmail: jest.fn(),
+  defaultParams: vi.fn(),
+  sendChatMessageMail: vi.fn(),
+  sendRegistrationMail: vi.fn(),
+  sendEmailVerification: vi.fn(),
+  sendResetPasswordMail: vi.fn(),
+  sendWrongEmail: vi.fn(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { default: Factory, cleanDatabase } = await import('@db/factories')
 const { default: CreateComment } = await import('@graphql/queries/comments/CreateComment.gql')
 const { default: ChangeGroupMemberRole } =
@@ -268,7 +269,7 @@ describe('mentions in groups', () => {
 
   describe('post in public group', () => {
     beforeEach(async () => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
       authenticatedUser = await postAuthor.toJson()
       await mutate({
         mutation: CreatePost,
@@ -283,6 +284,7 @@ describe('mentions in groups', () => {
 
     it('sends a notification to the no member', async () => {
       authenticatedUser = await noMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -310,6 +312,7 @@ describe('mentions in groups', () => {
 
     it('sends a notification to the group member', async () => {
       authenticatedUser = await groupMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -378,7 +381,7 @@ describe('mentions in groups', () => {
 
   describe('post in closed group', () => {
     beforeEach(async () => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
       authenticatedUser = await postAuthor.toJson()
       await mutate({
         mutation: CreatePost,
@@ -393,6 +396,7 @@ describe('mentions in groups', () => {
 
     it('sends NO notification to the no member', async () => {
       authenticatedUser = await noMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -411,6 +415,7 @@ describe('mentions in groups', () => {
 
     it('sends NO notification to the pending member', async () => {
       authenticatedUser = await pendingMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -429,6 +434,7 @@ describe('mentions in groups', () => {
 
     it('sends a notification to the group member', async () => {
       authenticatedUser = await groupMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -485,7 +491,7 @@ describe('mentions in groups', () => {
 
   describe('post in hidden group', () => {
     beforeEach(async () => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
       authenticatedUser = await postAuthor.toJson()
       await mutate({
         mutation: CreatePost,
@@ -500,6 +506,7 @@ describe('mentions in groups', () => {
 
     it('sends NO notification to the no member', async () => {
       authenticatedUser = await noMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -518,6 +525,7 @@ describe('mentions in groups', () => {
 
     it('sends NO notification to the pending member', async () => {
       authenticatedUser = await pendingMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -536,6 +544,7 @@ describe('mentions in groups', () => {
 
     it('sends a notification to the group member', async () => {
       authenticatedUser = await groupMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -606,7 +615,7 @@ describe('mentions in groups', () => {
         authenticatedUser = await groupMember.toJson()
         await mutate({ mutation: markAllAsRead })
         authenticatedUser = await postAuthor.toJson()
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         await mutate({
           mutation: CreateComment,
           variables: {
@@ -619,6 +628,7 @@ describe('mentions in groups', () => {
 
       it('sends a notification to the no member', async () => {
         authenticatedUser = await noMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -646,6 +656,7 @@ describe('mentions in groups', () => {
 
       it('sends a notification to the group member', async () => {
         authenticatedUser = await groupMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -703,7 +714,7 @@ describe('mentions in groups', () => {
         authenticatedUser = await groupMember.toJson()
         await mutate({ mutation: markAllAsRead })
         authenticatedUser = await postAuthor.toJson()
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         await mutate({
           mutation: CreateComment,
           variables: {
@@ -716,6 +727,7 @@ describe('mentions in groups', () => {
 
       it('sends NO notification to the no member', async () => {
         authenticatedUser = await noMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -734,6 +746,7 @@ describe('mentions in groups', () => {
 
       it('sends NO notification to the pending member', async () => {
         authenticatedUser = await pendingMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -752,6 +765,7 @@ describe('mentions in groups', () => {
 
       it('sends a notification to the group member', async () => {
         authenticatedUser = await groupMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -803,7 +817,7 @@ describe('mentions in groups', () => {
         authenticatedUser = await groupMember.toJson()
         await mutate({ mutation: markAllAsRead })
         authenticatedUser = await postAuthor.toJson()
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         await mutate({
           mutation: CreateComment,
           variables: {
@@ -816,6 +830,7 @@ describe('mentions in groups', () => {
 
       it('sends NO notification to the no member', async () => {
         authenticatedUser = await noMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -834,6 +849,7 @@ describe('mentions in groups', () => {
 
       it('sends NO notification to the pending member', async () => {
         authenticatedUser = await pendingMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -852,6 +868,7 @@ describe('mentions in groups', () => {
 
       it('sends a notification to the group member', async () => {
         authenticatedUser = await groupMember.toJson()
+
         await expect(
           query({
             query: notifications,

--- a/backend/src/middleware/notifications/notificationsMiddleware.observing-posts.spec.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.observing-posts.spec.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { jest } from '@jest/globals'
+
+import { beforeAll, afterAll, describe, it, expect } from 'vitest'
 
 import type { ApolloTestSetup } from '@root/test/helpers'
 import type { Context } from '@src/context'
 
-const sendNotificationMailMock: (notification) => void = jest.fn()
-jest.unstable_mockModule('@src/emails/sendEmail', () => ({
+const sendNotificationMailMock: (notification) => void = vi.fn()
+vi.mock('@src/emails/sendEmail', () => ({
   sendNotificationMail: (notification) => {
     sendNotificationMailMock(notification)
   },
@@ -16,16 +17,16 @@ jest.unstable_mockModule('@src/emails/sendEmail', () => ({
   // registration/verification mails in transitively). Under CommonJS a missing key was
   // simply undefined and only mattered if it was called. The stubs below carry no
   // behaviour — only the two above are asserted on.
-  defaultParams: jest.fn(),
-  sendChatMessageMail: jest.fn(),
-  sendRegistrationMail: jest.fn(),
-  sendEmailVerification: jest.fn(),
-  sendResetPasswordMail: jest.fn(),
-  sendWrongEmail: jest.fn(),
+  defaultParams: vi.fn(),
+  sendChatMessageMail: vi.fn(),
+  sendRegistrationMail: vi.fn(),
+  sendEmailVerification: vi.fn(),
+  sendResetPasswordMail: vi.fn(),
+  sendWrongEmail: vi.fn(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { default: Factory, cleanDatabase } = await import('@db/factories')
 const { default: CreateComment } = await import('@graphql/queries/comments/CreateComment.gql')
 const { default: notifications } = await import('@graphql/queries/notifications/notifications.gql')
@@ -150,6 +151,7 @@ describe('notifications for users that observe a post', () => {
 
     it('sends notification to the author', async () => {
       authenticatedUser = await postAuthor.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -184,7 +186,7 @@ describe('notifications for users that observe a post', () => {
 
     describe('second comment on post', () => {
       beforeAll(async () => {
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await secondCommenter.toJson()
         await mutate({
           mutation: CreateComment,
@@ -212,6 +214,7 @@ describe('notifications for users that observe a post', () => {
 
       it('sends notification to the author', async () => {
         authenticatedUser = await postAuthor.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -244,6 +247,7 @@ describe('notifications for users that observe a post', () => {
 
       it('sends notification to first commenter', async () => {
         authenticatedUser = await firstCommenter.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -285,7 +289,7 @@ describe('notifications for users that observe a post', () => {
 
     describe('first commenter unfollows the post and post author comments post', () => {
       beforeAll(async () => {
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await firstCommenter.toJson()
         await mutate({
           mutation: toggleObservePost,
@@ -339,6 +343,7 @@ describe('notifications for users that observe a post', () => {
 
       it('sends no new notification to first commenter', async () => {
         authenticatedUser = await firstCommenter.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -363,6 +368,7 @@ describe('notifications for users that observe a post', () => {
 
       it('sends notification to second commenter', async () => {
         authenticatedUser = await secondCommenter.toJson()
+
         await expect(
           query({
             query: notifications,

--- a/backend/src/middleware/notifications/notificationsMiddleware.online-status.spec.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.online-status.spec.ts
@@ -2,13 +2,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import { jest } from '@jest/globals'
+import { beforeAll, afterAll, afterEach, describe, beforeEach, it, expect } from 'vitest'
 
 import type { ApolloTestSetup } from '@root/test/helpers'
 import type { Context } from '@src/context'
 
-const sendNotificationMailMock: (notification) => void = jest.fn()
-jest.unstable_mockModule('@src/emails/sendEmail', () => ({
+const sendNotificationMailMock: (notification) => void = vi.fn()
+vi.mock('@src/emails/sendEmail', () => ({
   sendNotificationMail: (notification) => {
     sendNotificationMailMock(notification)
   },
@@ -17,21 +17,21 @@ jest.unstable_mockModule('@src/emails/sendEmail', () => ({
   // registration/verification mails in transitively). Under CommonJS a missing key was
   // simply undefined and only mattered if it was called. The stubs below carry no
   // behaviour — only the two above are asserted on.
-  defaultParams: jest.fn(),
-  sendChatMessageMail: jest.fn(),
-  sendRegistrationMail: jest.fn(),
-  sendEmailVerification: jest.fn(),
-  sendResetPasswordMail: jest.fn(),
-  sendWrongEmail: jest.fn(),
+  defaultParams: vi.fn(),
+  sendChatMessageMail: vi.fn(),
+  sendRegistrationMail: vi.fn(),
+  sendEmailVerification: vi.fn(),
+  sendResetPasswordMail: vi.fn(),
+  sendWrongEmail: vi.fn(),
 }))
 
-let isUserOnlineMock = jest.fn().mockReturnValue(false)
-jest.unstable_mockModule('../helpers/isUserOnline', () => ({
-  isUserOnline: () => isUserOnlineMock(),
+let isUserOnlineMock = vi.fn<() => boolean>().mockReturnValue(false)
+vi.mock('../helpers/isUserOnline', () => ({
+  isUserOnline: (): boolean => isUserOnlineMock(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { default: Factory, cleanDatabase } = await import('@db/factories')
 const { default: CreatePost } = await import('@graphql/queries/posts/CreatePost.gql')
 const { createApolloTestSetup } = await import('@root/test/helpers')
@@ -94,12 +94,12 @@ describe('online status and sending emails', () => {
 
   describe('user is online', () => {
     beforeAll(() => {
-      isUserOnlineMock = jest.fn().mockReturnValue(true)
+      isUserOnlineMock = vi.fn().mockReturnValue(true)
     })
 
     describe('mentioned in post', () => {
       beforeEach(async () => {
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await postAuthor.toJson()
         await mutate({
           mutation: CreatePost,
@@ -120,12 +120,12 @@ describe('online status and sending emails', () => {
 
   describe('user is offline', () => {
     beforeAll(() => {
-      isUserOnlineMock = jest.fn().mockReturnValue(false)
+      isUserOnlineMock = vi.fn().mockReturnValue(false)
     })
 
     describe('mentioned in post', () => {
       beforeEach(async () => {
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await postAuthor.toJson()
         await mutate({
           mutation: CreatePost,

--- a/backend/src/middleware/notifications/notificationsMiddleware.posts-in-groups.spec.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.posts-in-groups.spec.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { jest } from '@jest/globals'
+
+import { beforeAll, afterAll, describe, beforeEach, afterEach, it, expect } from 'vitest'
 
 import type { ApolloTestSetup } from '@root/test/helpers'
 import type { Context } from '@src/context'
 
-const sendNotificationMailMock: (notification) => void = jest.fn()
-jest.unstable_mockModule('@src/emails/sendEmail', () => ({
+const sendNotificationMailMock: (notification) => void = vi.fn()
+vi.mock('@src/emails/sendEmail', () => ({
   sendNotificationMail: (notification) => {
     sendNotificationMailMock(notification)
   },
@@ -16,16 +17,16 @@ jest.unstable_mockModule('@src/emails/sendEmail', () => ({
   // registration/verification mails in transitively). Under CommonJS a missing key was
   // simply undefined and only mattered if it was called. The stubs below carry no
   // behaviour — only the two above are asserted on.
-  defaultParams: jest.fn(),
-  sendChatMessageMail: jest.fn(),
-  sendRegistrationMail: jest.fn(),
-  sendEmailVerification: jest.fn(),
-  sendResetPasswordMail: jest.fn(),
-  sendWrongEmail: jest.fn(),
+  defaultParams: vi.fn(),
+  sendChatMessageMail: vi.fn(),
+  sendRegistrationMail: vi.fn(),
+  sendEmailVerification: vi.fn(),
+  sendResetPasswordMail: vi.fn(),
+  sendWrongEmail: vi.fn(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { default: Factory, cleanDatabase } = await import('@db/factories')
 const { default: ChangeGroupMemberRole } =
   await import('@graphql/queries/groups/ChangeGroupMemberRole.gql')
@@ -168,7 +169,7 @@ describe('notify group members of new posts in group', () => {
 
   describe('group owner posts in group', () => {
     beforeEach(async () => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
       authenticatedUser = await groupMember.toJson()
       await mutate({ mutation: markAllAsRead })
       authenticatedUser = await postAuthor.toJson()
@@ -203,6 +204,7 @@ describe('notify group members of new posts in group', () => {
 
     it('sends NO notification to the pending group member', async () => {
       authenticatedUser = await pendingMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -221,6 +223,7 @@ describe('notify group members of new posts in group', () => {
 
     it('sends notification to the group member', async () => {
       authenticatedUser = await groupMember.toJson()
+
       await expect(
         query({
           query: notifications,
@@ -265,7 +268,7 @@ describe('notify group members of new posts in group', () => {
             groupId: 'g-1',
           },
         })
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await postAuthor.toJson()
         await mutate({
           mutation: CreatePost,
@@ -308,7 +311,7 @@ describe('notify group members of new posts in group', () => {
               groupId: 'g-1',
             },
           })
-          jest.clearAllMocks()
+          vi.clearAllMocks()
           await groupMember.update({ emailNotificationsPostInGroup: false })
         })
 
@@ -326,6 +329,7 @@ describe('notify group members of new posts in group', () => {
             },
           })
           authenticatedUser = await groupMember.toJson()
+
           await expect(
             query({
               query: notifications,
@@ -362,7 +366,7 @@ describe('notify group members of new posts in group', () => {
         await groupMember.relateTo(postAuthor, 'blocked')
         authenticatedUser = await groupMember.toJson()
         await mutate({ mutation: markAllAsRead })
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await postAuthor.toJson()
         await mutate({
           mutation: CreatePost,
@@ -377,6 +381,7 @@ describe('notify group members of new posts in group', () => {
 
       it('sends no notification to the user', async () => {
         authenticatedUser = await groupMember.toJson()
+
         await expect(
           query({
             query: notifications,
@@ -403,7 +408,7 @@ describe('notify group members of new posts in group', () => {
         await groupMember.relateTo(postAuthor, 'muted')
         authenticatedUser = await groupMember.toJson()
         await mutate({ mutation: markAllAsRead })
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await postAuthor.toJson()
         await mutate({
           mutation: CreatePost,
@@ -418,6 +423,7 @@ describe('notify group members of new posts in group', () => {
 
       it('sends no notification to the user', async () => {
         authenticatedUser = await groupMember.toJson()
+
         await expect(
           query({
             query: notifications,

--- a/backend/src/middleware/notifications/notificationsMiddleware.spec.ts
+++ b/backend/src/middleware/notifications/notificationsMiddleware.spec.ts
@@ -4,14 +4,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import { jest } from '@jest/globals'
+import { beforeAll, afterAll, beforeEach, afterEach, describe, it, expect } from 'vitest'
 
 import type { ApolloTestSetup } from '@root/test/helpers'
 import type { Context } from '@src/context'
 
-const sendChatMessageMailMock: (notification) => void = jest.fn()
-const sendNotificationMailMock: (notification) => void = jest.fn()
-jest.unstable_mockModule('@src/emails/sendEmail', () => ({
+const sendChatMessageMailMock: (notification) => void = vi.fn()
+const sendNotificationMailMock: (notification) => void = vi.fn()
+vi.mock('@src/emails/sendEmail', () => ({
   sendChatMessageMail: (notification) => {
     sendChatMessageMailMock(notification)
   },
@@ -23,20 +23,20 @@ jest.unstable_mockModule('@src/emails/sendEmail', () => ({
   // registration/verification mails in transitively). Under CommonJS a missing key was
   // simply undefined and only mattered if it was called. The stubs below carry no
   // behaviour — only the two above are asserted on.
-  defaultParams: jest.fn(),
-  sendRegistrationMail: jest.fn(),
-  sendEmailVerification: jest.fn(),
-  sendResetPasswordMail: jest.fn(),
-  sendWrongEmail: jest.fn(),
+  defaultParams: vi.fn(),
+  sendRegistrationMail: vi.fn(),
+  sendEmailVerification: vi.fn(),
+  sendResetPasswordMail: vi.fn(),
+  sendWrongEmail: vi.fn(),
 }))
 
-let isUserOnlineMock = jest.fn()
-jest.unstable_mockModule('../helpers/isUserOnline', () => ({
-  isUserOnline: () => isUserOnlineMock(),
+let isUserOnlineMock = vi.fn<() => boolean>()
+vi.mock('../helpers/isUserOnline', () => ({
+  isUserOnline: (): boolean => isUserOnlineMock(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { default: pubsubContext } = await import('@context/pubsub')
 const { default: Factory, cleanDatabase } = await import('@db/factories')
 const { default: CreateComment } = await import('@graphql/queries/comments/CreateComment.gql')
@@ -57,7 +57,7 @@ const { default: UpdatePost } = await import('@graphql/queries/posts/UpdatePost.
 const { createApolloTestSetup } = await import('@root/test/helpers')
 
 const pubsub = pubsubContext()
-const pubsubSpy = jest.spyOn(pubsub, 'publish')
+const pubsubSpy = vi.spyOn(pubsub, 'publish')
 
 let notifiedUser
 let authenticatedUser: Context['user']
@@ -161,7 +161,7 @@ describe('notifications', () => {
 
         describe('commenter is not me', () => {
           beforeEach(async () => {
-            jest.clearAllMocks()
+            vi.clearAllMocks()
             commentContent = 'Commenters comment.'
             commentAuthor = await Factory.build(
               'user',
@@ -179,6 +179,7 @@ describe('notifications', () => {
 
           it('sends me a notification and email', async () => {
             await createCommentOnPostAction()
+
             await expect(
               query({
                 query: notifications,
@@ -222,6 +223,7 @@ describe('notifications', () => {
             it('sends me a notification but no email', async () => {
               await notifiedUser.update({ emailNotificationsCommentOnObservedPost: false })
               await createCommentOnPostAction()
+
               await expect(
                 query({
                   query: notifications,
@@ -323,7 +325,7 @@ describe('notifications', () => {
       })
 
       beforeEach(async () => {
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         postAuthor = await Factory.build(
           'user',
           {
@@ -350,6 +352,7 @@ describe('notifications', () => {
           await createPostAction()
           const expectedContent =
             'Hey <a class="mention" data-mention-id="you" href="/profile/you/al-capone" target="_blank">@al-capone</a> how do you do?'
+
           await expect(
             query({
               query: notifications,
@@ -393,6 +396,7 @@ describe('notifications', () => {
             await createPostAction()
             const expectedContent =
               'Hey <a class="mention" data-mention-id="you" href="/profile/you/al-capone" target="_blank">@al-capone</a> how do you do?'
+
             await expect(
               query({
                 query: notifications,
@@ -427,6 +431,7 @@ describe('notifications', () => {
 
         it('publishes `NOTIFICATION_ADDED` to me', async () => {
           await createPostAction()
+
           expect(pubsubSpy).toHaveBeenCalledWith(
             'NOTIFICATION_ADDED',
             expect.objectContaining({
@@ -493,6 +498,7 @@ describe('notifications', () => {
                 ],
               },
             })
+
             await expect(
               query({
                 query: notifications,
@@ -531,6 +537,7 @@ describe('notifications', () => {
                     read: false,
                   },
                 })
+
                 expect(readBefore).toEqual(true)
                 expect(readAfter).toEqual(false)
               })
@@ -560,6 +567,7 @@ describe('notifications', () => {
                     read: false,
                   },
                 })
+
                 expect(createdAtBefore).toBeTruthy()
                 expect(Date.parse(createdAtBefore)).toEqual(expect.any(Number))
                 expect(createdAtAfter).toBeTruthy()
@@ -594,6 +602,7 @@ describe('notifications', () => {
 
           it('does not publish `NOTIFICATION_ADDED`', async () => {
             await createPostAction()
+
             expect(pubsubSpy).not.toHaveBeenCalled()
           })
         })
@@ -638,6 +647,7 @@ describe('notifications', () => {
 
           it('publishes `NOTIFICATION_ADDED`', async () => {
             await createPostAction()
+
             expect(pubsubSpy).toHaveBeenCalled()
           })
         })
@@ -717,6 +727,7 @@ describe('notifications', () => {
             postContent = 'Content of post where I get mentioned in a comment.'
             postAuthor = notifiedUser
           })
+
           it('sends only one notification with reason commented_on_post, no notification with reason mentioned_in_comment', async () => {
             await createCommentOnPostAction()
             const expected = {
@@ -771,6 +782,7 @@ describe('notifications', () => {
 
           it('sends no notification', async () => {
             await createCommentOnPostAction()
+
             await expect(
               query({
                 query: notifications,
@@ -787,6 +799,7 @@ describe('notifications', () => {
 
           it('does not publish `NOTIFICATION_ADDED` to authenticated user', async () => {
             await createCommentOnPostAction()
+
             expect(pubsubSpy).toHaveBeenCalledWith(
               'NOTIFICATION_ADDED',
               expect.objectContaining({
@@ -823,6 +836,7 @@ describe('notifications', () => {
 
           it('sends me a notification', async () => {
             await createCommentOnPostAction()
+
             await expect(
               query({
                 query: notifications,
@@ -855,6 +869,7 @@ describe('notifications', () => {
 
           it('publishes `NOTIFICATION_ADDED` to authenticated user and me', async () => {
             await createCommentOnPostAction()
+
             expect(pubsubSpy).toHaveBeenCalledWith(
               'NOTIFICATION_ADDED',
               expect.objectContaining({
@@ -879,8 +894,8 @@ describe('notifications', () => {
     let roomId
 
     beforeEach(async () => {
-      jest.clearAllMocks()
-      isUserOnlineMock = jest.fn().mockReturnValue(false)
+      vi.clearAllMocks()
+      isUserOnlineMock = vi.fn().mockReturnValue(false)
 
       chatSender = await Factory.build(
         'user',
@@ -914,12 +929,12 @@ describe('notifications', () => {
 
       // Reset mocks after init message to avoid contamination
       pubsubSpy.mockClear()
-      ;(sendChatMessageMailMock as jest.Mock).mockClear()
+      vi.mocked(sendChatMessageMailMock).mockClear()
     })
 
     describe('if the chatReceiver is online', () => {
       it('publishes subscriptions but sends no email', async () => {
-        isUserOnlineMock = jest.fn().mockReturnValue(true)
+        isUserOnlineMock = vi.fn().mockReturnValue(true)
 
         await mutate({
           mutation: CreateMessage,
@@ -954,7 +969,7 @@ describe('notifications', () => {
 
     describe('if the chatReceiver is offline', () => {
       it('publishes subscriptions and sends an email', async () => {
-        isUserOnlineMock = jest.fn().mockReturnValue(false)
+        isUserOnlineMock = vi.fn().mockReturnValue(false)
 
         await mutate({
           mutation: CreateMessage,
@@ -1002,7 +1017,7 @@ describe('notifications', () => {
 
     describe('if the chatReceiver has blocked chatSender', () => {
       it('publishes no subscriptions and sends no email', async () => {
-        isUserOnlineMock = jest.fn().mockReturnValue(false)
+        isUserOnlineMock = vi.fn().mockReturnValue(false)
         await chatReceiver.relateTo(chatSender, 'blocked')
 
         await mutate({
@@ -1022,7 +1037,7 @@ describe('notifications', () => {
 
     describe('if the chatReceiver has muted chatSender', () => {
       it('publishes no subscriptions and sends no email', async () => {
-        isUserOnlineMock = jest.fn().mockReturnValue(false)
+        isUserOnlineMock = vi.fn().mockReturnValue(false)
         await chatReceiver.relateTo(chatSender, 'muted')
 
         await mutate({
@@ -1042,7 +1057,7 @@ describe('notifications', () => {
 
     describe('if the chatReceiver has disabled `emailNotificationsChatMessage`', () => {
       it('publishes subscriptions but sends no email', async () => {
-        isUserOnlineMock = jest.fn().mockReturnValue(false)
+        isUserOnlineMock = vi.fn().mockReturnValue(false)
         await chatReceiver.update({ emailNotificationsChatMessage: false })
 
         await mutate({
@@ -1105,12 +1120,12 @@ describe('notifications', () => {
         groupRoomId = createRoomResult.data.CreateGroupRoom.id
 
         pubsubSpy.mockClear()
-        ;(sendChatMessageMailMock as jest.Mock).mockClear()
+        vi.mocked(sendChatMessageMailMock).mockClear()
       })
 
       describe('if the chatReceiver has muted the group', () => {
         it('publishes subscriptions but sends no email', async () => {
-          isUserOnlineMock = jest.fn().mockReturnValue(false)
+          isUserOnlineMock = vi.fn().mockReturnValue(false)
           authenticatedUser = await chatReceiver.toJson()
           await mutate({
             mutation: muteGroup,
@@ -1139,7 +1154,7 @@ describe('notifications', () => {
 
       describe('if the chatReceiver has not muted the group', () => {
         it('publishes subscriptions and sends an email', async () => {
-          isUserOnlineMock = jest.fn().mockReturnValue(false)
+          isUserOnlineMock = vi.fn().mockReturnValue(false)
 
           await mutate({
             mutation: CreateMessage,
@@ -1205,11 +1220,12 @@ describe('notifications', () => {
       }
 
       beforeEach(async () => {
-        jest.clearAllMocks()
+        vi.clearAllMocks()
       })
 
       it('sends the group owner a notification and email', async () => {
         await joinGroupAction()
+
         await expect(
           query({
             query: notifications,
@@ -1253,6 +1269,7 @@ describe('notifications', () => {
         it('sends the group owner a notification but no email', async () => {
           await groupOwner.update({ emailNotificationsGroupMemberJoined: false })
           await joinGroupAction()
+
           await expect(
             query({
               query: notifications,
@@ -1302,7 +1319,7 @@ describe('notifications', () => {
       }
 
       beforeEach(async () => {
-        jest.clearAllMocks()
+        vi.clearAllMocks()
         authenticatedUser = await notifiedUser.toJson()
         await mutate({
           mutation: JoinGroup,
@@ -1315,6 +1332,7 @@ describe('notifications', () => {
 
       it('sends the group owner two notifications and emails', async () => {
         await leaveGroupAction()
+
         await expect(
           query({
             query: notifications,
@@ -1377,6 +1395,7 @@ describe('notifications', () => {
         it('sends the group owner two notification but only only one email', async () => {
           await groupOwner.update({ emailNotificationsGroupMemberLeft: false })
           await leaveGroupAction()
+
           await expect(
             query({
               query: notifications,
@@ -1449,11 +1468,12 @@ describe('notifications', () => {
           },
         })
         // Clear after because the above generates a notification not related
-        jest.clearAllMocks()
+        vi.clearAllMocks()
       })
 
       it('sends the group member a notification and email', async () => {
         await changeGroupMemberRoleAction()
+
         await expect(
           query({
             query: notifications,
@@ -1497,6 +1517,7 @@ describe('notifications', () => {
         it('sends the group member a notification but no email', async () => {
           notifiedUser.update({ emailNotificationsGroupMemberRoleChanged: false })
           await changeGroupMemberRoleAction()
+
           await expect(
             query({
               query: notifications,
@@ -1555,11 +1576,12 @@ describe('notifications', () => {
           },
         })
         // Clear after because the above generates a notification not related
-        jest.clearAllMocks()
+        vi.clearAllMocks()
       })
 
       it('sends the previous group member a notification and email', async () => {
         await removeUserFromGroupAction()
+
         await expect(
           query({
             query: notifications,
@@ -1603,6 +1625,7 @@ describe('notifications', () => {
         it('sends the previous group member a notification but no email', async () => {
           notifiedUser.update({ emailNotificationsGroupMemberRemoved: false })
           await removeUserFromGroupAction()
+
           await expect(
             query({
               query: notifications,

--- a/backend/src/middleware/orderByMiddleware.spec.ts
+++ b/backend/src/middleware/orderByMiddleware.spec.ts
@@ -1,3 +1,5 @@
+import { beforeAll, afterAll, beforeEach, afterEach, describe, it, expect } from 'vitest'
+
 import { cleanDatabase } from '@db/factories'
 import Post from '@graphql/queries/posts/Post.gql'
 import { createApolloTestSetup } from '@root/test/helpers'

--- a/backend/src/middleware/permissionsMiddleware.spec.ts
+++ b/backend/src/middleware/permissionsMiddleware.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { beforeEach, beforeAll, afterAll, describe, afterEach, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import Signup from '@graphql/queries/auth/Signup.gql'
 import User from '@graphql/queries/users/User.gql'
@@ -119,6 +121,7 @@ describe('authorization', () => {
 
           it("exposes the owner's email address", async () => {
             variables = { name: 'Owner' }
+
             await expect(query({ query: UserEmail, variables })).resolves.toMatchObject({
               data: { User: [{ email: 'owner@example.org' }] },
               errors: undefined,
@@ -163,6 +166,7 @@ describe('authorization', () => {
 
           it("exposes the owner's email address", async () => {
             variables = { name: 'Owner' }
+
             await expect(query({ query: UserEmail, variables })).resolves.toMatchObject({
               data: { User: [{ email: 'owner@example.org' }] },
               errors: undefined,

--- a/backend/src/middleware/sentryMiddleware.spec.ts
+++ b/backend/src/middleware/sentryMiddleware.spec.ts
@@ -1,21 +1,26 @@
-import { jest } from '@jest/globals'
+import { beforeEach, describe, it, expect } from 'vitest'
 
-jest.unstable_mockModule('@sentry/node', () => ({
-  init: jest.fn(),
-  withScope: jest.fn(),
-  captureException: jest.fn(),
+import type { Mock } from 'vitest'
+
+vi.mock('@sentry/node', () => ({
+  init: vi.fn(),
+  withScope: vi.fn(),
+  captureException: vi.fn(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const { init, withScope, captureException } = await import('@sentry/node')
 const { createSentryMiddleware } = await import('./sentryMiddleware')
 
-const initMock = init as jest.Mock
-// Signature stated: the tests configure this one with mockImplementation, and
-// `Mock<UnknownFunction>` accepts no implementation under @jest/globals.
-const withScopeMock = withScope as unknown as jest.Mock<(run: (scope: unknown) => void) => void>
-const captureExceptionMock = captureException as jest.Mock
+const initMock = vi.mocked(init)
+// Signature stated: the tests configure this one with mockImplementation, and a bare `vi.fn()`
+// would type its argument as `any` instead of checking it against the real callback.
+// Cast rather than vi.mocked(withScope): Sentry's real signature is
+// `(scope, callback) => unknown`, while the middleware only ever calls the single-argument form
+// — typing the stub to what is actually used keeps the implementations below honest.
+const withScopeMock = withScope as unknown as Mock<(run: (scope: unknown) => void) => void>
+const captureExceptionMock = vi.mocked(captureException)
 
 beforeEach(() => {
   initMock.mockReset()
@@ -27,14 +32,13 @@ describe('createSentryMiddleware', () => {
   describe('without a DSN', () => {
     it('does not call Sentry.init', () => {
       createSentryMiddleware({})
+
       expect(initMock).not.toHaveBeenCalled()
     })
 
     it('returns a passthrough middleware that forwards arguments to resolve', async () => {
       const middleware = createSentryMiddleware({})
-      const resolve = jest
-        .fn<(...args: unknown[]) => Promise<unknown>>()
-        .mockResolvedValue('result')
+      const resolve = vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue('result')
       const root = { r: 1 }
       const args = { a: 1 }
       const context = { c: 1 }
@@ -48,7 +52,7 @@ describe('createSentryMiddleware', () => {
     it('propagates errors from resolve without capturing them', async () => {
       const middleware = createSentryMiddleware({})
       const error = new Error('boom')
-      const resolve = jest.fn<(...args: unknown[]) => Promise<unknown>>().mockRejectedValue(error)
+      const resolve = vi.fn<(...args: unknown[]) => Promise<unknown>>().mockRejectedValue(error)
 
       await expect(middleware(resolve, {}, {}, {}, {})).rejects.toBe(error)
       expect(captureExceptionMock).not.toHaveBeenCalled()
@@ -72,7 +76,7 @@ describe('createSentryMiddleware', () => {
 
     it('forwards successful resolver results without reporting', async () => {
       const middleware = createSentryMiddleware({ dsn: 'x' })
-      const resolve = jest.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue('ok')
+      const resolve = vi.fn<(...args: unknown[]) => Promise<unknown>>().mockResolvedValue('ok')
 
       await expect(middleware(resolve, {}, {}, {}, {})).resolves.toBe('ok')
       expect(withScopeMock).not.toHaveBeenCalled()
@@ -82,7 +86,7 @@ describe('createSentryMiddleware', () => {
     it('captures errors with user and request metadata, then rethrows', async () => {
       const middleware = createSentryMiddleware({ dsn: 'x' })
       const error = new Error('boom')
-      const resolve = jest.fn<(...args: unknown[]) => Promise<unknown>>().mockRejectedValue(error)
+      const resolve = vi.fn<(...args: unknown[]) => Promise<unknown>>().mockRejectedValue(error)
       const context = {
         user: { id: 'user-42' },
         req: {
@@ -92,8 +96,8 @@ describe('createSentryMiddleware', () => {
       }
 
       const scope = {
-        setUser: jest.fn<(...args: unknown[]) => void>(),
-        setExtra: jest.fn<(...args: unknown[]) => void>(),
+        setUser: vi.fn<(...args: unknown[]) => void>(),
+        setExtra: vi.fn<(...args: unknown[]) => void>(),
       }
       withScopeMock.mockImplementation((run: (s: typeof scope) => void) => {
         run(scope)
@@ -111,11 +115,11 @@ describe('createSentryMiddleware', () => {
     it('handles missing user and request metadata gracefully', async () => {
       const middleware = createSentryMiddleware({ dsn: 'x' })
       const error = new Error('boom')
-      const resolve = jest.fn<(...args: unknown[]) => Promise<unknown>>().mockRejectedValue(error)
+      const resolve = vi.fn<(...args: unknown[]) => Promise<unknown>>().mockRejectedValue(error)
 
       const scope = {
-        setUser: jest.fn(),
-        setExtra: jest.fn(),
+        setUser: vi.fn(),
+        setExtra: vi.fn(),
       }
       withScopeMock.mockImplementation((run: (s: typeof scope) => void) => {
         run(scope)

--- a/backend/src/middleware/slugify/uniqueSlug.spec.ts
+++ b/backend/src/middleware/slugify/uniqueSlug.spec.ts
@@ -1,41 +1,44 @@
-import { jest } from '@jest/globals'
+import { describe, it, expect } from 'vitest'
 
 import uniqueSlug from './uniqueSlug'
 
-// Mirrors the (unexported) callback type uniqueSlug takes; `@jest/globals` needs a
-// signature on the mock, a bare jest.fn() is Mock<UnknownFunction>.
+// Mirrors the (unexported) callback type uniqueSlug takes: a bare `vi.fn()` would type
+// `mockResolvedValue` as `any` instead of checking it against the real callback.
 type IsUnique = (slug: string) => Promise<boolean>
 
-describe('uniqueSlug', () => {
+describe(uniqueSlug, () => {
   it('slugifies given string', async () => {
     const string = 'Hello World'
-    const isUnique = jest.fn<IsUnique>().mockResolvedValue(true)
+    const isUnique = vi.fn<IsUnique>().mockResolvedValue(true)
+
     await expect(uniqueSlug(string, isUnique)).resolves.toEqual('hello-world')
   })
 
   it('increments slugified string until unique', async () => {
     const string = 'Hello World'
-    const isUnique = jest.fn<IsUnique>().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    const isUnique = vi.fn<IsUnique>().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
     await expect(uniqueSlug(string, isUnique)).resolves.toEqual('hello-world-1')
   })
 
   it('slugify null string', async () => {
     const nullString = null
-    const isUnique = jest.fn<IsUnique>().mockResolvedValue(true)
-    await expect(uniqueSlug(nullString as unknown as string, isUnique)).resolves.toEqual(
-      'anonymous',
-    )
+    const isUnique = vi.fn<IsUnique>().mockResolvedValue(true)
+
+    await expect(uniqueSlug(nullString as unknown as string, isUnique)).resolves.toBe('anonymous')
   })
 
   it('Converts umlaut to a two letter equivalent', async () => {
     const umlaut = 'ÄÖÜäöüß'
-    const isUnique = jest.fn<IsUnique>().mockResolvedValue(true)
+    const isUnique = vi.fn<IsUnique>().mockResolvedValue(true)
+
     await expect(uniqueSlug(umlaut, isUnique)).resolves.toEqual('aeoeueaeoeuess')
   })
 
   it('Removes Spanish enya and diacritics', async () => {
     const diacritics = 'áàéèíìóòúùñçÁÀÉÈÍÌÓÒÚÙÑÇ'
-    const isUnique = jest.fn<IsUnique>().mockResolvedValue(true)
+    const isUnique = vi.fn<IsUnique>().mockResolvedValue(true)
+
     await expect(uniqueSlug(diacritics, isUnique)).resolves.toEqual('aaeeiioouuncaaeeiioouunc')
   })
 
@@ -43,12 +46,10 @@ describe('uniqueSlug', () => {
   // character the slugify config lets through outside that alphabet ends in an
   // opaque neode ERROR_VALIDATION on create. Guard the full alphabet contract.
   describe('always produces a slug matching /^[a-z0-9_-]+$/', () => {
-    const isUnique = jest.fn<IsUnique>().mockResolvedValue(true)
+    const isUnique = vi.fn<IsUnique>().mockResolvedValue(true)
 
     it('strips commas (slugify keeps them once a custom `remove` is set)', async () => {
-      await expect(uniqueSlug('Foo, Bar & Friends', isUnique)).resolves.toEqual(
-        'foo-bar-and-friends',
-      )
+      await expect(uniqueSlug('Foo, Bar & Friends', isUnique)).resolves.toBe('foo-bar-and-friends')
     })
 
     it('strips apostrophes', async () => {

--- a/backend/src/middleware/slugifyMiddleware.spec.ts
+++ b/backend/src/middleware/slugifyMiddleware.spec.ts
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { beforeAll, afterAll, beforeEach, afterEach, describe, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import SignupVerification from '@graphql/queries/auth/SignupVerification.gql'
 import CreateGroup from '@graphql/queries/groups/CreateGroup.gql'
@@ -501,6 +503,7 @@ describe('slugifyMiddleware', () => {
           content: 'Some edited content',
         }
         await mutate({ mutation: UpdatePost, variables: editVariables })
+
         await expect(
           mutate({ mutation: UpdatePost, variables: editVariables }),
         ).resolves.toMatchObject({

--- a/backend/src/middleware/softDelete/softDeleteMiddleware.spec.ts
+++ b/backend/src/middleware/softDelete/softDeleteMiddleware.spec.ts
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { beforeAll, afterAll, describe, beforeEach, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import Post from '@graphql/queries/posts/Post.gql'
 import User from '@graphql/queries/users/User.gql'
@@ -227,12 +229,15 @@ describe('softDeleteMiddleware', () => {
         it('displays name', () => {
           expect(subject.name).toEqual('Offensive Name')
         })
+
         it('displays slug', () => {
           expect(subject.slug).toEqual('offensive-name')
         })
+
         it('displays about', () => {
           expect(subject.about).toEqual('This self description is very offensive')
         })
+
         it('displays avatar', () => {
           expect(subject.avatar).toEqual({
             url: expect.stringMatching('http://localhost/some/offensive/avatar.jpg'),
@@ -246,12 +251,15 @@ describe('softDeleteMiddleware', () => {
         it('displays title', () => {
           expect(subject.title).toEqual('Disabled post')
         })
+
         it('displays slug', () => {
           expect(subject.slug).toEqual('disabled-post')
         })
+
         it('displays content', () => {
           expect(subject.content).toEqual('This is an offensive post content')
         })
+
         it('displays image', () => {
           expect(subject.image).toEqual({
             url: expect.stringMatching('http://localhost/some/offensive/image.jpg'),
@@ -279,12 +287,15 @@ describe('softDeleteMiddleware', () => {
         it('obfuscates name', () => {
           expect(subject.name).toEqual('UNAVAILABLE')
         })
+
         it('obfuscates slug', () => {
           expect(subject.slug).toEqual('UNAVAILABLE')
         })
+
         it('obfuscates about', () => {
           expect(subject.about).toEqual('UNAVAILABLE')
         })
+
         it('obfuscates avatar', () => {
           expect(subject.avatar).toEqual(null)
         })
@@ -296,12 +307,15 @@ describe('softDeleteMiddleware', () => {
         it('obfuscates title', () => {
           expect(subject.title).toEqual('UNAVAILABLE')
         })
+
         it('obfuscates slug', () => {
           expect(subject.slug).toEqual('UNAVAILABLE')
         })
+
         it('obfuscates content', () => {
           expect(subject.content).toEqual('UNAVAILABLE')
         })
+
         it('obfuscates image', () => {
           expect(subject.image).toEqual(null)
         })
@@ -326,6 +340,7 @@ describe('softDeleteMiddleware', () => {
 
         it('hides deleted or disabled posts', async () => {
           const expected = { data: { Post: [{ title: 'Publicly visible post' }] } }
+
           await expect(query({ query: Post })).resolves.toMatchObject(expected)
         })
       })
@@ -338,6 +353,7 @@ describe('softDeleteMiddleware', () => {
         it('shows disabled but hides deleted posts', async () => {
           const { data } = await query({ query: Post })
           const { Post: PostData } = data
+
           expect(PostData).toEqual(
             expect.arrayContaining([
               expect.objectContaining({ title: 'Disabled post' }),
@@ -362,6 +378,7 @@ describe('softDeleteMiddleware', () => {
             const {
               Post: [{ comments }],
             } = data
+
             expect(comments).toEqual(expect.arrayContaining(expected))
           })
         })
@@ -380,6 +397,7 @@ describe('softDeleteMiddleware', () => {
             const {
               Post: [{ comments }],
             } = data
+
             expect(comments).toEqual(expect.arrayContaining(expected))
           })
         })

--- a/backend/src/middleware/userInteractions.spec.ts
+++ b/backend/src/middleware/userInteractions.spec.ts
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
+import { beforeAll, afterAll, describe, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import Post from '@graphql/queries/posts/Post.gql'
 import { createApolloTestSetup } from '@root/test/helpers'
@@ -59,6 +61,7 @@ describe('middleware/userInteractions', () => {
 
     it('changes clickedCount when queried with ID', async () => {
       variables = { id: post.get('id') }
+
       await expect(query({ query: Post, variables })).resolves.toMatchObject({
         data: {
           Post: expect.arrayContaining([
@@ -84,6 +87,7 @@ describe('middleware/userInteractions', () => {
 
     it('changes clickedCount when another user queries the post', async () => {
       authenticatedUser = await bUser.toJson()
+
       await expect(query({ query: Post, variables })).resolves.toMatchObject({
         data: {
           Post: expect.arrayContaining([

--- a/backend/src/middleware/validation/validationMiddleware.spec.ts
+++ b/backend/src/middleware/validation/validationMiddleware.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { beforeAll, afterAll, beforeEach, afterEach, describe, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import CreateComment from '@graphql/queries/comments/CreateComment.gql'
 import UpdateComment from '@graphql/queries/comments/UpdateComment.gql'
@@ -99,6 +101,7 @@ afterEach(async () => {
 
 describe('validateCreateComment', () => {
   let createCommentVariables
+
   beforeEach(async () => {
     createCommentVariables = {
       postId: 'whatever',
@@ -109,6 +112,7 @@ describe('validateCreateComment', () => {
 
   it('throws an error if content is empty', async () => {
     createCommentVariables = { ...createCommentVariables, postId: 'post-4-commenting' }
+
     await expect(
       mutate({ mutation: CreateComment, variables: createCommentVariables }),
     ).resolves.toMatchObject({
@@ -119,6 +123,7 @@ describe('validateCreateComment', () => {
 
   it('sanitizes content and throws an error if not longer than 1 character', async () => {
     createCommentVariables = { postId: 'post-4-commenting', content: '<a></a>' }
+
     await expect(
       mutate({ mutation: CreateComment, variables: createCommentVariables }),
     ).resolves.toMatchObject({
@@ -133,6 +138,7 @@ describe('validateCreateComment', () => {
       postId: 'non-existent-post',
       content: 'valid content',
     }
+
     await expect(
       mutate({ mutation: CreateComment, variables: createCommentVariables }),
     ).resolves.toMatchObject({
@@ -143,6 +149,7 @@ describe('validateCreateComment', () => {
 
   describe('validateUpdateComment', () => {
     let updateCommentVariables
+
     beforeEach(async () => {
       await Factory.build(
         'comment',
@@ -162,6 +169,7 @@ describe('validateCreateComment', () => {
 
     it('throws an error if content is empty', async () => {
       updateCommentVariables = { ...updateCommentVariables, id: 'comment-id' }
+
       await expect(
         mutate({ mutation: UpdateComment, variables: updateCommentVariables }),
       ).resolves.toMatchObject({
@@ -172,6 +180,7 @@ describe('validateCreateComment', () => {
 
     it('sanitizes content and throws an error if not longer than 1 character', async () => {
       updateCommentVariables = { id: 'comment-id', content: '<a></a>' }
+
       await expect(
         mutate({ mutation: UpdateComment, variables: updateCommentVariables }),
       ).resolves.toMatchObject({
@@ -186,6 +195,7 @@ describe('validateReport', () => {
   it('throws an error if a user tries to report themself', async () => {
     authenticatedUser = await reportingUser.toJson()
     reportVariables = { ...reportVariables, resourceId: 'reporting-user' }
+
     await expect(
       mutate({ mutation: fileReport, variables: reportVariables }),
     ).resolves.toMatchObject({
@@ -210,6 +220,7 @@ describe('validateReview', () => {
 
   it('throws an error if a user tries to review a report against them', async () => {
     disableVariables = { ...disableVariables, resourceId: 'moderating-user' }
+
     await expect(mutate({ mutation: review, variables: disableVariables })).resolves.toMatchObject({
       data: { review: null },
       errors: [{ message: 'You cannot review yourself!' }],
@@ -218,6 +229,7 @@ describe('validateReview', () => {
 
   it('throws an error for invaild resource', async () => {
     disableVariables = { ...disableVariables, resourceId: 'non-existent-resource' }
+
     await expect(mutate({ mutation: review, variables: disableVariables })).resolves.toMatchObject({
       data: { review: null },
       errors: [{ message: 'Resource not found or is not a Post|Comment|User!' }],
@@ -226,6 +238,7 @@ describe('validateReview', () => {
 
   it('throws an error if no report exists', async () => {
     disableVariables = { ...disableVariables, resourceId: 'offensive-post' }
+
     await expect(mutate({ mutation: review, variables: disableVariables })).resolves.toMatchObject({
       data: { review: null },
       errors: [{ message: 'Before starting the review process, please report the Post!' }],
@@ -242,6 +255,7 @@ describe('validateReview', () => {
       reportAgainstOffensivePost.relateTo(offensivePost, 'belongsTo'),
     ])
     disableVariables = { ...disableVariables, resourceId: 'offensive-post' }
+
     await expect(mutate({ mutation: review, variables: disableVariables })).resolves.toMatchObject({
       data: { review: null },
       errors: [{ message: 'You cannot review your own Post!' }],
@@ -258,6 +272,7 @@ describe('validateReview', () => {
         ...disableVariables,
         resourceId: 'tag-id',
       }
+
       await expect(
         mutate({ mutation: review, variables: disableVariables }),
       ).resolves.toMatchObject({
@@ -289,6 +304,7 @@ describe('validateReview', () => {
         ...variables,
         name: '  ',
       }
+
       await expect(mutate({ mutation: UpdateUser, variables })).resolves.toMatchObject({
         data: { UpdateUser: null },
         errors: [{ message: 'Username must be at least 3 character long!' }],

--- a/backend/src/permission/gates.spec.ts
+++ b/backend/src/permission/gates.spec.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals'
+import { describe, it, expect } from 'vitest'
 
 import {
   blockingGateFor,
@@ -19,7 +19,7 @@ const ctx = (open: PermissionGate[] = []): GateContext => ({
 })
 
 describe('permission gates', () => {
-  describe('isGateOpen', () => {
+  describe(isGateOpen, () => {
     it('follows the backing policy effective value', () => {
       expect(isGateOpen('videoConference', ctx(['videoConference']))).toBe(true)
       expect(isGateOpen('videoConference', ctx([]))).toBe(false)
@@ -28,7 +28,8 @@ describe('permission gates', () => {
     })
 
     it('reads exactly the gate key', () => {
-      const getEffective = jest.fn((key: PermissionGate) => key === 'videoConference')
+      const getEffective = vi.fn((key: PermissionGate) => key === 'videoConference')
+
       expect(isGateOpen('videoConference', { policy: { getEffective } })).toBe(true)
       expect(getEffective).toHaveBeenCalledWith('videoConference')
     })
@@ -38,9 +39,10 @@ describe('permission gates', () => {
     })
   })
 
-  describe('isPermissionAvailable', () => {
+  describe(isPermissionAvailable, () => {
     it('ungated permissions are always available', () => {
       const closed = ctx() // every gate closed
+
       expect(isPermissionAvailable('post.create', closed)).toBe(true)
       expect(isPermissionAvailable('role.manage', closed)).toBe(true)
     })
@@ -76,7 +78,7 @@ describe('permission gates', () => {
     })
   })
 
-  describe('blockingGateFor', () => {
+  describe(blockingGateFor, () => {
     it('is null for an ungated permission and for a fully-open gated one', () => {
       expect(blockingGateFor('post.create', ctx())).toBeNull()
       expect(
@@ -97,7 +99,7 @@ describe('permission gates', () => {
     })
   })
 
-  describe('isPermissionGatePolicyKey', () => {
+  describe(isPermissionGatePolicyKey, () => {
     it('flags both gate policy keys', () => {
       expect(isPermissionGatePolicyKey('apiKeysEnabled')).toBe(true)
       expect(isPermissionGatePolicyKey('videoConference')).toBe(true)

--- a/backend/src/permission/schema.spec.ts
+++ b/backend/src/permission/schema.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import {
   allPermissionGates,
   allPermissionKeys,
@@ -43,7 +45,7 @@ const EXPECTED_KEYS: PermissionKey[] = [
 ]
 
 describe('permission catalog', () => {
-  describe('allPermissionKeys', () => {
+  describe(allPermissionKeys, () => {
     it('returns exactly the catalog keys, in declaration order', () => {
       expect(allPermissionKeys()).toEqual(EXPECTED_KEYS)
     })
@@ -51,6 +53,7 @@ describe('permission catalog', () => {
     it('returns a fresh array (mutating it does not affect the catalog)', () => {
       const first = allPermissionKeys()
       first.pop()
+
       expect(allPermissionKeys()).toEqual(EXPECTED_KEYS)
     })
   })
@@ -82,8 +85,10 @@ describe('permission catalog', () => {
       expect(gatesFor('apiKey.administer')).toEqual([])
       // A representative ungated right.
       expect(gatesFor('post.create')).toEqual([])
+
       // The projection carries the (multi-)gate through.
       const publicCall = permissionCatalog().find((e) => e.key === 'videoCall.create_public')
+
       expect(publicCall?.gatedBy).toEqual(['videoConference', 'groupsEnabled'])
     })
 
@@ -124,7 +129,7 @@ describe('permission catalog', () => {
     })
   })
 
-  describe('isKnownPermission', () => {
+  describe(isKnownPermission, () => {
     it('is true for every catalog key', () => {
       for (const key of EXPECTED_KEYS) {
         expect(isKnownPermission(key)).toBe(true)
@@ -138,11 +143,13 @@ describe('permission catalog', () => {
     })
   })
 
-  describe('permissionCatalog', () => {
+  describe(permissionCatalog, () => {
     it('projects every key with its group and description', () => {
       const catalog = permissionCatalog()
+
       expect(catalog).toHaveLength(EXPECTED_KEYS.length)
       expect(catalog.map((entry) => entry.key)).toEqual(EXPECTED_KEYS)
+
       for (const entry of catalog) {
         expect(entry.group).toBe(groupFor(entry.key))
         expect(entry.description).toBe(descriptionFor(entry.key))
@@ -150,7 +157,7 @@ describe('permission catalog', () => {
     })
   })
 
-  describe('sanitizePermissions', () => {
+  describe(sanitizePermissions, () => {
     it('drops unknown keys (catalog drift grants nothing)', () => {
       expect(sanitizePermissions(['role.manage', 'ghost.permission', 'post.pin'])).toEqual([
         'role.manage',

--- a/backend/src/plugins/apolloLogger.spec.ts
+++ b/backend/src/plugins/apolloLogger.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
-import { jest } from '@jest/globals'
+import { beforeAll, afterAll, afterEach, describe, beforeEach, it, expect } from 'vitest'
 
 import Factory, { cleanDatabase } from '@db/factories'
 import login from '@graphql/queries/auth/login.gql'
@@ -34,8 +34,8 @@ afterAll(async () => {
   database.neode.close()
 })
 
-const loggerSpy = jest.spyOn(ocelotLogger, 'debug')
-const consoleSpy = jest.spyOn(console, 'log')
+const loggerSpy = vi.spyOn(ocelotLogger, 'debug')
+const consoleSpy = vi.spyOn(console, 'log')
 
 afterEach(async () => {
   await cleanDatabase()

--- a/backend/src/policy/PolicyService.spec.ts
+++ b/backend/src/policy/PolicyService.spec.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 // Unit tests for PolicyService — no DB dependency. The repository is mocked
 // so we can verify resolution-order (DB > ENV > Schema-Default) deterministically.
-// (no-unsafe-assignment disabled: jest matchers like expect.objectContaining are `any`.)
+// (no-unsafe-assignment disabled: matchers like expect.objectContaining are `any`.)
 
-import { jest } from '@jest/globals'
+import { describe, beforeEach, it, expect, afterEach } from 'vitest'
 
 import type { PolicyChangeEvent, PolicyPubSub } from './PolicyService'
 import type {
@@ -14,8 +14,8 @@ import type {
 } from './repository'
 import type { PolicyKey } from './types'
 
-// The mocks carry the real signatures: `@jest/globals` types a bare `jest.fn()` as
-// `Mock<UnknownFunction>`, whose `mockResolvedValue` argument is `never`.
+// The mocks carry the real signatures: a bare `vi.fn()` types its `mockResolvedValue` argument
+// as `any`, which would let a wrong shape through unnoticed.
 interface Repository {
   readAllSettings: typeof ReadAllSettings
   readLastChange: typeof ReadLastChange
@@ -23,16 +23,16 @@ interface Repository {
   deleteSetting: typeof DeleteSetting
 }
 
-jest.unstable_mockModule('./repository', () => ({
+vi.mock('./repository', () => ({
   POLICY_NAMESPACE: 'policy',
-  readAllSettings: jest.fn<Repository['readAllSettings']>(),
-  readLastChange: jest.fn<Repository['readLastChange']>().mockResolvedValue(null),
-  writeSetting: jest.fn<Repository['writeSetting']>(),
-  deleteSetting: jest.fn<Repository['deleteSetting']>(),
+  readAllSettings: vi.fn<Repository['readAllSettings']>(),
+  readLastChange: vi.fn<Repository['readLastChange']>().mockResolvedValue(null),
+  writeSetting: vi.fn<Repository['writeSetting']>(),
+  deleteSetting: vi.fn<Repository['deleteSetting']>(),
 }))
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Imported below the mock registrations — a carry-over from Jest's ESM mode, where the
+// registration did not hoist. `vi.mock` does hoist, so a static import would bind the mock too.
 const {
   PolicyService,
   createInMemoryPolicyService,
@@ -47,10 +47,10 @@ const {
   deleteSetting: deleteSettingImpl,
 } = await import('./repository')
 
-const readAllSettings = readAllSettingsImpl as jest.MockedFunction<typeof readAllSettingsImpl>
-const readLastChange = readLastChangeImpl as jest.MockedFunction<typeof readLastChangeImpl>
-const writeSetting = writeSettingImpl as jest.MockedFunction<typeof writeSettingImpl>
-const deleteSetting = deleteSettingImpl as jest.MockedFunction<typeof deleteSettingImpl>
+const readAllSettings = vi.mocked(readAllSettingsImpl)
+const readLastChange = vi.mocked(readLastChangeImpl)
+const writeSetting = vi.mocked(writeSettingImpl)
+const deleteSetting = vi.mocked(deleteSettingImpl)
 
 // A minimal stub for the database-context shape that PolicyService passes through.
 // The repository is mocked above, so this object is never actually consulted.
@@ -58,7 +58,7 @@ const dbStub = {} as never
 
 describe('PolicyService', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    vi.clearAllMocks()
   })
 
   describe('init() resolution order', () => {
@@ -141,11 +141,13 @@ describe('PolicyService', () => {
       readAllSettings.mockResolvedValue({ publicRegistration: true })
       const svc = new PolicyService(dbStub)
       await svc.init({})
+
       expect(svc.get('publicRegistration')).toBe(true)
 
       // The DB changed out-of-process (e.g. a db:reset/seed); reload re-reads it.
       readAllSettings.mockResolvedValue({ publicRegistration: false })
       await svc.reload()
+
       expect(svc.get('publicRegistration')).toBe(false)
     })
 
@@ -155,7 +157,7 @@ describe('PolicyService', () => {
       // not left for the next restart to re-read. Must not throw (a bad row may
       // not crash startup).
       readAllSettings.mockResolvedValue({ publicRegistration: 42 })
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const svc = new PolicyService(dbStub)
       await svc.init({ PUBLIC_REGISTRATION: 'true' })
@@ -211,6 +213,7 @@ describe('PolicyService', () => {
     it('returns authenticated-only keys as null to an anonymous viewer', async () => {
       const svc = await initService()
       const snap = svc.getVisibleSnapshot(null)
+
       expect(Object.keys(snap).sort()).toEqual(ALL_KEYS)
       expect(snap.apiKeysEnabled).toBeNull()
       expect(snap.publicRegistration).toBe(false) // public key still has its value
@@ -219,6 +222,7 @@ describe('PolicyService', () => {
     it('exposes authenticated key values to a logged-in viewer', async () => {
       const svc = await initService()
       const snap = svc.getVisibleSnapshot({ authenticated: true })
+
       expect(Object.keys(snap).sort()).toEqual(ALL_KEYS)
       expect(snap.apiKeysEnabled).toBe(false) // value, not null
     })
@@ -228,6 +232,7 @@ describe('PolicyService', () => {
       // admin's effective permissions cover any permission-gated key; the shipped
       // keys are all public/authenticated, so an authenticated viewer sees them.
       const snap = svc.getVisibleSnapshot({ authenticated: true, permissions: ['policy.manage'] })
+
       expect(Object.keys(snap).sort()).toEqual(ALL_KEYS)
       expect(snap.apiKeysEnabled).toBe(false)
     })
@@ -235,6 +240,7 @@ describe('PolicyService', () => {
     it('returns integer keys as numbers (schema default) to a logged-in viewer', async () => {
       const svc = await initService()
       const snap = svc.getVisibleSnapshot({ authenticated: true })
+
       expect(snap.apiKeysMaxPerUser).toBe(5) // integer schema default, not coerced to boolean
       expect(snap.maxGroupPinnedPosts).toBe(1)
     })
@@ -242,6 +248,7 @@ describe('PolicyService', () => {
     it('hides authenticated integer keys as null from an anonymous viewer', async () => {
       const svc = await initService()
       const snap = svc.getVisibleSnapshot(null)
+
       expect(snap.apiKeysMaxPerUser).toBeNull()
       expect(snap.maxGroupPinnedPosts).toBeNull()
     })
@@ -304,6 +311,7 @@ describe('PolicyService', () => {
       readLastChange.mockResolvedValue(null)
       const svc = new PolicyService(dbStub)
       await svc.init({})
+
       expect(svc.getLastChange()).toBeNull()
     })
 
@@ -312,6 +320,7 @@ describe('PolicyService', () => {
       readLastChange.mockResolvedValue({ actor: 'someone', timestamp: '2020-01-01T00:00:00.000Z' })
       const svc = new PolicyService(dbStub)
       await svc.init({})
+
       expect(svc.getLastChange()).toEqual({
         actor: 'someone',
         timestamp: '2020-01-01T00:00:00.000Z',
@@ -324,6 +333,7 @@ describe('PolicyService', () => {
       const svc = new PolicyService(dbStub)
       await svc.init({})
       const event = await svc.set('publicRegistration', true, 'admin-id-1')
+
       expect(svc.getLastChange()).toEqual({ actor: 'admin-id-1', timestamp: event.timestamp })
     })
 
@@ -338,6 +348,7 @@ describe('PolicyService', () => {
         actor: 'remote-admin',
         timestamp: '2021-02-03T04:05:06.000Z',
       })
+
       expect(svc.getLastChange()).toEqual({
         actor: 'remote-admin',
         timestamp: '2021-02-03T04:05:06.000Z',
@@ -351,6 +362,7 @@ describe('PolicyService', () => {
         publicRegistration: true,
         categoriesActive: true,
       })
+
       expect(svc.get('publicRegistration')).toBe(true)
       expect(svc.get('categoriesActive')).toBe(true)
       // Unspecified keys still fall back to schema default
@@ -361,6 +373,7 @@ describe('PolicyService', () => {
 
     it('has a no-op init() that touches no DB (the double has none)', async () => {
       const svc = createInMemoryPolicyService({ publicRegistration: true })
+
       // Must resolve without hitting the repository / undefined this.db.
       await expect(svc.init({})).resolves.toBeUndefined()
       expect(readAllSettings).not.toHaveBeenCalled()
@@ -376,6 +389,7 @@ describe('PolicyService', () => {
         showGroupButtonInHeader: true,
         groupsEnabled: false,
       })
+
       expect(svc.get('showGroupButtonInHeader')).toBe(true)
       expect(svc.getEffective('groupsEnabled')).toBe(false)
       expect(svc.getEffective('showGroupButtonInHeader')).toBe(false)
@@ -386,12 +400,15 @@ describe('PolicyService', () => {
         showGroupButtonInHeader: true,
         groupsEnabled: true,
       })
+
       expect(on.getEffective('showGroupButtonInHeader')).toBe(true)
+
       // The dependency being on does not override the key's own off state.
       const off = createInMemoryPolicyService({
         showGroupButtonInHeader: false,
         groupsEnabled: true,
       })
+
       expect(off.getEffective('showGroupButtonInHeader')).toBe(false)
     })
   })
@@ -399,11 +416,11 @@ describe('PolicyService', () => {
   describe('set()', () => {
     it('persists the value, updates the cache, and publishes a change event', async () => {
       readAllSettings.mockResolvedValue({})
-      const publish = jest.fn<PolicyPubSub['publish']>()
+      const publish = vi.fn<PolicyPubSub['publish']>()
       const pubsub: PolicyPubSub = {
         publish,
-        subscribe: jest.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        subscribe: vi.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
 
       const svc = new PolicyService(dbStub)
@@ -509,13 +526,11 @@ describe('PolicyService', () => {
 
     it('still commits and logs (no throw / no unhandled rejection) when publish fails', async () => {
       readAllSettings.mockResolvedValue({})
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const pubsub: PolicyPubSub = {
-        publish: jest
-          .fn<PolicyPubSub['publish']>()
-          .mockImplementation(async () => Promise.reject(new Error('redis down'))),
-        subscribe: jest.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        publish: vi.fn<PolicyPubSub['publish']>().mockRejectedValue(new Error('redis down')),
+        subscribe: vi.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
 
       const svc = new PolicyService(dbStub)
@@ -528,6 +543,7 @@ describe('PolicyService', () => {
       // Let the catch on the floating publish promise run, then assert it logged.
       await Promise.resolve()
       await Promise.resolve()
+
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining('failed to publish'),
         expect.any(Error),
@@ -538,15 +554,15 @@ describe('PolicyService', () => {
 
     it('still commits and does not throw when publish fails SYNCHRONOUSLY', async () => {
       readAllSettings.mockResolvedValue({})
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const pubsub: PolicyPubSub = {
         // Synchronous throw (not a rejected promise) — the non-blocking guarantee
         // must still hold: set() resolves, the change is committed, it is logged.
-        publish: jest.fn(() => {
+        publish: vi.fn(() => {
           throw new Error('redis sync error')
         }),
-        subscribe: jest.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        subscribe: vi.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
 
       const svc = new PolicyService(dbStub)
@@ -592,11 +608,11 @@ describe('PolicyService', () => {
 
     it('publishes a change event', async () => {
       readAllSettings.mockResolvedValue({})
-      const publish = jest.fn<PolicyPubSub['publish']>()
+      const publish = vi.fn<PolicyPubSub['publish']>()
       const pubsub: PolicyPubSub = {
         publish,
-        subscribe: jest.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        subscribe: vi.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
 
       const svc = new PolicyService(dbStub)
@@ -647,11 +663,11 @@ describe('PolicyService', () => {
 
     it('publishes one change event per key that actually changed', async () => {
       readAllSettings.mockResolvedValue({ publicRegistration: true, categoriesActive: true })
-      const publish = jest.fn<PolicyPubSub['publish']>()
+      const publish = vi.fn<PolicyPubSub['publish']>()
       const pubsub: PolicyPubSub = {
         publish,
-        subscribe: jest.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        subscribe: vi.fn<PolicyPubSub['subscribe']>().mockResolvedValue(1),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
       const svc = new PolicyService(dbStub)
       await svc.init({}, pubsub) // defaults: publicRegistration=false, categoriesActive=false, inviteRegistration=true
@@ -700,7 +716,7 @@ describe('PolicyService', () => {
     it('discards a change whose value type does not match the schema', async () => {
       readAllSettings.mockResolvedValue({})
       readLastChange.mockResolvedValue(null)
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const svc = new PolicyService(dbStub)
       await svc.init({})
 
@@ -724,11 +740,11 @@ describe('PolicyService', () => {
   describe('init() with pubsub', () => {
     it('subscribes to POLICY_CHANGED_CHANNEL', async () => {
       readAllSettings.mockResolvedValue({})
-      const subscribe = jest.fn<PolicyPubSub['subscribe']>().mockResolvedValue(42)
+      const subscribe = vi.fn<PolicyPubSub['subscribe']>().mockResolvedValue(42)
       const pubsub: PolicyPubSub = {
-        publish: jest.fn<PolicyPubSub['publish']>(),
+        publish: vi.fn<PolicyPubSub['publish']>(),
         subscribe,
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
 
       const svc = new PolicyService(dbStub)
@@ -741,19 +757,20 @@ describe('PolicyService', () => {
       readAllSettings.mockResolvedValue({})
       let onMessage: ((payload: { policyChanged: PolicyChangeEvent }) => void) | undefined
       const pubsub: PolicyPubSub = {
-        publish: jest.fn<PolicyPubSub['publish']>(),
-        subscribe: jest
+        publish: vi.fn<PolicyPubSub['publish']>(),
+        subscribe: vi
           .fn<PolicyPubSub['subscribe']>()
           .mockImplementation(async (_channel, handler) => {
             onMessage = handler
             await Promise.resolve()
             return 7
           }),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
 
       const svc = new PolicyService(dbStub)
       await svc.init({}, pubsub)
+
       expect(svc.get('publicRegistration')).toBe(false)
 
       onMessage?.({
@@ -775,15 +792,15 @@ describe('PolicyService', () => {
     it('does not lose a change that arrives during init (subscribe-first; snapshot does not clobber)', async () => {
       let onMessage: ((payload: { policyChanged: PolicyChangeEvent }) => void) | undefined
       const pubsub: PolicyPubSub = {
-        publish: jest.fn<PolicyPubSub['publish']>(),
-        subscribe: jest
+        publish: vi.fn<PolicyPubSub['publish']>(),
+        subscribe: vi
           .fn<PolicyPubSub['subscribe']>()
           .mockImplementation(async (_channel, handler) => {
             onMessage = handler
             await Promise.resolve()
             return 1
           }),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
       // Another instance publishes a change while we read the (now stale) snapshot.
       // Because we subscribe BEFORE reading, the callback is already live; the
@@ -812,15 +829,15 @@ describe('PolicyService', () => {
       readAllSettings.mockResolvedValue({}) // key missing → seed path runs
       let onMessage: ((payload: { policyChanged: PolicyChangeEvent }) => void) | undefined
       const pubsub: PolicyPubSub = {
-        publish: jest.fn<PolicyPubSub['publish']>(),
-        subscribe: jest
+        publish: vi.fn<PolicyPubSub['publish']>(),
+        subscribe: vi
           .fn<PolicyPubSub['subscribe']>()
           .mockImplementation(async (_channel, handler) => {
             onMessage = handler
             await Promise.resolve()
             return 1
           }),
-        unsubscribe: jest.fn<PolicyPubSub['unsubscribe']>(),
+        unsubscribe: vi.fn<PolicyPubSub['unsubscribe']>(),
       }
       // While we seed 'publicRegistration' (default false), a concurrent admin
       // change event arrives mid-write. The post-await cache re-check (`??=`) must
@@ -850,10 +867,10 @@ describe('PolicyService', () => {
   describe('shutdown()', () => {
     it('unsubscribes from the pubsub channel', async () => {
       readAllSettings.mockResolvedValue({})
-      const unsubscribe = jest.fn()
+      const unsubscribe = vi.fn()
       const pubsub: PolicyPubSub = {
-        publish: jest.fn<PolicyPubSub['publish']>(),
-        subscribe: jest.fn<PolicyPubSub['subscribe']>().mockResolvedValue(99),
+        publish: vi.fn<PolicyPubSub['publish']>(),
+        subscribe: vi.fn<PolicyPubSub['subscribe']>().mockResolvedValue(99),
         unsubscribe,
       }
 
@@ -862,8 +879,10 @@ describe('PolicyService', () => {
       svc.shutdown()
 
       expect(unsubscribe).toHaveBeenCalledWith(99)
+
       // Idempotent: a second shutdown does not unsubscribe again.
       svc.shutdown()
+
       expect(unsubscribe).toHaveBeenCalledTimes(1)
     })
 
@@ -871,6 +890,7 @@ describe('PolicyService', () => {
       readAllSettings.mockResolvedValue({})
       const svc = new PolicyService(dbStub)
       await svc.init({}) // no pubsub
+
       expect(() => {
         svc.shutdown()
       }).not.toThrow()
@@ -880,6 +900,7 @@ describe('PolicyService', () => {
   describe('get() before init()', () => {
     it('falls back to the schema default', () => {
       const svc = new PolicyService(dbStub)
+
       expect(svc.get('inviteRegistration')).toBe(true) // schema default, no DB access
       expect(svc.get('publicRegistration')).toBe(false)
       expect(readAllSettings).not.toHaveBeenCalled()
@@ -895,12 +916,14 @@ describe('PolicyService', () => {
       setPolicyServiceForTesting(undefined)
       const a = getPolicyService()
       const b = getPolicyService()
+
       expect(a).toBe(b)
     })
 
     it('can be swapped out for testing', () => {
       const fake = createInMemoryPolicyService({ publicRegistration: true })
       setPolicyServiceForTesting(fake)
+
       expect(getPolicyService()).toBe(fake)
     })
   })

--- a/backend/src/policy/repository.spec.ts
+++ b/backend/src/policy/repository.spec.ts
@@ -6,6 +6,8 @@
 // the id-uniqueness encoding) is verified end-to-end. PolicyService.spec.ts
 // mocks this module; here we run it for real.
 
+import { beforeEach, afterAll, describe, it, expect } from 'vitest'
+
 import databaseContext from '@context/database'
 import { cleanDatabase } from '@db/factories'
 
@@ -48,6 +50,7 @@ describe('writeSetting / readAllSettings', () => {
     await writeSetting(db, 'branding', 'logo', 'url', 'admin-1')
 
     const policy = await readAllSettings(db, POLICY_NAMESPACE)
+
     expect(policy).toEqual({ publicRegistration: true })
   })
 
@@ -56,12 +59,14 @@ describe('writeSetting / readAllSettings', () => {
     await writeSetting(db, POLICY_NAMESPACE, 'publicRegistration', true, 'admin-2')
 
     const settings = await readAllSettings(db, POLICY_NAMESPACE)
+
     expect(settings).toEqual({ publicRegistration: true })
 
     const result = await db.query({
       query: `MATCH (s:Setting {namespace: $namespace, key: $key}) RETURN count(s) AS n`,
       variables: { namespace: POLICY_NAMESPACE, key: 'publicRegistration' },
     })
+
     expect(result.records[0].get('n').toNumber()).toBe(1)
   })
 
@@ -72,6 +77,7 @@ describe('writeSetting / readAllSettings', () => {
       query: `MATCH (s:Setting {namespace: $namespace, key: $key}) RETURN s.id AS id`,
       variables: { namespace: POLICY_NAMESPACE, key: 'publicRegistration' },
     })
+
     expect(result.records[0].get('id')).toBe('policy.publicRegistration')
   })
 
@@ -84,6 +90,7 @@ describe('writeSetting / readAllSettings', () => {
     })
 
     const settings = await readAllSettings(db, POLICY_NAMESPACE)
+
     expect(settings).toEqual({ publicRegistration: true }) // 'broken' silently skipped
   })
 
@@ -92,13 +99,14 @@ describe('writeSetting / readAllSettings', () => {
   })
 })
 
-describe('readLastChange', () => {
+describe(readLastChange, () => {
   it('returns null when nothing has been written', async () => {
     expect(await readLastChange(db, POLICY_NAMESPACE)).toBeNull()
   })
 
   it('ignores system writes (actor "system:*")', async () => {
     await writeSetting(db, POLICY_NAMESPACE, 'publicRegistration', true, 'system:seed')
+
     expect(await readLastChange(db, POLICY_NAMESPACE)).toBeNull()
   })
 
@@ -107,17 +115,22 @@ describe('readLastChange', () => {
     await writeSetting(db, POLICY_NAMESPACE, 'inviteRegistration', true, 'admin-7')
 
     const last = await readLastChange(db, POLICY_NAMESPACE)
+
     expect(last?.actor).toBe('admin-7')
     expect(typeof last?.timestamp).toBe('string')
   })
 })
 
-describe('deleteSetting', () => {
+describe(deleteSetting, () => {
   it('removes the setting node', async () => {
     await writeSetting(db, POLICY_NAMESPACE, 'publicRegistration', true, 'admin-1')
-    expect(await readAllSettings(db, POLICY_NAMESPACE)).toEqual({ publicRegistration: true })
+
+    await expect(readAllSettings(db, POLICY_NAMESPACE)).resolves.toEqual({
+      publicRegistration: true,
+    })
 
     await deleteSetting(db, POLICY_NAMESPACE, 'publicRegistration')
+
     expect(await readAllSettings(db, POLICY_NAMESPACE)).toEqual({})
   })
 

--- a/backend/src/policy/schema.spec.ts
+++ b/backend/src/policy/schema.spec.ts
@@ -1,7 +1,7 @@
 // Unit tests for the visibility primitive — the single mechanism shared by the
 // `policy` query resolver and the policyChanged subscription filter.
 
-import { jest } from '@jest/globals'
+import { describe, it, expect } from 'vitest'
 
 import {
   allKeys,
@@ -13,6 +13,14 @@ import {
   typeFor,
   visibleKeys,
 } from './schema'
+
+// vitest has no `isolateModulesAsync`: resetting the registry before the dynamic import does the
+// same job, since a module graph is only shared within a file. Wrapped so the call sites keep
+// reading as "load this in isolation".
+const isolateModules = async (run: () => Promise<void>): Promise<void> => {
+  vi.resetModules()
+  await run()
+}
 
 // The subset of ./schema the perm-gating tests re-import against a mocked JSON
 // schema. Built from the already-imported functions to avoid a namespace import.
@@ -32,6 +40,7 @@ describe('policy visibility', () => {
     it('returns a copy — mutating it does not alter the shared schema', () => {
       const audiences = audiencesFor('apiKeysEnabled')
       audiences.push('public') // would widen visibility if it were the shared ref
+
       expect(audiencesFor('apiKeysEnabled')).toEqual(['authenticated'])
       // canView must stay unaffected: an anonymous viewer still cannot see it.
       expect(canView('apiKeysEnabled', null)).toBe(false)
@@ -87,10 +96,10 @@ describe('policy visibility', () => {
     // The fresh module is passed as an object (not destructured) so its functions
     // don't shadow the outer imports.
     const withMockedSchema = async (run: (schema: SchemaModule) => void) => {
-      await jest.isolateModulesAsync(async () => {
+      await isolateModules(async () => {
         // `default:` because the consumer imports the JSON as a default; ESM mock factories get
         // no CommonJS interop layer to synthesise one.
-        jest.unstable_mockModule('./policy.schema.json', () => ({
+        vi.doMock('./policy.schema.json', () => ({
           default: {
             type: 'object',
             properties: {
@@ -127,6 +136,7 @@ describe('policy visibility', () => {
     it('gates an explicit perm:<key> on exactly that permission', async () => {
       await withMockedSchema((schema) => {
         const viewer = (permissions: string[]) => ({ authenticated: true, permissions })
+
         expect(schema.canView('badgeGatedKey' as never, viewer(['badge.manage']))).toBe(true)
         // a different held permission must NOT unlock it
         expect(schema.canView('badgeGatedKey' as never, viewer(['policy.manage']))).toBe(false)
@@ -197,7 +207,7 @@ describe('policy visibility', () => {
   })
 })
 
-describe('categoryFor', () => {
+describe(categoryFor, () => {
   it('returns each key’s declared admin-config category', () => {
     expect(categoryFor('publicRegistration')).toBe('registration')
     expect(categoryFor('inviteLinkLimit')).toBe('registration')
@@ -215,7 +225,7 @@ describe('categoryFor', () => {
   })
 })
 
-describe('requiresPolicyFor', () => {
+describe(requiresPolicyFor, () => {
   it('returns the declared policy→policy dependencies (empty for most keys)', () => {
     expect(requiresPolicyFor('showGroupButtonInHeader')).toEqual(['groupsEnabled'])
     expect(requiresPolicyFor('groupsEnabled')).toEqual([])
@@ -225,6 +235,7 @@ describe('requiresPolicyFor', () => {
   it('returns a fresh copy — a caller mutating it cannot alter the shared schema', () => {
     const deps = requiresPolicyFor('showGroupButtonInHeader')
     deps.push('groupsEnabled')
+
     expect(requiresPolicyFor('showGroupButtonInHeader')).toEqual(['groupsEnabled'])
   })
 
@@ -239,6 +250,7 @@ describe('requiresPolicyFor', () => {
         expect(allKeys()).toContain(dep)
         expect(typeFor(key)).toBe('boolean')
         expect(typeFor(dep)).toBe('boolean')
+
         // Every audience that can see the dependent must also see the dependency.
         for (const audience of keyAudiences) {
           expect(audiencesFor(dep)).toContain(audience)
@@ -258,8 +270,8 @@ describe('requiresPolicyFor', () => {
     // Async: ESM has no synchronous module load. isolateModulesAsync would swallow the load
     // rejection this asserts on, so the registry is reset directly instead.
     const loadWith = (properties: Record<string, unknown>) => async (): Promise<void> => {
-      jest.resetModules()
-      jest.unstable_mockModule('./policy.schema.json', () => ({
+      vi.resetModules()
+      vi.doMock('./policy.schema.json', () => ({
         default: { type: 'object', properties },
       }))
       await import('./schema')

--- a/backend/src/policy/valueLayers.spec.ts
+++ b/backend/src/policy/valueLayers.spec.ts
@@ -1,11 +1,14 @@
+import { describe, it, expect } from 'vitest'
+
 import { createInMemoryPolicyService, policyValueLayers } from './index'
 
 // Driven through a real in-memory PolicyService so the effective/default folding is
 // exercised exactly as in production; the same helper feeds both the policyConfig resolver
 // and systemConfigStatus, which is why the encoding lives in one place.
-describe('policyValueLayers', () => {
+describe(policyValueLayers, () => {
   it('JSON-encodes all three layers of a boolean key with no override', () => {
     const policy = createInMemoryPolicyService({}, {})
+
     expect(policyValueLayers(policy, 'apiKeysEnabled')).toEqual({
       effective: 'false',
       softwareDefault: 'false',
@@ -15,6 +18,7 @@ describe('policyValueLayers', () => {
 
   it('JSON-encodes an integer key as a number literal', () => {
     const policy = createInMemoryPolicyService({}, {})
+
     expect(policyValueLayers(policy, 'maxPinnedPosts')).toEqual({
       effective: '1',
       softwareDefault: '1',
@@ -30,6 +34,7 @@ describe('policyValueLayers', () => {
       { API_KEYS_ENABLED: 'true' },
     )
     const layers = policyValueLayers(policy, 'apiKeysEnabled')
+
     expect(layers.effective).toBe('false')
     expect(layers.configuredDefault).toBe('true')
     // The software default is the schema baseline, independent of the env seed.

--- a/backend/src/proxy.spec.ts
+++ b/backend/src/proxy.spec.ts
@@ -1,7 +1,7 @@
 import { once } from 'node:events'
 import http from 'node:http'
 
-import { jest } from '@jest/globals'
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
 
 import createProxy from './proxy'
 
@@ -47,7 +47,7 @@ async function request(
   }
 }
 
-describe('createProxy', () => {
+describe(createProxy, () => {
   let target: http.Server
   let targetPort: number
   let proxy: http.Server
@@ -118,7 +118,7 @@ describe('createProxy', () => {
   })
 
   it('responds with 500 when the target is unreachable', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const closedTarget = http.createServer()
     const closedPort = await listen(closedTarget)
     await close(closedTarget)
@@ -128,11 +128,14 @@ describe('createProxy', () => {
 
     try {
       const res = await request(brokenPort, { path: '/gone' })
+
       expect(res.status).toBe(500)
       expect(res.body).toBe('Proxy error')
       expect(res.headers['content-type']).toBe('text/plain')
       expect(errorSpy).toHaveBeenCalledTimes(1)
+
       const [prefix, err] = errorSpy.mock.calls[0] as [unknown, unknown]
+
       expect(prefix).toBe('Proxy request error:')
       expect((err as Error).message).toContain('ECONNREFUSED')
     } finally {

--- a/backend/src/role/RoleService.spec.ts
+++ b/backend/src/role/RoleService.spec.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals'
+import { describe, it, expect } from 'vitest'
 
 import { allPermissionKeys } from '@src/permission'
 
@@ -20,7 +20,7 @@ const BASELINE = [
   'apiKey.create',
 ]
 
-describe('RoleService', () => {
+describe(RoleService, () => {
   describe('permissionsForRole (single-role resolution)', () => {
     const svc = createInMemoryRoleService()
 
@@ -36,8 +36,10 @@ describe('RoleService', () => {
 
     it('returns the self-contained moderator set (baseline + content.moderate + badge.manage)', () => {
       const perms = svc.permissionsForRole(MODERATOR_ROLE)
+
       expect(perms.has('content.moderate')).toBe(true)
       expect(perms.has('badge.manage')).toBe(true)
+
       for (const baseline of BASELINE) {
         expect(perms.has(baseline as never)).toBe(true)
       }
@@ -45,10 +47,12 @@ describe('RoleService', () => {
 
     it('returns the self-contained admin set (baseline + moderation + admin extras)', () => {
       const perms = svc.permissionsForRole(ADMIN_ROLE)
+
       expect(perms.has('content.moderate')).toBe(true)
       expect(perms.has('role.manage')).toBe(true)
       expect(perms.has('policy.manage')).toBe(true)
       expect(perms.has('badge.manage')).toBe(true)
+
       for (const baseline of BASELINE) {
         expect(perms.has(baseline as never)).toBe(true)
       }
@@ -64,6 +68,7 @@ describe('RoleService', () => {
 
     it('returns roles broadest-first (owner, then by permission count)', () => {
       const names = svc.allRoles().map((role) => role.name)
+
       expect(names).toEqual([OWNER_ROLE, ADMIN_ROLE, MODERATOR_ROLE, USER_ROLE])
     })
 
@@ -88,6 +93,7 @@ describe('RoleService', () => {
         timestamp: 't',
       }
       svc.applyExternalChange(event)
+
       expect(svc.getRole('editor')?.permissions).toEqual(['post.create'])
     })
 
@@ -99,6 +105,7 @@ describe('RoleService', () => {
         actor: 'u1',
         timestamp: 't',
       })
+
       expect(svc.getRole(MODERATOR_ROLE)).toBeUndefined()
     })
 
@@ -116,6 +123,7 @@ describe('RoleService', () => {
         actor: 'u1',
         timestamp: 't',
       })
+
       expect(svc.getRole(MODERATOR_ROLE)).toBeUndefined()
       expect(svc.getRole('staff')?.permissions).toEqual(['content.moderate'])
     })
@@ -233,7 +241,9 @@ describe('RoleService', () => {
         name: 'badge-setter',
         actor: 'admin-1',
       })
+
       const event = published[published.length - 1]?.payload.roleChanged
+
       expect(event?.name).toBe('badge-setter')
       expect(event?.definition?.permissions).toEqual(['badge.manage'])
     })
@@ -246,7 +256,9 @@ describe('RoleService', () => {
       await svc.deleteRole('temp', 'admin-1')
 
       expect(svc.getRole('temp')).toBeUndefined()
+
       const event = published[published.length - 1]?.payload.roleChanged
+
       expect(event).toMatchObject({ name: 'temp', definition: null, actor: 'admin-1' })
     })
 
@@ -267,8 +279,10 @@ describe('RoleService', () => {
         newName: 'badge-setter',
         actor: 'a-1',
       })
+
       // Broadcast carries the previous name so peers drop the stale key.
       const event = published[published.length - 1]?.payload.roleChanged
+
       expect(event).toMatchObject({
         name: 'badge-setter',
         previousName: 'temp',
@@ -281,7 +295,7 @@ describe('RoleService', () => {
       // The write never lands (fake write is a no-op), so `user` stays missing even
       // after the self-heal attempt. init() must reject so a broken instance never
       // serves traffic.
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const fakeDb = {
         query: async () =>
           Promise.resolve({
@@ -290,7 +304,9 @@ describe('RoleService', () => {
         write: async () => Promise.resolve({ records: [] }),
       } as unknown as DbArg
       const svc = new RoleService(fakeDb)
+
       await expect(svc.init()).rejects.toThrow(/mandatory role node\(s\) missing after seeding/)
+
       warn.mockRestore()
     })
 
@@ -313,6 +329,7 @@ describe('RoleService', () => {
       await svc.init()
 
       const seeded = writes.map((w) => w.variables?.name)
+
       expect(seeded).toEqual(
         expect.arrayContaining([OWNER_ROLE, ADMIN_ROLE, MODERATOR_ROLE, USER_ROLE]),
       )
@@ -345,6 +362,7 @@ describe('RoleService', () => {
         actor: 'x',
         timestamp: 't',
       })
+
       expect(svc.getRole('ghost')).toBeDefined()
 
       await svc.reload()
@@ -359,7 +377,7 @@ describe('RoleService', () => {
       // Same boot invariant as init(): if the resync ends up without a mandatory role
       // (here `user` never lands because the fake write is a no-op), reload() must reject
       // rather than silently install a half-empty role set.
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const fakeDb = {
         query: async () =>
           Promise.resolve({
@@ -368,7 +386,9 @@ describe('RoleService', () => {
         write: async () => Promise.resolve({ records: [] }),
       } as unknown as DbArg
       const svc = new RoleService(fakeDb)
+
       await expect(svc.reload()).rejects.toThrow(/mandatory role node\(s\) missing after seeding/)
+
       warn.mockRestore()
     })
 
@@ -415,7 +435,7 @@ describe('RoleService', () => {
     })
 
     it('self-heals only the missing mandatory role (not admin/moderator) and warns', async () => {
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const writes: Array<{ variables?: { name?: string } }> = []
       let queryCalls = 0
       const fakeDb = {
@@ -439,10 +459,12 @@ describe('RoleService', () => {
       await svc.init()
 
       const seeded = writes.map((w) => w.variables?.name)
+
       expect(seeded).toEqual([USER_ROLE]) // only the missing mandatory role
       expect(seeded).not.toContain(ADMIN_ROLE)
       expect(seeded).not.toContain(MODERATOR_ROLE)
       expect(warn).toHaveBeenCalledWith(expect.stringContaining(USER_ROLE))
+
       warn.mockRestore()
     })
   })

--- a/backend/src/role/defaults.spec.ts
+++ b/backend/src/role/defaults.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { isKnownPermission } from '@src/permission'
 
 import { DEFAULT_ROLES } from './defaults'
@@ -25,8 +27,10 @@ describe('DEFAULT_ROLES', () => {
 
   it('marks only owner as protected, with no stored permissions (expanded to all at runtime)', () => {
     const owner = DEFAULT_ROLES.find((role) => role.name === OWNER_ROLE)
+
     expect(owner?.protected).toBe(true)
     expect(owner?.permissions).toEqual([])
+
     for (const role of DEFAULT_ROLES.filter((r) => r.name !== OWNER_ROLE)) {
       expect(role.protected).toBe(false)
     }
@@ -94,6 +98,7 @@ describe('DEFAULT_ROLES', () => {
     const admin = new Set(permsOf(ADMIN_ROLE))
     const isStrictSuperset = (a: Set<string>, b: Set<string>) =>
       a.size > b.size && [...b].every((p) => a.has(p))
+
     expect(isStrictSuperset(moderator, user)).toBe(true)
     expect(isStrictSuperset(admin, moderator)).toBe(true)
   })

--- a/backend/src/role/dominance.spec.ts
+++ b/backend/src/role/dominance.spec.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { dominates } from './dominance'
 
 import type { PermissionKey } from '@src/permission'

--- a/backend/src/role/effectiveRoleNames.spec.ts
+++ b/backend/src/role/effectiveRoleNames.spec.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals'
+import { afterEach, describe, it, expect } from 'vitest'
 
 import { effectiveRoleName, resolveRoleName } from './effectiveRoleNames'
 import { USER_ROLE } from './types'
@@ -6,7 +6,7 @@ import { USER_ROLE } from './types'
 // Restore any spy (e.g. the console.warn spy below) even if an assertion throws
 // mid-test, so a leaked mock can't corrupt later tests.
 afterEach(() => {
-  jest.restoreAllMocks()
+  vi.restoreAllMocks()
 })
 
 describe('resolveRoleName (collapse HAS_ROLE edges → one role)', () => {
@@ -24,7 +24,8 @@ describe('resolveRoleName (collapse HAS_ROLE edges → one role)', () => {
   it('fails closed to the baseline (and warns) when more than one edge is present', () => {
     // Multiple HAS_ROLE edges violate the single-role model. Picking the "highest"
     // would be a privilege-escalation oracle on corrupt data, so we drop to USER_ROLE.
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
     expect(resolveRoleName(['admin', 'user'])).toBe(USER_ROLE)
     expect(resolveRoleName(['owner', 'admin'])).toBe(USER_ROLE)
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('single-role model violated'))

--- a/backend/src/role/userRoleEdges.spec.ts
+++ b/backend/src/role/userRoleEdges.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
+import { describe, beforeEach, afterAll, it, expect } from 'vitest'
+
 import Factory, { cleanDatabase } from '@db/factories'
 import { getDriver } from '@db/neo4j'
 
@@ -58,12 +60,14 @@ describe('role-edge helpers (DB)', () => {
 
   it('seeds the default role nodes', async () => {
     await ensureUserRoleEdges()
+
     expect(await roleNodeExists('owner')).toBe(true)
     expect(await roleNodeExists('user')).toBe(true)
   })
 
   it('gives every (edgeless) user a HAS_ROLE edge matching their legacy tier', async () => {
     await ensureUserRoleEdges()
+
     expect(await rolesOf('a')).toEqual(['admin'])
     expect(await rolesOf('m')).toEqual(['moderator'])
     expect(await rolesOf('u')).toEqual(['user'])
@@ -72,19 +76,22 @@ describe('role-edge helpers (DB)', () => {
   it('is idempotent — re-running adds no duplicate edges', async () => {
     await ensureUserRoleEdges()
     await ensureUserRoleEdges()
+
     expect(await rolesOf('a')).toEqual(['admin'])
   })
 
-  describe('promoteToOwner', () => {
+  describe(promoteToOwner, () => {
     it('promotes a user found by email, replacing their previous role', async () => {
       await ensureUserRoleEdges() // 'u' now holds the user edge
       const result = await promoteToOwner('u@e.org')
+
       expect(result?.id).toBe('u')
       expect(await rolesOf('u')).toEqual(['owner']) // single edge, replaced
     })
 
     it('promotes a user found by id (seeds roles itself, no prior edge needed)', async () => {
       const result = await promoteToOwner('a')
+
       expect(result?.id).toBe('a')
       expect(await rolesOf('a')).toEqual(['owner'])
     })
@@ -98,6 +105,7 @@ describe('role-edge helpers (DB)', () => {
         { email: 's@e.org', password: '1' },
       )
       const result = await promoteToOwner('slug-user')
+
       expect(result?.id).toBe('s')
       expect(await rolesOf('s')).toEqual(['owner'])
     })
@@ -156,6 +164,7 @@ describe('role-edge helpers (DB)', () => {
         { id: 'o', role: 'admin' },
         { email: 'o@e.org', password: '1', roleName: 'owner' },
       )
+
       expect(await rolesOf('o')).toEqual(['owner']) // owner edge, not the admin tier
     })
   })

--- a/backend/src/uploads/s3Service.spec.ts
+++ b/backend/src/uploads/s3Service.spec.ts
@@ -1,35 +1,43 @@
 import { Readable } from 'node:stream'
 
-import { jest } from '@jest/globals'
+import { describe, beforeEach, it, expect } from 'vitest'
 
 import type { S3Config } from '@config/index'
 import type { FileUpload } from 'graphql-upload'
+import type { Mock } from 'vitest'
 
-jest.unstable_mockModule('@aws-sdk/client-s3', () => {
+// `function`, not an arrow: these stand in for CLASSES and the code under test calls them with
+// `new`. Vitest constructs the mock's implementation via Reflect.construct, and an arrow function
+// is not a constructor — Jest got away with arrows because it applied the implementation instead.
+vi.mock('@aws-sdk/client-s3', () => {
   return {
-    S3Client: jest.fn().mockImplementation(() => ({
-      send: jest.fn(),
-    })),
+    S3Client: vi.fn().mockImplementation(function () {
+      return { send: vi.fn() }
+    }),
     ObjectCannedACL: { public_read: 'public_read' },
-    DeleteObjectCommand: jest.fn().mockImplementation(() => ({})),
+    DeleteObjectCommand: vi.fn().mockImplementation(function () {
+      return {}
+    }),
   }
 })
 
-jest.unstable_mockModule('@aws-sdk/lib-storage', () => {
+vi.mock('@aws-sdk/lib-storage', () => {
   return {
-    Upload: jest.fn(),
+    Upload: vi.fn(),
   }
 })
 
-// Imported after the mock registrations, not above them: `unstable_mockModule`
-// does not hoist, so a static import would bind the real module first.
+// Dynamic imports: `vi.mock` above is hoisted, so these resolve to the mocked modules.
 const { Upload } = await import('@aws-sdk/lib-storage')
 const { s3Service } = await import('./s3Service')
 
+// Cast, not vi.mocked(Upload): the real signature is a constructor taking the full SDK
+// `Options`, while the stub only needs the one field the service passes and returns a `done()`.
 interface UploadInput {
   params: { Bucket: string; Key: string; ContentType: string; Body: unknown }
 }
-const uploadMock = Upload as unknown as jest.Mock<
+
+const uploadMock = Upload as unknown as Mock<
   (input: UploadInput) => { done: () => Promise<{ Location: string }> }
 >
 
@@ -57,16 +65,19 @@ describe('s3Service', () => {
   describe('upload', () => {
     beforeEach(() => {
       uploadMock.mockReset()
-      uploadMock.mockImplementation(({ params: { Key } }) => ({
-        done: async () =>
-          Promise.resolve({ Location: `http://your-objectstorage.com/bucket/${Key}` }),
-      }))
+      uploadMock.mockImplementation(function ({ params: { Key } }: UploadInput) {
+        return {
+          done: async () =>
+            Promise.resolve({ Location: `http://your-objectstorage.com/bucket/${Key}` }),
+        }
+      })
     })
 
     it('hands the file to the s3 client library as a readable `Body`', async () => {
       const service = s3Service(config, 'ocelot-social')
       await service.uploadFile(input)
       const { params } = uploadMock.mock.calls[0][0]
+
       expect(params).toMatchObject({
         Bucket: 'AWS_BUCKET',
         Key: 'ocelot-social/unique-filename.jpg',
@@ -78,6 +89,7 @@ describe('s3Service', () => {
     describe('if the S3 service returns a valid URL as a `Location`', () => {
       it('returns the `Location` that was returned by the s3 client library', async () => {
         const service = s3Service(config, 'ocelot-social')
+
         await expect(service.uploadFile(input)).resolves.toEqual(
           'http://your-objectstorage.com/bucket/ocelot-social/unique-filename.jpg',
         )
@@ -86,13 +98,16 @@ describe('s3Service', () => {
 
     describe('but if for some reason, the S3 service returns a `Location` wich is not a valid URL and misses the protocol part', () => {
       beforeEach(() => {
-        uploadMock.mockImplementation(({ params: { Key } }) => ({
-          done: async () => Promise.resolve({ Location: `your-objectstorage.com/bucket/${Key}` }),
-        }))
+        uploadMock.mockImplementation(function ({ params: { Key } }: UploadInput) {
+          return {
+            done: async () => Promise.resolve({ Location: `your-objectstorage.com/bucket/${Key}` }),
+          }
+        })
       })
 
       it('adds `https:` as protocol', async () => {
         const service = s3Service(config, 'ocelot-social')
+
         await expect(service.uploadFile(input)).resolves.toEqual(
           'https://your-objectstorage.com/bucket/ocelot-social/unique-filename.jpg',
         )


### PR DESCRIPTION
…ing specs

Jest -> Vitest migration, shard B/2 (review shard, not meant to merge standalone — see the 'vitest' branch for the full, tested state):

- backend/src/middleware/**
- backend/src/db/**, src/role/**, src/policy/**, src/permission/**
- backend/src/emails/** (incl. snapshots), config/**, branding/**, livekit/**, jwt/**, context/**, uploads/**, plugins/**, proxy.spec.ts converted to Vitest syntax

<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Umfangreiche Testsuiten auf den neuen Test-Runner umgestellt.
  - Branding- und E-Mail-Darstellung umfassender abgesichert.
  - Zusätzliche Prüfungen für die korrekte Behandlung von Branding-Ressourcen ergänzt.
  - Bestehende Tests für Routing, Konfiguration, Datenbank, Benachrichtigungen, Rollen und Uploads beibehalten und strukturell verbessert.

- **Dokumentation**
  - Testbezogene Kommentare und Beschreibungen aktualisiert.

- **Hinweis**
  - Keine direkt sichtbaren Änderungen an Funktionen oder Benutzeroberflächen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->