### PR TITLE
refactor(backend): update apollo server & webapp error contract

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "3.18.4",
       "license": "MIT",
       "dependencies": {
-        "@apollo/server": "^4.11.3",
+        "@apollo/server": "^5.5.1",
+        "@as-integrations/express5": "^1.1.2",
         "@aws-sdk/client-s3": "^3.1125.0",
         "@aws-sdk/lib-storage": "^3.1125.0",
         "@graphql-tools/load-files": "^7.0.0",
@@ -80,9 +81,11 @@
         "@faker-js/faker": "10.6.0",
         "@types/debug": "^4.1.13",
         "@types/email-templates": "^10.0.4",
+        "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "~9.0.10",
         "@types/lodash": "^4.17.25",
         "@types/node": "^26.1.1",
+        "@types/node-fetch": "^2.6.13",
         "@types/request": "^2.48.13",
         "@types/slug": "^5.0.9",
         "@types/validator": "^13.15.10",
@@ -157,426 +160,52 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.13.0.tgz",
-      "integrity": "sha512-t4GzaRiYIcPwYy40db6QjZzgvTr9ztDKBddykUXmBb2SVjswMKXbkaJ5nPeHqmT3awr9PAaZdCZdZhRj55I/8A==",
-      "deprecated": "Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.1.tgz",
+      "integrity": "sha512-Rn3g5TJQsMSUY23CWZTghWdBWyjX7dP1eaEBPkvmM2RHi82cDcpgTIkSCbGvtTUEGjwopLv1AAooU/n7iIZ20A==",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
-        "@apollo/server-gateway-interface": "^1.1.1",
+        "@apollo/server-gateway-interface": "^2.0.0",
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.createhash": "^2.0.2",
-        "@apollo/utils.fetcher": "^2.0.0",
-        "@apollo/utils.isnodelike": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.1.0",
-        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.createhash": "^3.0.0",
+        "@apollo/utils.fetcher": "^3.0.0",
+        "@apollo/utils.isnodelike": "^3.0.0",
+        "@apollo/utils.keyvaluecache": "^4.0.0",
+        "@apollo/utils.logger": "^3.0.0",
         "@apollo/utils.usagereporting": "^2.1.0",
-        "@apollo/utils.withrequired": "^2.0.0",
-        "@graphql-tools/schema": "^9.0.0",
-        "@types/express": "^4.17.13",
-        "@types/express-serve-static-core": "^4.17.30",
-        "@types/node-fetch": "^2.6.1",
+        "@apollo/utils.withrequired": "^3.0.0",
+        "@graphql-tools/schema": "^10.0.0",
         "async-retry": "^1.2.1",
+        "body-parser": "^2.2.2",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "express": "^4.21.1",
+        "finalhandler": "^2.1.0",
         "loglevel": "^1.6.8",
-        "lru-cache": "^7.10.1",
-        "negotiator": "^0.6.3",
-        "node-abort-controller": "^3.1.1",
-        "node-fetch": "^2.6.7",
-        "uuid": "^9.0.0",
-        "whatwg-mimetype": "^3.0.0"
+        "lru-cache": "^11.1.0",
+        "negotiator": "^1.0.0",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.16.0"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "graphql": "^16.6.0"
+        "graphql": "^16.11.0"
       }
     },
     "node_modules/@apollo/server-gateway-interface": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.1.1.tgz",
-      "integrity": "sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==",
-      "deprecated": "@apollo/server-gateway-interface v1 is part of Apollo Server v4, which is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v2 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-2.0.0.tgz",
+      "integrity": "sha512-3HEMD6fSantG2My3jWkb9dvfkF9vJ4BDLRjMgsnD790VINtuPaEp+h3Hg9HOHiWkML6QsOhnaRqZ+gvhp3y8Nw==",
       "license": "MIT",
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.1.1",
-        "@apollo/utils.fetcher": "^2.0.0",
-        "@apollo/utils.keyvaluecache": "^2.1.0",
-        "@apollo/utils.logger": "^2.0.0"
+        "@apollo/utils.fetcher": "^3.0.0",
+        "@apollo/utils.keyvaluecache": "^4.0.0",
+        "@apollo/utils.logger": "^3.0.0"
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@graphql-tools/merge": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
-      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@graphql-tools/schema": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
-      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/merge": "^8.4.1",
-        "@graphql-tools/utils": "^9.2.1",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/cookie-signature": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
-      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "license": "MIT"
-    },
-    "node_modules/@apollo/server/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/@apollo/server/node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
-    },
-    "node_modules/@apollo/server/node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {
@@ -589,16 +218,16 @@
       }
     },
     "node_modules/@apollo/utils.createhash": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.2.tgz",
