### PR TITLE
fix(workflow): group dependabot packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -193,16 +193,32 @@ updates:
       patterns:
         - "size-limit"
         - "@size-limit/*"
+    storybook:
+      applies-to: version-updates
+      patterns:
+        - "*storybook*"
+    # `tailwind-merge` and `tailwind-csstree` are deliberately outside this group: they are
+    # independent packages that happen to start with the same word, not part of the v4 release train.
+    tailwind:
+      applies-to: version-updates
+      patterns:
+        - "tailwindcss*"
+        - "@tailwindcss*"
     vue:
       applies-to: version-updates
       patterns:
         - "vue*"
         - "@vue*"
+    # `vite*` also matches `vitest`, which would pull it out of the `vitest` group below and away from
+    # `@vitest/coverage-v8` — and that one pins its `vitest` peer to an exact version. Excluded here so
+    # the two vitest packages stay in one pull request.
     vite:
       applies-to: version-updates
       patterns:
         - "vite*"
         - "@vitejs*"
+      exclude-patterns:
+        - "vitest*"
     vitest:
       applies-to: version-updates
       patterns:


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

group dependabot packages

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Dependabot-Gruppierungen für Tailwind- und Storybook-Pakete ergänzt.
  - Vitest-Pakete von der Vite-Gruppe ausgeschlossen, damit sie separat aktualisiert werden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->