-      "integrity": "sha512-UkS3xqnVFLZ3JFpEmU/2cM2iKJotQXMoSTgxXsfQgXLC5gR1WaepoXagmYnPSA7Q/2cmnyTYK5OgAgoC4RULPg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-3.0.1.tgz",
+      "integrity": "sha512-CKrlySj4eQYftBE5MJ8IzKwIibQnftDT7yGfsJy5KSEEnLlPASX0UTpbKqkjlVEwPPd4mEwI7WOM7XNxEuO05A==",
       "license": "MIT",
       "dependencies": {
-        "@apollo/utils.isnodelike": "^2.0.1",
+        "@apollo/utils.isnodelike": "^3.0.0",
         "sha.js": "^2.4.11"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.dropunuseddefinitions": {
@@ -614,43 +243,43 @@
       }
     },
     "node_modules/@apollo/utils.fetcher": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz",
-      "integrity": "sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-3.1.0.tgz",
+      "integrity": "sha512-Z3QAyrsQkvrdTuHAFwWDNd+0l50guwoQUoaDQssLOjkmnmVuvXlJykqlEJolio+4rFwBnWdoY1ByFdKaQEcm7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.isnodelike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.1.tgz",
-      "integrity": "sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-3.0.0.tgz",
+      "integrity": "sha512-xrjyjfkzunZ0DeF6xkHaK5IKR8F1FBq6qV+uZ+h9worIF/2YSzA0uoBxGv6tbTeo9QoIQnRW4PVFzGix5E7n/g==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.keyvaluecache": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz",
-      "integrity": "sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-4.0.0.tgz",
+      "integrity": "sha512-mKw1myRUkQsGPNB+9bglAuhviodJ2L2MRYLTafCMw5BIo7nbvCPNCkLnIHjZ1NOzH7SnMAr5c9LmXiqsgYqLZw==",
       "license": "MIT",
       "dependencies": {
-        "@apollo/utils.logger": "^2.0.1",
-        "lru-cache": "^7.14.1"
+        "@apollo/utils.logger": "^3.0.0",
+        "lru-cache": "^11.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -725,12 +354,25 @@
       }
     },
     "node_modules/@apollo/utils.withrequired": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz",
-      "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-3.0.0.tgz",
+      "integrity": "sha512-aaxeavfJ+RHboh7c2ofO5HHtQobGX4AgUujXP4CXpREHp9fQ9jPi6K9T1jrAKe7HIipoP0OJ1gd6JamSkFIpvA==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      }
+    },
+    "node_modules/@as-integrations/express5": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@as-integrations/express5/-/express5-1.1.2.tgz",
+      "integrity": "sha512-BxfwtcWNf2CELDkuPQxi5Zl3WqY/dQVJYafeCBOGoFQjv5M0fjhxmAFZ9vKx/5YKKNeok4UY6PkFbHzmQrdxIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^4.0.0 || ^5.0.0",
+        "express": "^5.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -746,15 +388,6 @@
         "lru-cache": "^11.2.4"
       }
     },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@asamuzakjp/dom-selector": {
       "version": "6.7.6",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
@@ -766,15 +399,6 @@
         "css-tree": "^3.1.0",
         "is-potential-custom-element-name": "^1.0.1",
         "lru-cache": "^11.2.4"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -3856,15 +3480,6 @@
         "jsonrepair": "bin/cli.js"
       }
     },
-    "node_modules/@metascraper/helpers/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@metascraper/helpers/node_modules/mime": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
@@ -5112,9 +4727,10 @@
       }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -5165,6 +4781,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5214,21 +4831,22 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
-      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "^1"
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5264,6 +4882,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -5305,12 +4924,6 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "license": "MIT"
-    },
     "node_modules/@types/mime-types": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
@@ -5343,6 +4956,7 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5363,12 +4977,14 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/request": {
@@ -5438,29 +5054,20 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
-      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "<1"
-      }
-    },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -6340,15 +5947,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/accepts/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6531,12 +6129,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
-    },
     "node_modules/array-slice": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
@@ -6632,6 +6224,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/audio-extensions": {
@@ -7033,14 +6626,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -7192,15 +6785,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -7491,6 +7075,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -7951,15 +7536,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
-      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
@@ -8175,6 +7751,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8202,6 +7779,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -8660,15 +8238,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/email-templates/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -8822,6 +8391,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10259,6 +9829,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -10275,6 +9846,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10284,6 +9856,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -13003,15 +12576,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/jsdom/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -13940,12 +13504,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=12"
+        "node": "20 || >=22"
       }
     },
     "node_modules/magic-string": {
@@ -14663,15 +14227,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/microfiber": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/microfiber/-/microfiber-2.1.2.tgz",
@@ -15122,6 +14677,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -15192,12 +14776,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
@@ -18275,16 +17853,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/sync-fetch/node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/sync-request": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
@@ -19256,6 +18824,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -19303,15 +18872,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/value-or-promise": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
-      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/vary": {
@@ -19783,12 +19343,12 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -19820,13 +19380,13 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -43,7 +43,8 @@
     "prod:db:func:disable:notifications": "node build/src/db/disable-notifications.js"
   },
   "dependencies": {
-    "@apollo/server": "^4.11.3",
+    "@apollo/server": "^5.5.1",
+    "@as-integrations/express5": "^1.1.2",
     "@aws-sdk/client-s3": "^3.1125.0",
     "@aws-sdk/lib-storage": "^3.1125.0",
     "@graphql-tools/load-files": "^7.0.0",
@@ -114,9 +115,11 @@
     "@faker-js/faker": "10.6.0",
     "@types/debug": "^4.1.13",
     "@types/email-templates": "^10.0.4",
+    "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "~9.0.10",
     "@types/lodash": "^4.17.25",
     "@types/node": "^26.1.1",
+    "@types/node-fetch": "^2.6.13",
     "@types/request": "^2.48.13",
     "@types/slug": "^5.0.9",
     "@types/validator": "^13.15.10",
@@ -145,7 +148,6 @@
     "string-width": "4.2.0",
     "wrap-ansi": "7.0.0",
     "jwa": "^2.0.1",
-    "@types/express": "4.17.25",
     "re2": "~1.24.1"
   },
   "engines": {

--- a/backend/src/server.spec.ts
+++ b/backend/src/server.spec.ts
@@ -119,6 +119,33 @@ describe(createServer, () => {
       expect(body.errors).toBeUndefined()
       expect(body.data?.embedProviders?.length).toBeGreaterThan(0)
     })
+
+    // Apollo Server 5 turned `status400ForVariableCoercionErrors` on by default, where 4 left it
+    // off and answered 200. That default is DELIBERATELY kept — asserted here because it is a
+    // contract with the webapp, not an implementation detail: apollo-link-http-common rejects every
+    // response with a status >= 300 before it looks at the body, so the webapp needs its own link
+    // to keep these visible as GraphQL errors (webapp/plugins/apollo-config/graphqlResponseLink.js).
+    // Without both halves a mistyped variable reads as "server unreachable" in the UI.
+    it('answers a variable coercion error with 400 and a GraphQL error body', async () => {
+      const response = await fetch(running.httpUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          // The variable is USED, so the document itself validates and the request fails during
+          // coercion rather than during validation (which answered 400 in Apollo Server 4 too).
+          query: 'query ($id: ID!) { User(id: $id) { id } }',
+          variables: { id: { not: 'an id' } },
+        }),
+      })
+
+      expect(response.status).toBe(400)
+
+      const body = (await response.json()) as {
+        errors?: { message: string; extensions?: { code?: string } }[]
+      }
+
+      expect(body.errors?.[0].extensions?.code).toBe('BAD_USER_INPUT')
+    })
   })
 
   // The injected-context branch, which is the one test/helpers.ts uses throughout the suite.

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,14 +2,12 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable import-x/no-named-as-default-member */
-/* eslint-disable import-x/no-deprecated */
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import http from 'node:http'
 
 import { ApolloServer } from '@apollo/server'
-import { expressMiddleware } from '@apollo/server/express4'
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer'
+import { expressMiddleware } from '@as-integrations/express5'
 import { searchPath } from '@ocelot-social/branding/dist/discover.js'
 import bodyParser from 'body-parser'
 import express from 'express'

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -21,6 +21,7 @@
         "accounting": "~0.4.1",
         "apollo-cache-inmemory": "~1.6.6",
         "apollo-client": "~2.6.10",
+        "apollo-link": "~1.2.14",
         "async-validator": "^4.2.5",
         "cookie-universal-nuxt": "~2.2.2",
         "cropperjs": "^1.6.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -38,6 +38,7 @@
     "accounting": "~0.4.1",
     "apollo-cache-inmemory": "~1.6.6",
     "apollo-client": "~2.6.10",
+    "apollo-link": "~1.2.14",
     "async-validator": "^4.2.5",
     "cookie-universal-nuxt": "~2.2.2",
     "cropperjs": "^1.6.2",

--- a/webapp/plugins/apollo-config.js
+++ b/webapp/plugins/apollo-config.js
@@ -1,5 +1,6 @@
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
 import introspectionQueryResultData from './apollo-config/fragmentTypes.json'
+import { createGraphqlResponseLink } from './apollo-config/graphqlResponseLink'
 import { createAuthCookie } from '~/utils/authCookie'
 
 const fragmentMatcher = new IntrospectionFragmentMatcher({
@@ -38,6 +39,10 @@ export default (context) => {
     },
     persisting: false,
     websocketsOnly: false,
+    // A NON-terminating link: vue-cli-plugin-apollo's createApolloClient combines it as
+    // `from([link, httpLink])` while `defaultHttpLink` stays on, so it wraps HTTP requests only —
+    // subscriptions are split off to the websocket link further down and never pass through it.
+    link: createGraphqlResponseLink(),
     cache: new InMemoryCache({ fragmentMatcher }),
   }
 }

--- a/webapp/plugins/apollo-config.spec.js
+++ b/webapp/plugins/apollo-config.spec.js
@@ -1,3 +1,5 @@
+import { ApolloLink } from 'apollo-link'
+
 import apolloConfig from './apollo-config.js'
 
 const context = ({ cookies = {}, $config = {}, env = {} } = {}) => ({
@@ -49,6 +51,15 @@ describe('apollo client config', () => {
     expect(config.getAuth()).toBe('')
     cookies['a-token'] = 'later-jwt'
     expect(config.getAuth()).toBe('Bearer later-jwt')
+  })
+
+  it('installs the GraphQL-response link WITHOUT replacing the http link', () => {
+    // `defaultHttpLink` is deliberately left at its default: vue-cli-plugin-apollo then combines the
+    // two as `from([link, httpLink])`, which is what makes ours a wrapper rather than the transport.
+    // Turning it off here would leave the client with no terminating link at all.
+    const config = apolloConfig(context())
+    expect(config.link).toBeInstanceOf(ApolloLink)
+    expect(config.defaultHttpLink).toBeUndefined()
   })
 
   it('routes browser HTTP through the /api proxy and subscriptions to the configured WEBSOCKETS_URI', () => {

--- a/webapp/plugins/apollo-config.spec.js
+++ b/webapp/plugins/apollo-config.spec.js
@@ -165,14 +165,23 @@ describe('apollo client config', () => {
         text: () => Promise.resolve(JSON.stringify(body)),
       })
 
+    // jsdom exposes no fetch today, so this saves `undefined` — but restoring the DESCRIPTOR rather
+    // than deleting keeps the block honest if the environment (or a setup file) ever provides one:
+    // a plain reassignment would also flatten a getter into a data property.
+    let previousFetch
     beforeEach(() => {
+      previousFetch = Object.getOwnPropertyDescriptor(global, 'fetch')
       // apollo-upload-client's `checkFetcher` runs while the link is BUILT, not when it is used, so
       // a global fetch has to exist even for the tests that never send a request.
       global.fetch = jest.fn()
     })
 
     afterEach(() => {
-      delete global.fetch
+      if (previousFetch) {
+        Object.defineProperty(global, 'fetch', previousFetch)
+      } else {
+        delete global.fetch
+      }
       jest.clearAllMocks()
     })
 

--- a/webapp/plugins/apollo-config.spec.js
+++ b/webapp/plugins/apollo-config.spec.js
@@ -1,6 +1,38 @@
 import { ApolloLink } from 'apollo-link'
+import gql from 'graphql-tag'
+import { SubscriptionClient } from 'subscriptions-transport-ws'
+import { createApolloClient } from 'vue-cli-plugin-apollo/graphql-client'
 
 import apolloConfig from './apollo-config.js'
+
+// The websocket is the one part of the composition that cannot be exercised for real: both stand-ins
+// are constructed unconditionally by createApolloClient as soon as a `wsEndpoint` is configured, and
+// the real ones would open a socket to wss://ocelot.test. The mocks keep the LINK GRAPH intact —
+// `split()` still gets a genuine ApolloLink — so what the tests below assert about routing is the
+// production wiring, not the mock's.
+jest.mock('subscriptions-transport-ws', () => ({
+  SubscriptionClient: jest.fn().mockImplementation((endpoint, options) => ({ endpoint, options })),
+}))
+
+jest.mock('apollo-link-ws', () => {
+  const { ApolloLink: Link, Observable } = require('apollo-link')
+  return {
+    // Emits a payload shaped like the SUBSCRIPTION document below — the cache writes every
+    // subscription result, and a shape that does not match the selection set only produces warnings.
+    WebSocketLink: jest.fn().mockImplementation(
+      () =>
+        new Link(
+          () =>
+            new Observable((observer) => {
+              observer.next({
+                data: { chatMessageAdded: { __typename: 'Message', id: 'served-by-websocket' } },
+              })
+              observer.complete()
+            }),
+        ),
+    ),
+  }
+})
 
 const context = ({ cookies = {}, $config = {}, env = {} } = {}) => ({
   req: {
@@ -91,6 +123,135 @@ describe('apollo client config', () => {
       const ctx = context()
       delete ctx.req.env.GRAPHQL_URI
       expect(apolloConfig(ctx).httpEndpoint).toBe('http://localhost:4000')
+    })
+  })
+
+  describe('composed into the client vue-cli-plugin-apollo actually builds', () => {
+    // The assertions above only describe the config OBJECT. Everything that makes it work is
+    // decided afterwards, inside createApolloClient: `from([link, httpLink])`, the `setContext` auth
+    // link wrapped around both, and `split(isSubscription, wsLink, link)`. Get one of those wrong —
+    // by turning off `defaultHttpLink`, or by making our link terminating — and every assertion up
+    // there still passes while the app talks to nothing. So build the real client here.
+    const QUERY = gql`
+      query Posts {
+        Post {
+          id
+        }
+      }
+    `
+    const SUBSCRIPTION = gql`
+      subscription ChatMessage {
+        chatMessageAdded {
+          id
+        }
+      }
+    `
+
+    // Mirrors @nuxtjs/apollo's generated plugin (lib/templates/plugin.js): it spreads the client
+    // config and then sets `ssr` and `tokenName` itself.
+    const buildClient = (
+      ctx = context({ cookies: { 'a-token': 'jwt' }, $config: { cookieName: 'a-token' } }),
+    ) =>
+      createApolloClient({
+        ...apolloConfig(ctx),
+        ssr: !!process.server,
+        tokenName: 'apollo-token',
+      })
+
+    const respondWith = (status, body) =>
+      global.fetch.mockResolvedValue({
+        status,
+        // apollo-link-http-common reads the body as TEXT and parses it itself.
+        text: () => Promise.resolve(JSON.stringify(body)),
+      })
+
+    beforeEach(() => {
+      // apollo-upload-client's `checkFetcher` runs while the link is BUILT, not when it is used, so
+      // a global fetch has to exist even for the tests that never send a request.
+      global.fetch = jest.fn()
+    })
+
+    afterEach(() => {
+      delete global.fetch
+      jest.clearAllMocks()
+    })
+
+    it('surfaces a 4xx GraphQL response as graphQLErrors instead of a network outage', async () => {
+      // The regression the response link exists for, proven END TO END: Apollo Server 5 answers a
+      // variable-coercion failure with 400 + a well-formed body, apollo-upload-client rejects it as
+      // a ServerError, and only the composition `from([ours, httpLink])` turns it back into what the
+      // component layer can render. A terminating or mis-ordered link breaks exactly this.
+      respondWith(400, {
+        errors: [
+          {
+            message: 'Variable "$orderBy" got invalid value "nonsense"',
+            extensions: { code: 'BAD_USER_INPUT' },
+          },
+        ],
+      })
+
+      const error = await buildClient()
+        .apolloClient.query({ query: QUERY })
+        .catch((caught) => caught)
+
+      expect(error.networkError).toBeNull()
+      expect(error.graphQLErrors).toEqual([
+        expect.objectContaining({ extensions: { code: 'BAD_USER_INPUT' } }),
+      ])
+    })
+
+    it('still fails loudly when the transport itself breaks', async () => {
+      // The other half of the contract: a 5xx carrying an errors array must NOT be laundered into a
+      // field error, or every backend crash hides behind a message about the user's input.
+      respondWith(500, { errors: [{ message: 'Internal server error' }] })
+
+      const error = await buildClient()
+        .apolloClient.query({ query: QUERY })
+        .catch((caught) => caught)
+
+      expect(error.networkError).toMatchObject({ statusCode: 500 })
+    })
+
+    it('sends queries to the http endpoint with the cookie session attached', async () => {
+      // Proves the auth link is composed AROUND ours rather than shadowed by it: getAuth feeds the
+      // header of the request that actually goes over the wire.
+      const fetchMock = respondWith(200, { data: { Post: [] } })
+
+      await buildClient().apolloClient.query({ query: QUERY })
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [uri, options] = fetchMock.mock.calls[0]
+      expect(uri).toBe('/api')
+      expect(options.headers).toMatchObject({ authorization: 'Bearer jwt' })
+    })
+
+    it('routes subscriptions over the websocket, never through the http chain', async () => {
+      // `split()` is the only thing keeping subscriptions off the HTTP link — and off our response
+      // link with it, which is why that link may assume it never sees a long-lived operation.
+      const fetchMock = respondWith(200, { data: {} })
+      const { apolloClient } = buildClient()
+
+      const result = await new Promise((resolve, reject) => {
+        apolloClient.subscribe({ query: SUBSCRIPTION }).subscribe({ next: resolve, error: reject })
+      })
+
+      // Only the websocket link can produce this id — the http transport was never asked.
+      expect(result.data.chatMessageAdded).toMatchObject({ id: 'served-by-websocket' })
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('points the websocket at the configured WEBSOCKETS_URI and authenticates it with the cookie', () => {
+      // wsEndpoint is passed through verbatim (ops own it) and the socket authenticates through the
+      // SAME getAuth as HTTP — connectionParams is a function, so a token written later still counts.
+      buildClient()
+
+      expect(SubscriptionClient).toHaveBeenCalledTimes(1)
+      const [endpoint, options] = SubscriptionClient.mock.calls[0]
+      expect(endpoint).toBe('wss://ocelot.test/api/graphql')
+      expect(options.connectionParams()).toEqual({
+        authorization: 'Bearer jwt',
+        headers: { authorization: 'Bearer jwt' },
+      })
     })
   })
 })

--- a/webapp/plugins/apollo-config/graphqlResponseLink.js
+++ b/webapp/plugins/apollo-config/graphqlResponseLink.js
@@ -1,0 +1,49 @@
+import { ApolloLink, Observable } from 'apollo-link'
+
+// apollo-link-http-common rejects EVERY response with a status >= 300 (`parseAndCheckHttpResponse`
+// calls `throwServerError` before it looks at the body), so a request that the backend answered in
+// perfectly good GraphQL — `{ errors: [...] }` with a `BAD_USER_INPUT` / `GRAPHQL_VALIDATION_FAILED`
+// extension — reaches the component as a `networkError` with no `graphQLErrors` on it. The user is
+// told the server is unreachable when in truth the request was malformed.
+//
+// Apollo Server has always answered 400 for document validation failures, and since v5 it also does
+// so for variable coercion errors (`status400ForVariableCoercionErrors` defaults to true there,
+// where v4 defaulted to false and returned 200). Both are exactly the class of failure this repo
+// has shipped twice — see backend/src/graphql/webappPostFilters.spec.ts on the `orderBy` and
+// hashtag-filter outages — so they must surface as GraphQL errors, not as a network outage.
+//
+// The status itself stays untouched: this reclassifies at the GraphQL layer instead of rewriting
+// the HTTP response, so nothing downstream is lied to about what came over the wire.
+const isGraphqlResponse = (networkError) =>
+  // `ServerError` carries the PARSED body on `.result`; a body that failed to parse yields a
+  // `ServerParseError` with `.bodyText` and no `.result`, which is a genuine transport fault.
+  Boolean(networkError) &&
+  Array.isArray(networkError.result?.errors) &&
+  networkError.result.errors.length > 0 &&
+  // 4xx only. A 5xx means the server itself broke; Apollo attaches an errors array to those too,
+  // and swallowing them here would hide every backend crash behind a field-level error message.
+  networkError.statusCode >= 400 &&
+  networkError.statusCode < 500
+
+export const createGraphqlResponseLink = () =>
+  new ApolloLink(
+    (operation, forward) =>
+      new Observable((observer) => {
+        const subscription = forward(operation).subscribe({
+          next: (result) => observer.next(result),
+          complete: () => observer.complete(),
+          error: (networkError) => {
+            if (!isGraphqlResponse(networkError)) {
+              observer.error(networkError)
+              return
+            }
+            // Hand the body on as the operation's result. `data` is forwarded as the backend sent
+            // it (absent on a validation failure, possibly partial otherwise) so that vue-apollo
+            // applies the same partial-data rules it would for a 200 response.
+            observer.next(networkError.result)
+            observer.complete()
+          },
+        })
+        return () => subscription.unsubscribe()
+      }),
+  )

--- a/webapp/plugins/apollo-config/graphqlResponseLink.spec.js
+++ b/webapp/plugins/apollo-config/graphqlResponseLink.spec.js
@@ -1,0 +1,146 @@
+import { ApolloLink, Observable, execute } from 'apollo-link'
+import gql from 'graphql-tag'
+
+import { createGraphqlResponseLink } from './graphqlResponseLink'
+
+const QUERY = gql`
+  query {
+    Post {
+      id
+    }
+  }
+`
+
+// The real ServerError, built the way apollo-link-http-common builds it (`throwServerError`):
+// message + statusCode + the PARSED body on `.result`.
+const serverError = (statusCode, result) => {
+  const error = new Error(`Response not successful: Received status code ${statusCode}`)
+  error.name = 'ServerError'
+  error.statusCode = statusCode
+  error.result = result
+  error.response = { status: statusCode }
+  return error
+}
+
+// Stands in for the http link: a terminating link that fails the request the way the transport
+// would, so the assertions run through the same subscribe/error path as production.
+const failingWith = (error) =>
+  new ApolloLink(
+    () =>
+      new Observable((observer) => {
+        observer.error(error)
+      }),
+  )
+
+const run = (terminatingLink) => {
+  const link = ApolloLink.from([createGraphqlResponseLink(), terminatingLink])
+  return new Promise((resolve) => {
+    const results = []
+    execute(link, { query: QUERY }).subscribe({
+      next: (result) => results.push(result),
+      complete: () => resolve({ results, error: null }),
+      error: (error) => resolve({ results, error }),
+    })
+  })
+}
+
+describe('graphqlResponseLink', () => {
+  it('delivers a 400 that carries GraphQL errors as a result, not as a network failure', async () => {
+    // Apollo Server 5 answers variable coercion errors with 400 (v4 defaulted to 200). Without this
+    // link the component sees `networkError` and renders "server unreachable" for what is really a
+    // malformed request — the failure mode the `orderBy` and hashtag-filter outages produced.
+    const body = {
+      errors: [
+        {
+          message: 'Variable "$filter" got invalid value ...',
+          extensions: { code: 'BAD_USER_INPUT' },
+        },
+      ],
+    }
+
+    const { results, error } = await run(failingWith(serverError(400, body)))
+
+    expect(error).toBeNull()
+    expect(results).toEqual([body])
+  })
+
+  it('forwards the data the backend sent alongside the errors', async () => {
+    // A 4xx response may still carry (partial) data. Passing the body through unchanged is what
+    // lets vue-apollo apply its normal partial-data handling instead of discarding the payload.
+    const body = { data: { Post: null }, errors: [{ message: 'nope' }] }
+
+    const { results } = await run(failingWith(serverError(400, body)))
+
+    expect(results).toEqual([body])
+  })
+
+  it('leaves a 500 alone — a broken backend must not look like a field error', async () => {
+    const error500 = serverError(500, { errors: [{ message: 'Internal server error' }] })
+
+    const { results, error } = await run(failingWith(error500))
+
+    expect(error).toBe(error500)
+    expect(results).toEqual([])
+  })
+
+  it('leaves a transport failure with no parsed body alone', async () => {
+    // A ServerParseError (HTML error page from a proxy, connection reset, …) has `bodyText` but no
+    // `.result`, and there is nothing GraphQL about it.
+    const parseError = new Error('Unexpected token < in JSON')
+    parseError.statusCode = 502
+    parseError.bodyText = '<html>502 Bad Gateway</html>'
+
+    const { error } = await run(failingWith(parseError))
+
+    expect(error).toBe(parseError)
+  })
+
+  it('leaves a 4xx whose body has no errors array alone', async () => {
+    // e.g. a 401 from an authenticating proxy in front of the backend: JSON, but not a GraphQL
+    // response — reclassifying it would silently swallow the request.
+    const error401 = serverError(401, { message: 'Unauthorized' })
+
+    const { error } = await run(failingWith(error401))
+
+    expect(error).toBe(error401)
+  })
+
+  it('leaves a 4xx with an EMPTY errors array alone', async () => {
+    // Not a valid GraphQL error response — `errors` must be non-empty when present. Passing it on
+    // as a result would complete the operation with nothing to show for it.
+    const emptyErrors = serverError(400, { errors: [] })
+
+    const { error } = await run(failingWith(emptyErrors))
+
+    expect(error).toBe(emptyErrors)
+  })
+
+  it('passes successful responses straight through', async () => {
+    const data = { data: { Post: [{ id: 'p1' }] } }
+    const succeeding = new ApolloLink(
+      () =>
+        new Observable((observer) => {
+          observer.next(data)
+          observer.complete()
+        }),
+    )
+
+    const { results, error } = await run(succeeding)
+
+    expect(error).toBeNull()
+    expect(results).toEqual([data])
+  })
+
+  it('unsubscribes from the wrapped link when the caller cancels', async () => {
+    // vue-apollo tears down in-flight queries on navigation; if the wrapper dropped the
+    // unsubscribe, the underlying request would keep running and later write into a dead component.
+    const unsubscribe = jest.fn()
+    const neverResolving = new ApolloLink(() => new Observable(() => unsubscribe))
+
+    const link = ApolloLink.from([createGraphqlResponseLink(), neverResolving])
+    const subscription = execute(link, { query: QUERY }).subscribe({ next: () => {} })
+    subscription.unsubscribe()
+
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

update apollo server & webapp error contract

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Neue Funktionen**
  - GraphQL-Fehler bei HTTP-400-Antworten werden im Webclient als reguläre GraphQL-Fehler statt als Netzwerkausfälle angezeigt.
  - Erfolgreiche Antworten und Subscription-Verbindungen bleiben unverändert.

- **Verbesserungen**
  - Aktualisierte Apollo-Server- und Express-Integration verbessert die Verarbeitung von GraphQL-Anfragen.
  - Fehler von HTTP-500-Antworten und echte Netzwerkfehler werden weiterhin als Netzwerkfehler behandelt.

- **Tests**
  - Zusätzliche Tests decken Validierungsfehler, Variablenfehler, HTTP-Fehlerstatus sowie HTTP- und Subscription-Routing ab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->